### PR TITLE
Eliminate quadratic block membership checking behaviour

### DIFF
--- a/src/converter.spec.js
+++ b/src/converter.spec.js
@@ -8,7 +8,7 @@ const DEC = 11
 const picosPerMilli = 1000n * 1000n * 1000n
 
 describe('Converter', () => {
-  describe('one block', () => {
+  describe('one ray', () => {
     const data = [
       [Date.UTC(1970, JAN, 1), 0]
     ]
@@ -423,7 +423,7 @@ describe('Converter', () => {
 
   describe('insane edge cases', () => {
     describe('when unixMillis converts to an atomicPicos which fits but an atomicMillis which does not', () => {
-      it('at the start of the block', () => {
+      it('at the start of the ray', () => {
         const data = [
           [Date.UTC(1970, JAN, 1, 0, 0, 0, 1), -0.0001]
         ]
@@ -431,7 +431,7 @@ describe('Converter', () => {
         expect(munge(data)).toEqual([{
           start: {
             unixMillis: 1,
-            atomicPicos: 900_000_000n // block start intentionally doesn't include TAI epoch
+            atomicPicos: 900_000_000n // ray start intentionally doesn't include TAI epoch
           },
           end: {
             atomicPicos: Infinity
@@ -446,17 +446,17 @@ describe('Converter', () => {
 
         const converter = Converter(data)
         expect(converter.oneToMany.unixToAtomicPicos(1)).toEqual([900_000_000n])
-        // rounds down to 0, which is not in the block
+        // rounds down to 0, which is not in the ray
         expect(converter.oneToMany.unixToAtomic(1)).toEqual([])
       })
 
-      it('at the end of the block', () => {
+      it('at the end of the ray', () => {
         const data = [
           [Date.UTC(1969, DEC, 31, 23, 59, 59, 999), 0.0001],
           [Date.UTC(1970, JAN, 1, 0, 0, 0, 1), -0.0011]
         ]
 
-        // first block's end intentionally doesn't include TAI epoch
+        // first ray's end intentionally doesn't include TAI epoch
         expect(munge(data)).toEqual([{
           start: {
             unixMillis: -1,
@@ -489,12 +489,12 @@ describe('Converter', () => {
 
         const converter = Converter(data)
         expect(converter.oneToMany.unixToAtomicPicos(-1)).toEqual([-900_000_000n])
-        // rounds up to 0, which is not in the block
+        // rounds up to 0, which is not in the ray
         expect(converter.oneToMany.unixToAtomic(-1)).toEqual([])
       })
     })
 
-    it('when a block has length 0', () => {
+    it('when a ray has length 0', () => {
       const data = [
         [Date.UTC(1970, JAN, 1), 0, 40_587, 0],
         [Date.UTC(1970, JAN, 1), 0, 40_587, 0.086_400]
@@ -516,7 +516,7 @@ describe('Converter', () => {
         }
       }, {
         start: {
-          // Same start point as previous block, so previous block has length 0 TAI seconds
+          // Same start point as previous ray, so previous ray has length 0 TAI seconds
           unixMillis: 0,
           atomicPicos: 0n
         },

--- a/src/converter.spec.js
+++ b/src/converter.spec.js
@@ -433,6 +433,9 @@ describe('Converter', () => {
             unixMillis: 1,
             atomicPicos: 900_000_000n // block start intentionally doesn't include TAI epoch
           },
+          end: {
+            atomicPicos: Infinity
+          },
           ratio: {
             atomicPicosPerUnixMilli: 1_000_000_000n
           },
@@ -459,6 +462,9 @@ describe('Converter', () => {
             unixMillis: -1,
             atomicPicos: -900_000_000n
           },
+          end: {
+            atomicPicos: -100_000_000n
+          },
           ratio: {
             atomicPicosPerUnixMilli: 1_000_000_000n
           },
@@ -469,6 +475,9 @@ describe('Converter', () => {
           start: {
             unixMillis: 1,
             atomicPicos: -100_000_000n
+          },
+          end: {
+            atomicPicos: Infinity
           },
           ratio: {
             atomicPicosPerUnixMilli: 1_000_000_000n
@@ -496,6 +505,9 @@ describe('Converter', () => {
           unixMillis: 0,
           atomicPicos: 0n
         },
+        end: {
+          atomicPicos: 0n
+        },
         ratio: {
           atomicPicosPerUnixMilli: 1_000_000_000n
         },
@@ -507,6 +519,9 @@ describe('Converter', () => {
           // Same start point as previous block, so previous block has length 0 TAI seconds
           unixMillis: 0,
           atomicPicos: 0n
+        },
+        end: {
+          atomicPicos: Infinity
         },
         ratio: {
           atomicPicosPerUnixMilli: 1_000_001_000n

--- a/src/munge.js
+++ b/src/munge.js
@@ -63,16 +63,16 @@ module.exports = data => {
     }
   })
 
-  // `end` is the first TAI instant when this block ceases to be applicable.
-  // `end` can equal or come before `start`, indicating that this block has no validity at all
+  // `end` is the first TAI instant when this ray ceases to be applicable.
+  // `end` can equal or come before `start`, indicating that this ray has no validity at all
   let end = {
     atomicPicos: Infinity
   }
-  for (let blockId = munged.length - 1; blockId >= 0; blockId--) {
-    munged[blockId].end = end
-    if (munged[blockId].start.atomicPicos < end.atomicPicos) {
+  for (let rayId = munged.length - 1; rayId >= 0; rayId--) {
+    munged[rayId].end = end
+    if (munged[rayId].start.atomicPicos < end.atomicPicos) {
       end = {
-        atomicPicos: munged[blockId].start.atomicPicos
+        atomicPicos: munged[rayId].start.atomicPicos
       }
     }
   }

--- a/src/munge.js
+++ b/src/munge.js
@@ -63,5 +63,19 @@ module.exports = data => {
     }
   })
 
+  // `end` is the first TAI instant when this block ceases to be applicable.
+  // `end` can equal or come before `start`, indicating that this block has no validity at all
+  let end = {
+    atomicPicos: Infinity
+  }
+  for (let blockId = munged.length - 1; blockId >= 0; blockId--) {
+    munged[blockId].end = end
+    if (munged[blockId].start.atomicPicos < end.atomicPicos) {
+      end = {
+        atomicPicos: munged[blockId].start.atomicPicos
+      }
+    }
+  }
+
   return munged
 }

--- a/src/munge.spec.js
+++ b/src/munge.spec.js
@@ -14,6 +14,9 @@ describe('munge', () => {
         atomicPicos: 0n,
         unixMillis: 0
       },
+      end: {
+        atomicPicos: Infinity
+      },
       ratio: {
         atomicPicosPerUnixMilli: 1000_000_000n
       },
@@ -30,6 +33,9 @@ describe('munge', () => {
       start: {
         unixMillis: 7,
         atomicPicos: -3_993_000_000_000n
+      },
+      end: {
+        atomicPicos: Infinity
       },
       ratio: {
         atomicPicosPerUnixMilli: 1_000_000_000n
@@ -54,6 +60,9 @@ describe('munge', () => {
         unixMillis: -1000,
         atomicPicos: -5_000_000_000_000n
       },
+      end: {
+        atomicPicos: 6_000_000_000_000n
+      },
       ratio: {
         atomicPicosPerUnixMilli: 1_000_000_000n
       },
@@ -65,6 +74,9 @@ describe('munge', () => {
         unixMillis: 9000,
         atomicPicos: 6_000_000_000_000n
       },
+      end: {
+        atomicPicos: 9_000_000_000_000n
+      },
       ratio: {
         atomicPicosPerUnixMilli: 1_000_000_000n
       },
@@ -75,6 +87,9 @@ describe('munge', () => {
       start: {
         unixMillis: 13000,
         atomicPicos: 9_000_000_000_000n
+      },
+      end: {
+        atomicPicos: Infinity
       },
       ratio: {
         atomicPicosPerUnixMilli: 1_000_000_000n
@@ -97,6 +112,7 @@ describe('munge', () => {
       [Date.UTC(1970, JAN, 1), 0, 40_587, 8.640_0]
     ])).toEqual([{
       start: { unixMillis: 0, atomicPicos: 0n },
+      end: { atomicPicos: Infinity },
       ratio: { atomicPicosPerUnixMilli: 1_000_100_000n },
       offsetAtUnixEpoch: { atomicPicos: 0n }
     }])
@@ -106,6 +122,7 @@ describe('munge', () => {
       [Date.UTC(1970, JAN, 1), 0, 40_587, 0]
     ])).toEqual([{
       start: { unixMillis: 0, atomicPicos: 0n },
+      end: { atomicPicos: Infinity },
       ratio: { atomicPicosPerUnixMilli: 1_000_000_000n },
       offsetAtUnixEpoch: { atomicPicos: 0n }
     }])
@@ -115,6 +132,7 @@ describe('munge', () => {
       [Date.UTC(1970, JAN, 1), 0, 40_587, -8.640_0]
     ])).toEqual([{
       start: { unixMillis: 0, atomicPicos: 0n },
+      end: { atomicPicos: Infinity },
       ratio: { atomicPicosPerUnixMilli: 999_900_000n },
       offsetAtUnixEpoch: { atomicPicos: 0n }
     }])
@@ -125,6 +143,7 @@ describe('munge', () => {
       [Date.UTC(1970, JAN, 1), 0, 40_587, -86_400 + 8.640_0]
     ])).toEqual([{
       start: { unixMillis: 0, atomicPicos: 0n },
+      end: { atomicPicos: Infinity },
       ratio: { atomicPicosPerUnixMilli: 100_000n },
       offsetAtUnixEpoch: { atomicPicos: 0n }
     }])
@@ -137,6 +156,7 @@ describe('munge', () => {
       [Date.UTC(1970, JAN, 1), 0, 40_587, -86_400]
     ])).toEqual([{
       start: { unixMillis: 0, atomicPicos: 0n },
+      end: { atomicPicos: Infinity },
       ratio: { atomicPicosPerUnixMilli: 0n },
       offsetAtUnixEpoch: { atomicPicos: 0n }
     }])
@@ -146,6 +166,7 @@ describe('munge', () => {
       [Date.UTC(1970, JAN, 1), 0, 40_587, -86_400 - 8.640_0]
     ])).toEqual([{
       start: { unixMillis: 0, atomicPicos: 0n },
+      end: { atomicPicos: Infinity },
       ratio: { atomicPicosPerUnixMilli: -100_000n },
       offsetAtUnixEpoch: { atomicPicos: 0n }
     }])
@@ -158,6 +179,9 @@ describe('munge', () => {
       start: {
         unixMillis: -283_996_800_000,
         atomicPicos: -283_996_798_577_182_000_000n
+      },
+      end: {
+        atomicPicos: Infinity
       },
       ratio: {
         atomicPicosPerUnixMilli: 1_000_000_015n

--- a/src/munge.spec.js
+++ b/src/munge.spec.js
@@ -193,7 +193,7 @@ describe('munge', () => {
   })
 
   it('generates proper offsets at the Unix epoch', () => {
-    expect(munge(taiData).map(block => block.offsetAtUnixEpoch.atomicPicos)).toEqual([
+    expect(munge(taiData).map(ray => ray.offsetAtUnixEpoch.atomicPicos)).toEqual([
       5_682_770_000_000n,
       5_632_770_000_000n,
       5_127_848_400_000n,
@@ -239,7 +239,7 @@ describe('munge', () => {
   })
 
   it('generates proper drift rates', () => {
-    expect(munge(taiData).map(block => block.ratio.atomicPicosPerUnixMilli)).toEqual([
+    expect(munge(taiData).map(ray => ray.ratio.atomicPicosPerUnixMilli)).toEqual([
       1_000_000_015n,
       1_000_000_015n,
       1_000_000_013n,
@@ -285,13 +285,13 @@ describe('munge', () => {
   })
 
   it('generates proper overlaps', () => {
-    expect(munge(taiData).map((block, i, arr) =>
-      // block end minus overlap start
-      i + 1 in arr
+    expect(munge(taiData).map((ray, i, rays) =>
+      // ray end minus overlap start
+      i + 1 in rays
         ? (
-            arr[i + 1].start.atomicPicos -
-          BigInt(arr[i + 1].start.unixMillis) * block.ratio.atomicPicosPerUnixMilli -
-          block.offsetAtUnixEpoch.atomicPicos
+            rays[i + 1].start.atomicPicos -
+          BigInt(rays[i + 1].start.unixMillis) * ray.ratio.atomicPicosPerUnixMilli -
+          ray.offsetAtUnixEpoch.atomicPicos
           )
         : NaN
     )).toEqual([


### PR DESCRIPTION
* Precompute the end of each block as an `atomicPicos` count so we don't have to scan forwards every dang time.
* Refer to "blocks" as "rays" in source instead.

No functional changes.