### PR TITLE
Use precise ratios exclusively inside of `Segment`

### DIFF
--- a/src/converter.js
+++ b/src/converter.js
@@ -11,6 +11,7 @@
 // segment (according to its numbering).
 
 const { munge, MODELS } = require('./munge')
+const { Rat } = require('./rat')
 
 const Converter = (data, model) => {
   const segments = munge(data, model)
@@ -39,9 +40,11 @@ const Converter = (data, model) => {
       throw Error(`Not an integer: ${unixMillis}`)
     }
 
+    const unixMillisRatio = new Rat(BigInt(unixMillis))
+
     const ranges = []
     for (const segment of segments) {
-      if (!segment.unixMillisOnSegment(unixMillis)) {
+      if (!segment.unixMillisRatioOnSegment(unixMillisRatio)) {
         continue
       }
 

--- a/src/converter.js
+++ b/src/converter.js
@@ -40,11 +40,11 @@ const Converter = (data, model) => {
       throw Error(`Not an integer: ${unixMillis}`)
     }
 
-    const unixMillisRatio = new Rat(BigInt(unixMillis))
+    const unixRatio = new Rat(BigInt(unixMillis), 1000n)
 
     const ranges = []
     for (const segment of segments) {
-      if (!segment.unixMillisRatioOnSegment(unixMillisRatio)) {
+      if (!segment.unixRatioOnSegment(unixRatio)) {
         continue
       }
 

--- a/src/converter.js
+++ b/src/converter.js
@@ -43,6 +43,7 @@ const Converter = (data, model) => {
     }
 
     const unixRatio = new Rat(BigInt(unixMillis), 1000n)
+    const unixMillisRatio = new Rat(BigInt(unixMillis))
 
     const ranges = []
     for (const segment of segments) {
@@ -50,7 +51,7 @@ const Converter = (data, model) => {
         continue
       }
 
-      const range = segment.unixMillisToAtomicMillisRange(unixMillis)
+      const range = segment.unixMillisRatioToAtomicMillisRange(unixMillisRatio)
 
       if (ranges.length - 1 in ranges) {
         const prev = ranges[ranges.length - 1]

--- a/src/converter.js
+++ b/src/converter.js
@@ -50,9 +50,9 @@ const Converter = (data, model) => {
         continue
       }
 
-      const range = segment.unixRatioToAtomicPicosRatioRange(unixRatio)
-      range.start = Number(range.start.divide(new Rat(1_000_000_000n)).trunc())
-      range.end = Number(range.end.divide(new Rat(1_000_000_000n)).trunc())
+      const range = segment.unixRatioToAtomicRatioRange(unixRatio)
+      range.start = Number(range.start.times(new Rat(1_000n)).trunc())
+      range.end = Number(range.end.times(new Rat(1_000n)).trunc())
 
       if (ranges.length - 1 in ranges) {
         const prev = ranges[ranges.length - 1]

--- a/src/converter.js
+++ b/src/converter.js
@@ -25,10 +25,10 @@ const Converter = (data, model) => {
       throw Error(`Not an integer: ${atomicMillis}`)
     }
 
-    const atomicPicos = BigInt(atomicMillis) * picosPerMilli
+    const atomicPicosRatio = new Rat(BigInt(atomicMillis) * picosPerMilli)
 
     for (const segment of segments) {
-      if (!segment.atomicPicosOnSegment(atomicPicos)) {
+      if (!segment.atomicPicosRatioOnSegment(atomicPicosRatio)) {
         continue
       }
 

--- a/src/converter.js
+++ b/src/converter.js
@@ -30,7 +30,7 @@ const Converter = (data, model) => {
         continue
       }
 
-      return Number(segment.atomicRatioToUnixMillisRatio(atomicRatio).trunc())
+      return Number(segment.atomicRatioToUnixRatio(atomicRatio).times(new Rat(1000n)).trunc())
     }
 
     // Pre-1961, or BREAK model and we hit a break

--- a/src/converter.js
+++ b/src/converter.js
@@ -30,8 +30,7 @@ const Converter = (data, model) => {
         continue
       }
 
-      const atomicPicosRatio = new Rat(BigInt(atomicMillis) * 1_000_000_000n)
-      return segment.atomicPicosRatioToUnixMillis(atomicPicosRatio)
+      return segment.atomicRatioToUnixMillis(atomicRatio)
     }
 
     // Pre-1961, or BREAK model and we hit a break

--- a/src/converter.js
+++ b/src/converter.js
@@ -43,7 +43,6 @@ const Converter = (data, model) => {
     }
 
     const unixRatio = new Rat(BigInt(unixMillis), 1000n)
-    const unixMillisRatio = new Rat(BigInt(unixMillis))
 
     const ranges = []
     for (const segment of segments) {
@@ -51,7 +50,7 @@ const Converter = (data, model) => {
         continue
       }
 
-      const range = segment.unixMillisRatioToAtomicMillisRange(unixMillisRatio)
+      const range = segment.unixRatioToAtomicMillisRange(unixRatio)
 
       if (ranges.length - 1 in ranges) {
         const prev = ranges[ranges.length - 1]

--- a/src/converter.js
+++ b/src/converter.js
@@ -30,8 +30,8 @@ const Converter = (data, model) => {
         continue
       }
 
-      const atomicPicos = BigInt(atomicMillis) * 1_000_000_000n
-      return segment.atomicPicosToUnixMillis(atomicPicos)
+      const atomicPicosRatio = new Rat(BigInt(atomicMillis) * 1_000_000_000n)
+      return segment.atomicPicosRatioToUnixMillis(atomicPicosRatio)
     }
 
     // Pre-1961, or BREAK model and we hit a break

--- a/src/converter.js
+++ b/src/converter.js
@@ -13,8 +13,6 @@
 const { munge, MODELS } = require('./munge')
 const { Rat } = require('./rat')
 
-const picosPerMilli = 1000n * 1000n * 1000n
-
 const Converter = (data, model) => {
   const segments = munge(data, model)
 
@@ -25,10 +23,10 @@ const Converter = (data, model) => {
       throw Error(`Not an integer: ${atomicMillis}`)
     }
 
-    const atomicPicosRatio = new Rat(BigInt(atomicMillis) * picosPerMilli)
+    const atomicRatio = new Rat(BigInt(atomicMillis), 1000n)
 
     for (const segment of segments) {
-      if (!segment.atomicPicosRatioOnSegment(atomicPicosRatio)) {
+      if (!segment.atomicRatioOnSegment(atomicRatio)) {
         continue
       }
 

--- a/src/converter.js
+++ b/src/converter.js
@@ -50,7 +50,9 @@ const Converter = (data, model) => {
         continue
       }
 
-      const range = segment.unixRatioToAtomicMillisRange(unixRatio)
+      const range = segment.unixRatioToAtomicMillisRatioRange(unixRatio)
+      range.start = Number(range.start.trunc())
+      range.end = Number(range.end.trunc())
 
       if (ranges.length - 1 in ranges) {
         const prev = ranges[ranges.length - 1]

--- a/src/converter.js
+++ b/src/converter.js
@@ -13,6 +13,8 @@
 const { munge, MODELS } = require('./munge')
 const { Rat } = require('./rat')
 
+const picosPerMilli = 1000n * 1000n * 1000n
+
 const Converter = (data, model) => {
   const segments = munge(data, model)
 
@@ -23,8 +25,10 @@ const Converter = (data, model) => {
       throw Error(`Not an integer: ${atomicMillis}`)
     }
 
+    const atomicPicos = BigInt(atomicMillis) * picosPerMilli
+
     for (const segment of segments) {
-      if (!segment.atomicMillisOnSegment(atomicMillis)) {
+      if (!segment.atomicPicosOnSegment(atomicPicos)) {
         continue
       }
 

--- a/src/converter.js
+++ b/src/converter.js
@@ -50,9 +50,9 @@ const Converter = (data, model) => {
         continue
       }
 
-      const range = segment.unixRatioToAtomicMillisRatioRange(unixRatio)
-      range.start = Number(range.start.trunc())
-      range.end = Number(range.end.trunc())
+      const range = segment.unixRatioToAtomicPicosRatioRange(unixRatio)
+      range.start = Number(range.start.divide(new Rat(1_000_000_000n)).trunc())
+      range.end = Number(range.end.divide(new Rat(1_000_000_000n)).trunc())
 
       if (ranges.length - 1 in ranges) {
         const prev = ranges[ranges.length - 1]

--- a/src/converter.js
+++ b/src/converter.js
@@ -30,7 +30,8 @@ const Converter = (data, model) => {
         continue
       }
 
-      return segment.atomicMillisToUnixMillis(atomicMillis)
+      const atomicPicos = BigInt(atomicMillis) * 1_000_000_000n
+      return segment.atomicPicosToUnixMillis(atomicPicos)
     }
 
     // Pre-1961, or BREAK model and we hit a break

--- a/src/converter.js
+++ b/src/converter.js
@@ -30,7 +30,7 @@ const Converter = (data, model) => {
         continue
       }
 
-      return segment.atomicRatioToUnixMillis(atomicRatio)
+      return Number(segment.atomicRatioToUnixMillisRatio(atomicRatio).trunc())
     }
 
     // Pre-1961, or BREAK model and we hit a break

--- a/src/munge.spec.js
+++ b/src/munge.spec.js
@@ -163,49 +163,49 @@ describe('munge', () => {
     })
 
     it('generates proper drift rates', () => {
-      expect(munge(taiData, MODELS.OVERRUN).map(segment => segment.slope.unixMillisPerAtomicPico))
+      expect(munge(taiData, MODELS.OVERRUN).map(segment => segment.slope.unixMillisPerAtomic))
         .toEqual([
-          new Rat(1n, 1_000_000_015n),
-          new Rat(1n, 1_000_000_015n),
-          new Rat(1n, 1_000_000_013n),
-          new Rat(1n, 1_000_000_013n),
-          new Rat(1n, 1_000_000_015n),
-          new Rat(1n, 1_000_000_015n),
-          new Rat(1n, 1_000_000_015n),
-          new Rat(1n, 1_000_000_015n),
-          new Rat(1n, 1_000_000_015n),
-          new Rat(1n, 1_000_000_015n),
-          new Rat(1n, 1_000_000_015n),
-          new Rat(1n, 1_000_000_030n),
-          new Rat(1n, 1_000_000_030n),
-          new Rat(1n, 1_000_000_000n),
-          new Rat(1n, 1_000_000_000n),
-          new Rat(1n, 1_000_000_000n),
-          new Rat(1n, 1_000_000_000n),
-          new Rat(1n, 1_000_000_000n),
-          new Rat(1n, 1_000_000_000n),
-          new Rat(1n, 1_000_000_000n),
-          new Rat(1n, 1_000_000_000n),
-          new Rat(1n, 1_000_000_000n),
-          new Rat(1n, 1_000_000_000n),
-          new Rat(1n, 1_000_000_000n),
-          new Rat(1n, 1_000_000_000n),
-          new Rat(1n, 1_000_000_000n),
-          new Rat(1n, 1_000_000_000n),
-          new Rat(1n, 1_000_000_000n),
-          new Rat(1n, 1_000_000_000n),
-          new Rat(1n, 1_000_000_000n),
-          new Rat(1n, 1_000_000_000n),
-          new Rat(1n, 1_000_000_000n),
-          new Rat(1n, 1_000_000_000n),
-          new Rat(1n, 1_000_000_000n),
-          new Rat(1n, 1_000_000_000n),
-          new Rat(1n, 1_000_000_000n),
-          new Rat(1n, 1_000_000_000n),
-          new Rat(1n, 1_000_000_000n),
-          new Rat(1n, 1_000_000_000n),
-          new Rat(1n, 1_000_000_000n),
-          new Rat(1n, 1_000_000_000n)
+          new Rat(1_000_000_000n, 1_000_000_015n),
+          new Rat(1_000_000_000n, 1_000_000_015n),
+          new Rat(1_000_000_000n, 1_000_000_013n),
+          new Rat(1_000_000_000n, 1_000_000_013n),
+          new Rat(1_000_000_000n, 1_000_000_015n),
+          new Rat(1_000_000_000n, 1_000_000_015n),
+          new Rat(1_000_000_000n, 1_000_000_015n),
+          new Rat(1_000_000_000n, 1_000_000_015n),
+          new Rat(1_000_000_000n, 1_000_000_015n),
+          new Rat(1_000_000_000n, 1_000_000_015n),
+          new Rat(1_000_000_000n, 1_000_000_015n),
+          new Rat(1_000_000_000n, 1_000_000_030n),
+          new Rat(1_000_000_000n, 1_000_000_030n),
+          new Rat(1_000_000_000n, 1_000_000_000n),
+          new Rat(1_000_000_000n, 1_000_000_000n),
+          new Rat(1_000_000_000n, 1_000_000_000n),
+          new Rat(1_000_000_000n, 1_000_000_000n),
+          new Rat(1_000_000_000n, 1_000_000_000n),
+          new Rat(1_000_000_000n, 1_000_000_000n),
+          new Rat(1_000_000_000n, 1_000_000_000n),
+          new Rat(1_000_000_000n, 1_000_000_000n),
+          new Rat(1_000_000_000n, 1_000_000_000n),
+          new Rat(1_000_000_000n, 1_000_000_000n),
+          new Rat(1_000_000_000n, 1_000_000_000n),
+          new Rat(1_000_000_000n, 1_000_000_000n),
+          new Rat(1_000_000_000n, 1_000_000_000n),
+          new Rat(1_000_000_000n, 1_000_000_000n),
+          new Rat(1_000_000_000n, 1_000_000_000n),
+          new Rat(1_000_000_000n, 1_000_000_000n),
+          new Rat(1_000_000_000n, 1_000_000_000n),
+          new Rat(1_000_000_000n, 1_000_000_000n),
+          new Rat(1_000_000_000n, 1_000_000_000n),
+          new Rat(1_000_000_000n, 1_000_000_000n),
+          new Rat(1_000_000_000n, 1_000_000_000n),
+          new Rat(1_000_000_000n, 1_000_000_000n),
+          new Rat(1_000_000_000n, 1_000_000_000n),
+          new Rat(1_000_000_000n, 1_000_000_000n),
+          new Rat(1_000_000_000n, 1_000_000_000n),
+          new Rat(1_000_000_000n, 1_000_000_000n),
+          new Rat(1_000_000_000n, 1_000_000_000n),
+          new Rat(1_000_000_000n, 1_000_000_000n)
         ])
     })
 
@@ -221,14 +221,16 @@ describe('munge', () => {
         const a = unixRatio
           .minus(segment.start.unixRatio)
           .times(new Rat(1000n))
-          .divide(segment.slope.unixMillisPerAtomicPico)
+          .times(new Rat(1000_000_000n))
+          .divide(segment.slope.unixMillisPerAtomic)
           .plus(segment.start.atomicRatio.times(new Rat(1_000_000_000_000n)))
 
         // TAI picoseconds as of this Unix time, at the START of the NEXT segment
         const b = unixRatio
           .minus(segments[i + 1].start.unixRatio)
           .times(new Rat(1000n))
-          .divide(segments[i + 1].slope.unixMillisPerAtomicPico)
+          .times(new Rat(1000_000_000n))
+          .divide(segments[i + 1].slope.unixMillisPerAtomic)
           .plus(segments[i + 1].start.atomicRatio.times(new Rat(1_000_000_000_000n)))
 
         return b.minus(a).trunc()
@@ -489,84 +491,84 @@ describe('munge', () => {
 
     it('generates proper drift rates', () => {
       // Note the stalls for the duration of inserted time
-      expect(munge(taiData, MODELS.STALL).map(segment => segment.slope.unixMillisPerAtomicPico))
+      expect(munge(taiData, MODELS.STALL).map(segment => segment.slope.unixMillisPerAtomic))
         .toEqual([
-          new Rat(1n, 1_000_000_015n),
-          new Rat(1n, 1_000_000_015n),
-          new Rat(1n, 1_000_000_013n),
-          new Rat(0n, 100_000_000_000n),
-          new Rat(1n, 1_000_000_013n),
-          new Rat(1n, 1_000_000_015n),
-          new Rat(0n, 100_000_000_000n),
-          new Rat(1n, 1_000_000_015n),
-          new Rat(0n, 100_000_000_000n),
-          new Rat(1n, 1_000_000_015n),
-          new Rat(0n, 100_000_000_000n),
-          new Rat(1n, 1_000_000_015n),
-          new Rat(0n, 100_000_000_000n),
-          new Rat(1n, 1_000_000_015n),
-          new Rat(0n, 100_000_000_000n),
-          new Rat(1n, 1_000_000_015n),
-          new Rat(0n, 100_000_000_000n),
-          new Rat(1n, 1_000_000_015n),
-          new Rat(1n, 1_000_000_030n),
-          new Rat(1n, 1_000_000_030n),
-          new Rat(0n, 107_758_000_000n),
-          new Rat(1n, 1_000_000_000n),
-          new Rat(0n, 1_000_000_000_000n),
-          new Rat(1n, 1_000_000_000n),
-          new Rat(0n, 1_000_000_000_000n),
-          new Rat(1n, 1_000_000_000n),
-          new Rat(0n, 1_000_000_000_000n),
-          new Rat(1n, 1_000_000_000n),
-          new Rat(0n, 1_000_000_000_000n),
-          new Rat(1n, 1_000_000_000n),
-          new Rat(0n, 1_000_000_000_000n),
-          new Rat(1n, 1_000_000_000n),
-          new Rat(0n, 1_000_000_000_000n),
-          new Rat(1n, 1_000_000_000n),
-          new Rat(0n, 1_000_000_000_000n),
-          new Rat(1n, 1_000_000_000n),
-          new Rat(0n, 1_000_000_000_000n),
-          new Rat(1n, 1_000_000_000n),
-          new Rat(0n, 1_000_000_000_000n),
-          new Rat(1n, 1_000_000_000n),
-          new Rat(0n, 1_000_000_000_000n),
-          new Rat(1n, 1_000_000_000n),
-          new Rat(0n, 1_000_000_000_000n),
-          new Rat(1n, 1_000_000_000n),
-          new Rat(0n, 1_000_000_000_000n),
-          new Rat(1n, 1_000_000_000n),
-          new Rat(0n, 1_000_000_000_000n),
-          new Rat(1n, 1_000_000_000n),
-          new Rat(0n, 1_000_000_000_000n),
-          new Rat(1n, 1_000_000_000n),
-          new Rat(0n, 1_000_000_000_000n),
-          new Rat(1n, 1_000_000_000n),
-          new Rat(0n, 1_000_000_000_000n),
-          new Rat(1n, 1_000_000_000n),
-          new Rat(0n, 1_000_000_000_000n),
-          new Rat(1n, 1_000_000_000n),
-          new Rat(0n, 1_000_000_000_000n),
-          new Rat(1n, 1_000_000_000n),
-          new Rat(0n, 1_000_000_000_000n),
-          new Rat(1n, 1_000_000_000n),
-          new Rat(0n, 1_000_000_000_000n),
-          new Rat(1n, 1_000_000_000n),
-          new Rat(0n, 1_000_000_000_000n),
-          new Rat(1n, 1_000_000_000n),
-          new Rat(0n, 1_000_000_000_000n),
-          new Rat(1n, 1_000_000_000n),
-          new Rat(0n, 1_000_000_000_000n),
-          new Rat(1n, 1_000_000_000n),
-          new Rat(0n, 1_000_000_000_000n),
-          new Rat(1n, 1_000_000_000n),
-          new Rat(0n, 1_000_000_000_000n),
-          new Rat(1n, 1_000_000_000n),
-          new Rat(0n, 1_000_000_000_000n),
-          new Rat(1n, 1_000_000_000n),
-          new Rat(0n, 1_000_000_000_000n),
-          new Rat(1n, 1_000_000_000n)
+          new Rat(1_000_000_000n, 1_000_000_015n),
+          new Rat(1_000_000_000n, 1_000_000_015n),
+          new Rat(1_000_000_000n, 1_000_000_013n),
+          new Rat(0n),
+          new Rat(1_000_000_000n, 1_000_000_013n),
+          new Rat(1_000_000_000n, 1_000_000_015n),
+          new Rat(0n),
+          new Rat(1_000_000_000n, 1_000_000_015n),
+          new Rat(0n),
+          new Rat(1_000_000_000n, 1_000_000_015n),
+          new Rat(0n),
+          new Rat(1_000_000_000n, 1_000_000_015n),
+          new Rat(0n),
+          new Rat(1_000_000_000n, 1_000_000_015n),
+          new Rat(0n),
+          new Rat(1_000_000_000n, 1_000_000_015n),
+          new Rat(0n),
+          new Rat(1_000_000_000n, 1_000_000_015n),
+          new Rat(1_000_000_000n, 1_000_000_030n),
+          new Rat(1_000_000_000n, 1_000_000_030n),
+          new Rat(0n),
+          new Rat(1n),
+          new Rat(0n),
+          new Rat(1n),
+          new Rat(0n),
+          new Rat(1n),
+          new Rat(0n),
+          new Rat(1n),
+          new Rat(0n),
+          new Rat(1n),
+          new Rat(0n),
+          new Rat(1n),
+          new Rat(0n),
+          new Rat(1n),
+          new Rat(0n),
+          new Rat(1n),
+          new Rat(0n),
+          new Rat(1n),
+          new Rat(0n),
+          new Rat(1n),
+          new Rat(0n),
+          new Rat(1n),
+          new Rat(0n),
+          new Rat(1n),
+          new Rat(0n),
+          new Rat(1n),
+          new Rat(0n),
+          new Rat(1n),
+          new Rat(0n),
+          new Rat(1n),
+          new Rat(0n),
+          new Rat(1n),
+          new Rat(0n),
+          new Rat(1n),
+          new Rat(0n),
+          new Rat(1n),
+          new Rat(0n),
+          new Rat(1n),
+          new Rat(0n),
+          new Rat(1n),
+          new Rat(0n),
+          new Rat(1n),
+          new Rat(0n),
+          new Rat(1n),
+          new Rat(0n),
+          new Rat(1n),
+          new Rat(0n),
+          new Rat(1n),
+          new Rat(0n),
+          new Rat(1n),
+          new Rat(0n),
+          new Rat(1n),
+          new Rat(0n),
+          new Rat(1n),
+          new Rat(0n),
+          new Rat(1n)
         ])
     })
 
@@ -581,21 +583,23 @@ describe('munge', () => {
         const unixRatio = segments[i + 1].start.unixRatio
 
         // TAI picoseconds as of this Unix time, at the END of the CURRENT segment
-        const a = segment.slope.unixMillisPerAtomicPico.nu === 0n
+        const a = segment.slope.unixMillisPerAtomic.nu === 0n
           ? segment.end.atomicRatio.times(new Rat(1_000_000_000_000n))
           : unixRatio
             .minus(segment.start.unixRatio)
             .times(new Rat(1000n))
-            .divide(segment.slope.unixMillisPerAtomicPico)
+            .times(new Rat(1_000_000_000n))
+            .divide(segment.slope.unixMillisPerAtomic)
             .plus(segment.start.atomicRatio.times(new Rat(1_000_000_000_000n)))
 
         // TAI picoseconds as of this Unix time, at the START of the NEXT segment
-        const b = segments[i + 1].slope.unixMillisPerAtomicPico.nu === 0n
+        const b = segments[i + 1].slope.unixMillisPerAtomic.nu === 0n
           ? segments[i + 1].start.atomicRatio.times(new Rat(1_000_000_000_000n))
           : unixRatio
             .minus(segments[i + 1].start.unixRatio)
             .times(new Rat(1000n))
-            .divide(segments[i + 1].slope.unixMillisPerAtomicPico)
+            .times(new Rat(1_000_000_000n))
+            .divide(segments[i + 1].slope.unixMillisPerAtomic)
             .plus(segments[i + 1].start.atomicRatio.times(new Rat(1_000_000_000_000n)))
 
         return b.minus(a).trunc()
@@ -749,91 +753,91 @@ describe('munge', () => {
     })
 
     it('generates proper drift rates', () => {
-      expect(munge(taiData, MODELS.SMEAR).map(segment => segment.slope.unixMillisPerAtomicPico))
+      expect(munge(taiData, MODELS.SMEAR).map(segment => segment.slope.unixMillisPerAtomic))
         .toEqual([
           // During Unix-day-long smears, elapsed atomic time is a full day PLUS daily offset
           // PLUS inserted time
-          new Rat(1n, 1_000_000_015n),
-          new Rat(86_400_000n, 86_400_000_000_000_000n + 1_296_000_000n - 50_000_000_000n),
-          new Rat(1n, 1_000_000_015n),
-          new Rat(86_400_000n, 86_400_000_000_000_000n + 1_209_600_000n + 0n),
-          new Rat(1n, 1_000_000_013n),
-          new Rat(86_400_000n, 86_400_000_000_000_000n + 1_123_200_000n + 100_000_000_000n),
-          new Rat(1n, 1_000_000_013n),
-          new Rat(86_400_000n, 86_400_000_000_000_000n + 1_209_600_000n + 0n),
-          new Rat(1n, 1_000_000_015n),
-          new Rat(86_400_000n, 86_400_000_000_000_000n + 1_296_000_000n + 100_000_000_000n),
-          new Rat(1n, 1_000_000_015n),
-          new Rat(86_400_000n, 86_400_000_000_000_000n + 1_296_000_000n + 100_000_000_000n),
-          new Rat(1n, 1_000_000_015n),
-          new Rat(86_400_000n, 86_400_000_000_000_000n + 1_296_000_000n + 100_000_000_000n),
-          new Rat(1n, 1_000_000_015n),
-          new Rat(86_400_000n, 86_400_000_000_000_000n + 1_296_000_000n + 100_000_000_000n),
-          new Rat(1n, 1_000_000_015n),
-          new Rat(86_400_000n, 86_400_000_000_000_000n + 1_296_000_000n + 100_000_000_000n),
-          new Rat(1n, 1_000_000_015n),
-          new Rat(86_400_000n, 86_400_000_000_000_000n + 1_296_000_000n + 100_000_000_000n),
-          new Rat(1n, 1_000_000_015n),
-          new Rat(86_400_000n, 86_400_000_000_000_000n + 1_944_000_000n + 0n),
-          new Rat(1n, 1_000_000_030n),
-          new Rat(86_400_000n, 86_400_000_000_000_000n + 2_592_000_000n - 100_000_000_000n),
-          new Rat(1n, 1_000_000_030n),
-          new Rat(86_400_000n, 86_400_000_000_000_000n + 0n + 109_054_000_000n),
-          new Rat(1n, 1_000_000_000n),
-          new Rat(86_400_000n, 86_400_000_000_000_000n + 0n + 1_000_000_000_000n),
-          new Rat(1n, 1_000_000_000n),
-          new Rat(86_400_000n, 86_400_000_000_000_000n + 0n + 1_000_000_000_000n),
-          new Rat(1n, 1_000_000_000n),
-          new Rat(86_400_000n, 86_400_000_000_000_000n + 0n + 1_000_000_000_000n),
-          new Rat(1n, 1_000_000_000n),
-          new Rat(86_400_000n, 86_400_000_000_000_000n + 0n + 1_000_000_000_000n),
-          new Rat(1n, 1_000_000_000n),
-          new Rat(86_400_000n, 86_400_000_000_000_000n + 0n + 1_000_000_000_000n),
-          new Rat(1n, 1_000_000_000n),
-          new Rat(86_400_000n, 86_400_000_000_000_000n + 0n + 1_000_000_000_000n),
-          new Rat(1n, 1_000_000_000n),
-          new Rat(86_400_000n, 86_400_000_000_000_000n + 0n + 1_000_000_000_000n),
-          new Rat(1n, 1_000_000_000n),
-          new Rat(86_400_000n, 86_400_000_000_000_000n + 0n + 1_000_000_000_000n),
-          new Rat(1n, 1_000_000_000n),
-          new Rat(86_400_000n, 86_400_000_000_000_000n + 0n + 1_000_000_000_000n),
-          new Rat(1n, 1_000_000_000n),
-          new Rat(86_400_000n, 86_400_000_000_000_000n + 0n + 1_000_000_000_000n),
-          new Rat(1n, 1_000_000_000n),
-          new Rat(86_400_000n, 86_400_000_000_000_000n + 0n + 1_000_000_000_000n),
-          new Rat(1n, 1_000_000_000n),
-          new Rat(86_400_000n, 86_400_000_000_000_000n + 0n + 1_000_000_000_000n),
-          new Rat(1n, 1_000_000_000n),
-          new Rat(86_400_000n, 86_400_000_000_000_000n + 0n + 1_000_000_000_000n),
-          new Rat(1n, 1_000_000_000n),
-          new Rat(86_400_000n, 86_400_000_000_000_000n + 0n + 1_000_000_000_000n),
-          new Rat(1n, 1_000_000_000n),
-          new Rat(86_400_000n, 86_400_000_000_000_000n + 0n + 1_000_000_000_000n),
-          new Rat(1n, 1_000_000_000n),
-          new Rat(86_400_000n, 86_400_000_000_000_000n + 0n + 1_000_000_000_000n),
-          new Rat(1n, 1_000_000_000n),
-          new Rat(86_400_000n, 86_400_000_000_000_000n + 0n + 1_000_000_000_000n),
-          new Rat(1n, 1_000_000_000n),
-          new Rat(86_400_000n, 86_400_000_000_000_000n + 0n + 1_000_000_000_000n),
-          new Rat(1n, 1_000_000_000n),
-          new Rat(86_400_000n, 86_400_000_000_000_000n + 0n + 1_000_000_000_000n),
-          new Rat(1n, 1_000_000_000n),
-          new Rat(86_400_000n, 86_400_000_000_000_000n + 0n + 1_000_000_000_000n),
-          new Rat(1n, 1_000_000_000n),
-          new Rat(86_400_000n, 86_400_000_000_000_000n + 0n + 1_000_000_000_000n),
-          new Rat(1n, 1_000_000_000n),
-          new Rat(86_400_000n, 86_400_000_000_000_000n + 0n + 1_000_000_000_000n),
-          new Rat(1n, 1_000_000_000n),
-          new Rat(86_400_000n, 86_400_000_000_000_000n + 0n + 1_000_000_000_000n),
-          new Rat(1n, 1_000_000_000n),
-          new Rat(86_400_000n, 86_400_000_000_000_000n + 0n + 1_000_000_000_000n),
-          new Rat(1n, 1_000_000_000n),
-          new Rat(86_400_000n, 86_400_000_000_000_000n + 0n + 1_000_000_000_000n),
-          new Rat(1n, 1_000_000_000n),
-          new Rat(86_400_000n, 86_400_000_000_000_000n + 0n + 1_000_000_000_000n),
-          new Rat(1n, 1_000_000_000n),
-          new Rat(86_400_000n, 86_400_000_000_000_000n + 0n + 1_000_000_000_000n),
-          new Rat(1n, 1_000_000_000n)
+          new Rat(1_000_000_000n, 1_000_000_015n),
+          new Rat(86_400_000_000_000_000n, 86_400_000_000_000_000n + 1_296_000_000n - 50_000_000_000n),
+          new Rat(1_000_000_000n, 1_000_000_015n),
+          new Rat(86_400_000_000_000_000n, 86_400_000_000_000_000n + 1_209_600_000n + 0n),
+          new Rat(1_000_000_000n, 1_000_000_013n),
+          new Rat(86_400_000_000_000_000n, 86_400_000_000_000_000n + 1_123_200_000n + 100_000_000_000n),
+          new Rat(1_000_000_000n, 1_000_000_013n),
+          new Rat(86_400_000_000_000_000n, 86_400_000_000_000_000n + 1_209_600_000n + 0n),
+          new Rat(1_000_000_000n, 1_000_000_015n),
+          new Rat(86_400_000_000_000_000n, 86_400_000_000_000_000n + 1_296_000_000n + 100_000_000_000n),
+          new Rat(1_000_000_000n, 1_000_000_015n),
+          new Rat(86_400_000_000_000_000n, 86_400_000_000_000_000n + 1_296_000_000n + 100_000_000_000n),
+          new Rat(1_000_000_000n, 1_000_000_015n),
+          new Rat(86_400_000_000_000_000n, 86_400_000_000_000_000n + 1_296_000_000n + 100_000_000_000n),
+          new Rat(1_000_000_000n, 1_000_000_015n),
+          new Rat(86_400_000_000_000_000n, 86_400_000_000_000_000n + 1_296_000_000n + 100_000_000_000n),
+          new Rat(1_000_000_000n, 1_000_000_015n),
+          new Rat(86_400_000_000_000_000n, 86_400_000_000_000_000n + 1_296_000_000n + 100_000_000_000n),
+          new Rat(1_000_000_000n, 1_000_000_015n),
+          new Rat(86_400_000_000_000_000n, 86_400_000_000_000_000n + 1_296_000_000n + 100_000_000_000n),
+          new Rat(1_000_000_000n, 1_000_000_015n),
+          new Rat(86_400_000_000_000_000n, 86_400_000_000_000_000n + 1_944_000_000n + 0n),
+          new Rat(1_000_000_000n, 1_000_000_030n),
+          new Rat(86_400_000_000_000_000n, 86_400_000_000_000_000n + 2_592_000_000n - 100_000_000_000n),
+          new Rat(1_000_000_000n, 1_000_000_030n),
+          new Rat(86_400_000_000_000_000n, 86_400_000_000_000_000n + 0n + 109_054_000_000n),
+          new Rat(1_000_000_000n, 1_000_000_000n),
+          new Rat(86_400_000_000_000_000n, 86_400_000_000_000_000n + 0n + 1_000_000_000_000n),
+          new Rat(1_000_000_000n, 1_000_000_000n),
+          new Rat(86_400_000_000_000_000n, 86_400_000_000_000_000n + 0n + 1_000_000_000_000n),
+          new Rat(1_000_000_000n, 1_000_000_000n),
+          new Rat(86_400_000_000_000_000n, 86_400_000_000_000_000n + 0n + 1_000_000_000_000n),
+          new Rat(1_000_000_000n, 1_000_000_000n),
+          new Rat(86_400_000_000_000_000n, 86_400_000_000_000_000n + 0n + 1_000_000_000_000n),
+          new Rat(1_000_000_000n, 1_000_000_000n),
+          new Rat(86_400_000_000_000_000n, 86_400_000_000_000_000n + 0n + 1_000_000_000_000n),
+          new Rat(1_000_000_000n, 1_000_000_000n),
+          new Rat(86_400_000_000_000_000n, 86_400_000_000_000_000n + 0n + 1_000_000_000_000n),
+          new Rat(1_000_000_000n, 1_000_000_000n),
+          new Rat(86_400_000_000_000_000n, 86_400_000_000_000_000n + 0n + 1_000_000_000_000n),
+          new Rat(1_000_000_000n, 1_000_000_000n),
+          new Rat(86_400_000_000_000_000n, 86_400_000_000_000_000n + 0n + 1_000_000_000_000n),
+          new Rat(1_000_000_000n, 1_000_000_000n),
+          new Rat(86_400_000_000_000_000n, 86_400_000_000_000_000n + 0n + 1_000_000_000_000n),
+          new Rat(1_000_000_000n, 1_000_000_000n),
+          new Rat(86_400_000_000_000_000n, 86_400_000_000_000_000n + 0n + 1_000_000_000_000n),
+          new Rat(1_000_000_000n, 1_000_000_000n),
+          new Rat(86_400_000_000_000_000n, 86_400_000_000_000_000n + 0n + 1_000_000_000_000n),
+          new Rat(1_000_000_000n, 1_000_000_000n),
+          new Rat(86_400_000_000_000_000n, 86_400_000_000_000_000n + 0n + 1_000_000_000_000n),
+          new Rat(1_000_000_000n, 1_000_000_000n),
+          new Rat(86_400_000_000_000_000n, 86_400_000_000_000_000n + 0n + 1_000_000_000_000n),
+          new Rat(1_000_000_000n, 1_000_000_000n),
+          new Rat(86_400_000_000_000_000n, 86_400_000_000_000_000n + 0n + 1_000_000_000_000n),
+          new Rat(1_000_000_000n, 1_000_000_000n),
+          new Rat(86_400_000_000_000_000n, 86_400_000_000_000_000n + 0n + 1_000_000_000_000n),
+          new Rat(1_000_000_000n, 1_000_000_000n),
+          new Rat(86_400_000_000_000_000n, 86_400_000_000_000_000n + 0n + 1_000_000_000_000n),
+          new Rat(1_000_000_000n, 1_000_000_000n),
+          new Rat(86_400_000_000_000_000n, 86_400_000_000_000_000n + 0n + 1_000_000_000_000n),
+          new Rat(1_000_000_000n, 1_000_000_000n),
+          new Rat(86_400_000_000_000_000n, 86_400_000_000_000_000n + 0n + 1_000_000_000_000n),
+          new Rat(1_000_000_000n, 1_000_000_000n),
+          new Rat(86_400_000_000_000_000n, 86_400_000_000_000_000n + 0n + 1_000_000_000_000n),
+          new Rat(1_000_000_000n, 1_000_000_000n),
+          new Rat(86_400_000_000_000_000n, 86_400_000_000_000_000n + 0n + 1_000_000_000_000n),
+          new Rat(1_000_000_000n, 1_000_000_000n),
+          new Rat(86_400_000_000_000_000n, 86_400_000_000_000_000n + 0n + 1_000_000_000_000n),
+          new Rat(1_000_000_000n, 1_000_000_000n),
+          new Rat(86_400_000_000_000_000n, 86_400_000_000_000_000n + 0n + 1_000_000_000_000n),
+          new Rat(1_000_000_000n, 1_000_000_000n),
+          new Rat(86_400_000_000_000_000n, 86_400_000_000_000_000n + 0n + 1_000_000_000_000n),
+          new Rat(1_000_000_000n, 1_000_000_000n),
+          new Rat(86_400_000_000_000_000n, 86_400_000_000_000_000n + 0n + 1_000_000_000_000n),
+          new Rat(1_000_000_000n, 1_000_000_000n),
+          new Rat(86_400_000_000_000_000n, 86_400_000_000_000_000n + 0n + 1_000_000_000_000n),
+          new Rat(1_000_000_000n, 1_000_000_000n),
+          new Rat(86_400_000_000_000_000n, 86_400_000_000_000_000n + 0n + 1_000_000_000_000n),
+          new Rat(1_000_000_000n, 1_000_000_000n),
+          new Rat(86_400_000_000_000_000n, 86_400_000_000_000_000n + 0n + 1_000_000_000_000n),
+          new Rat(1_000_000_000n, 1_000_000_000n)
         ])
     })
 
@@ -850,14 +854,16 @@ describe('munge', () => {
         const a = unixRatio
           .minus(segment.start.unixRatio)
           .times(new Rat(1000n))
-          .divide(segment.slope.unixMillisPerAtomicPico)
+          .times(new Rat(1000_000_000n))
+          .divide(segment.slope.unixMillisPerAtomic)
           .plus(segment.start.atomicRatio.times(new Rat(1_000_000_000_000n)))
 
         // TAI picoseconds as of this Unix time, at the START of the NEXT segment
         const b = unixRatio
           .minus(segments[i + 1].start.unixRatio)
           .times(new Rat(1000n))
-          .divide(segments[i + 1].slope.unixMillisPerAtomicPico)
+          .times(new Rat(1000_000_000n))
+          .divide(segments[i + 1].slope.unixMillisPerAtomic)
           .plus(segments[i + 1].start.atomicRatio.times(new Rat(1_000_000_000_000n)))
 
         return b.minus(a).trunc()

--- a/src/munge.spec.js
+++ b/src/munge.spec.js
@@ -218,14 +218,16 @@ describe('munge', () => {
         const unixRatio = segments[i + 1].start.unixRatio
 
         // TAI picoseconds as of this Unix time, at the END of the CURRENT segment
-        const a = unixRatio.times(new Rat(1000n))
-          .minus(segment.start.unixRatio.times(new Rat(1000n)))
+        const a = unixRatio
+          .minus(segment.start.unixRatio)
+          .times(new Rat(1000n))
           .divide(segment.slope.unixMillisPerAtomicPico)
           .plus(segment.start.atomicPicosRatio)
 
         // TAI picoseconds as of this Unix time, at the START of the NEXT segment
-        const b = unixRatio.times(new Rat(1000n))
-          .minus(segments[i + 1].start.unixRatio.times(new Rat(1000n)))
+        const b = unixRatio
+          .minus(segments[i + 1].start.unixRatio)
+          .times(new Rat(1000n))
           .divide(segments[i + 1].slope.unixMillisPerAtomicPico)
           .plus(segments[i + 1].start.atomicPicosRatio)
 
@@ -581,16 +583,18 @@ describe('munge', () => {
         // TAI picoseconds as of this Unix time, at the END of the CURRENT segment
         const a = segment.slope.unixMillisPerAtomicPico.nu === 0n
           ? segment.end.atomicPicosRatio
-          : unixRatio.times(new Rat(1000n))
-            .minus(segment.start.unixRatio.times(new Rat(1000n)))
+          : unixRatio
+            .minus(segment.start.unixRatio)
+            .times(new Rat(1000n))
             .divide(segment.slope.unixMillisPerAtomicPico)
             .plus(segment.start.atomicPicosRatio)
 
         // TAI picoseconds as of this Unix time, at the START of the NEXT segment
         const b = segments[i + 1].slope.unixMillisPerAtomicPico.nu === 0n
           ? segments[i + 1].start.atomicPicosRatio
-          : unixRatio.times(new Rat(1000n))
-            .minus(segments[i + 1].start.unixRatio.times(new Rat(1000n)))
+          : unixRatio
+            .minus(segments[i + 1].start.unixRatio)
+            .times(new Rat(1000n))
             .divide(segments[i + 1].slope.unixMillisPerAtomicPico)
             .plus(segments[i + 1].start.atomicPicosRatio)
 
@@ -843,14 +847,16 @@ describe('munge', () => {
         const unixRatio = segments[i + 1].start.unixRatio
 
         // TAI picoseconds as of this Unix time, at the END of the CURRENT segment
-        const a = unixRatio.times(new Rat(1000n))
-          .minus(segment.start.unixRatio.times(new Rat(1000n)))
+        const a = unixRatio
+          .minus(segment.start.unixRatio)
+          .times(new Rat(1000n))
           .divide(segment.slope.unixMillisPerAtomicPico)
           .plus(segment.start.atomicPicosRatio)
 
         // TAI picoseconds as of this Unix time, at the START of the NEXT segment
-        const b = unixRatio.times(new Rat(1000n))
-          .minus(segments[i + 1].start.unixRatio.times(new Rat(1000n)))
+        const b = unixRatio
+          .minus(segments[i + 1].start.unixRatio)
+          .times(new Rat(1000n))
           .divide(segments[i + 1].slope.unixMillisPerAtomicPico)
           .plus(segments[i + 1].start.atomicPicosRatio)
 

--- a/src/munge.spec.js
+++ b/src/munge.spec.js
@@ -222,14 +222,14 @@ describe('munge', () => {
           .minus(segment.start.unixRatio)
           .times(new Rat(1000n))
           .divide(segment.slope.unixMillisPerAtomicPico)
-          .plus(segment.start.atomicPicosRatio)
+          .plus(segment.start.atomicRatio.times(new Rat(1_000_000_000_000n)))
 
         // TAI picoseconds as of this Unix time, at the START of the NEXT segment
         const b = unixRatio
           .minus(segments[i + 1].start.unixRatio)
           .times(new Rat(1000n))
           .divide(segments[i + 1].slope.unixMillisPerAtomicPico)
-          .plus(segments[i + 1].start.atomicPicosRatio)
+          .plus(segments[i + 1].start.atomicRatio.times(new Rat(1_000_000_000_000n)))
 
         return b.minus(a).trunc()
       })).toEqual([
@@ -587,16 +587,16 @@ describe('munge', () => {
             .minus(segment.start.unixRatio)
             .times(new Rat(1000n))
             .divide(segment.slope.unixMillisPerAtomicPico)
-            .plus(segment.start.atomicPicosRatio)
+            .plus(segment.start.atomicRatio.times(new Rat(1_000_000_000_000n)))
 
         // TAI picoseconds as of this Unix time, at the START of the NEXT segment
         const b = segments[i + 1].slope.unixMillisPerAtomicPico.nu === 0n
-          ? segments[i + 1].start.atomicPicosRatio
+          ? segments[i + 1].start.atomicRatio.times(new Rat(1_000_000_000_000n))
           : unixRatio
             .minus(segments[i + 1].start.unixRatio)
             .times(new Rat(1000n))
             .divide(segments[i + 1].slope.unixMillisPerAtomicPico)
-            .plus(segments[i + 1].start.atomicPicosRatio)
+            .plus(segments[i + 1].start.atomicRatio.times(new Rat(1_000_000_000_000n)))
 
         return b.minus(a).trunc()
       })).toEqual([
@@ -851,14 +851,14 @@ describe('munge', () => {
           .minus(segment.start.unixRatio)
           .times(new Rat(1000n))
           .divide(segment.slope.unixMillisPerAtomicPico)
-          .plus(segment.start.atomicPicosRatio)
+          .plus(segment.start.atomicRatio.times(new Rat(1_000_000_000_000n)))
 
         // TAI picoseconds as of this Unix time, at the START of the NEXT segment
         const b = unixRatio
           .minus(segments[i + 1].start.unixRatio)
           .times(new Rat(1000n))
           .divide(segments[i + 1].slope.unixMillisPerAtomicPico)
-          .plus(segments[i + 1].start.atomicPicosRatio)
+          .plus(segments[i + 1].start.atomicRatio.times(new Rat(1_000_000_000_000n)))
 
         return b.minus(a).trunc()
       })).toEqual([

--- a/src/munge.spec.js
+++ b/src/munge.spec.js
@@ -582,7 +582,7 @@ describe('munge', () => {
 
         // TAI picoseconds as of this Unix time, at the END of the CURRENT segment
         const a = segment.slope.unixMillisPerAtomicPico.nu === 0n
-          ? segment.end.atomicPicosRatio
+          ? segment.end.atomicRatio.times(new Rat(1_000_000_000_000n))
           : unixRatio
             .minus(segment.start.unixRatio)
             .times(new Rat(1000n))

--- a/src/munge.spec.js
+++ b/src/munge.spec.js
@@ -215,17 +215,17 @@ describe('munge', () => {
           return NaN
         }
 
-        const unixMillisRatio = segments[i + 1].start.unixMillisRatio
+        const unixRatio = segments[i + 1].start.unixRatio
 
         // TAI picoseconds as of this Unix time, at the END of the CURRENT segment
-        const a = unixMillisRatio
-          .minus(segment.start.unixMillisRatio)
+        const a = unixRatio.times(new Rat(1000n))
+          .minus(segment.start.unixRatio.times(new Rat(1000n)))
           .divide(segment.slope.unixMillisPerAtomicPico)
           .plus(segment.start.atomicPicosRatio)
 
         // TAI picoseconds as of this Unix time, at the START of the NEXT segment
-        const b = unixMillisRatio
-          .minus(segments[i + 1].start.unixMillisRatio)
+        const b = unixRatio.times(new Rat(1000n))
+          .minus(segments[i + 1].start.unixRatio.times(new Rat(1000n)))
           .divide(segments[i + 1].slope.unixMillisPerAtomicPico)
           .plus(segments[i + 1].start.atomicPicosRatio)
 
@@ -576,21 +576,21 @@ describe('munge', () => {
           return NaN
         }
 
-        const unixMillisRatio = segments[i + 1].start.unixMillisRatio
+        const unixRatio = segments[i + 1].start.unixRatio
 
         // TAI picoseconds as of this Unix time, at the END of the CURRENT segment
         const a = segment.slope.unixMillisPerAtomicPico.nu === 0n
           ? segment.end.atomicPicosRatio
-          : unixMillisRatio
-            .minus(segment.start.unixMillisRatio)
+          : unixRatio.times(new Rat(1000n))
+            .minus(segment.start.unixRatio.times(new Rat(1000n)))
             .divide(segment.slope.unixMillisPerAtomicPico)
             .plus(segment.start.atomicPicosRatio)
 
         // TAI picoseconds as of this Unix time, at the START of the NEXT segment
         const b = segments[i + 1].slope.unixMillisPerAtomicPico.nu === 0n
           ? segments[i + 1].start.atomicPicosRatio
-          : unixMillisRatio
-            .minus(segments[i + 1].start.unixMillisRatio)
+          : unixRatio.times(new Rat(1000n))
+            .minus(segments[i + 1].start.unixRatio.times(new Rat(1000n)))
             .divide(segments[i + 1].slope.unixMillisPerAtomicPico)
             .plus(segments[i + 1].start.atomicPicosRatio)
 
@@ -840,17 +840,17 @@ describe('munge', () => {
           return NaN
         }
 
-        const unixMillisRatio = segments[i + 1].start.unixMillisRatio
+        const unixRatio = segments[i + 1].start.unixRatio
 
         // TAI picoseconds as of this Unix time, at the END of the CURRENT segment
-        const a = unixMillisRatio
-          .minus(segment.start.unixMillisRatio)
+        const a = unixRatio.times(new Rat(1000n))
+          .minus(segment.start.unixRatio.times(new Rat(1000n)))
           .divide(segment.slope.unixMillisPerAtomicPico)
           .plus(segment.start.atomicPicosRatio)
 
         // TAI picoseconds as of this Unix time, at the START of the NEXT segment
-        const b = unixMillisRatio
-          .minus(segments[i + 1].start.unixMillisRatio)
+        const b = unixRatio.times(new Rat(1000n))
+          .minus(segments[i + 1].start.unixRatio.times(new Rat(1000n)))
           .divide(segments[i + 1].slope.unixMillisPerAtomicPico)
           .plus(segments[i + 1].start.atomicPicosRatio)
 

--- a/src/segment.js
+++ b/src/segment.js
@@ -11,7 +11,7 @@ class Segment {
     }
 
     this.slope = {
-      unixMillisPerAtomicPico: new Rat(BigInt(dy.unixMillis), dx.atomicPicos)
+      unixMillisPerAtomic: new Rat(BigInt(dy.unixMillis) * 1_000_000_000n, dx.atomicPicos)
     }
 
     // Start is inclusive.
@@ -30,8 +30,8 @@ class Segment {
       this.end.atomicRatio = new Rat(end.atomicPicos, 1_000_000_000_000n)
       this.end.unixRatio = this.end.atomicRatio
         .minus(this.start.atomicRatio)
-        .times(new Rat(1_000_000_000_000n))
-        .times(this.slope.unixMillisPerAtomicPico)
+        .times(new Rat(1_000n))
+        .times(this.slope.unixMillisPerAtomic)
         .plus(this.start.unixRatio.times(new Rat(1000n)))
         .divide(new Rat(1000n))
     }
@@ -39,7 +39,7 @@ class Segment {
 
   unixRatioToAtomicRatioRange (unixRatio) {
     const unixMillisRatio = unixRatio.times(new Rat(1000n))
-    if (this.slope.unixMillisPerAtomicPico.eq(new Rat(0n))) {
+    if (this.slope.unixMillisPerAtomic.eq(new Rat(0n))) {
       if (!unixMillisRatio.eq(this.start.unixRatio.times(new Rat(1000n)))) {
         throw Error('This Unix time never happened')
       }
@@ -53,8 +53,8 @@ class Segment {
 
     const atomicRatio = unixMillisRatio
       .minus(this.start.unixRatio.times(new Rat(1000n)))
-      .divide(this.slope.unixMillisPerAtomicPico)
-      .divide(new Rat(1_000_000_000_000n))
+      .divide(this.slope.unixMillisPerAtomic)
+      .divide(new Rat(1_000n))
       .plus(this.start.atomicRatio)
 
     return {
@@ -67,8 +67,8 @@ class Segment {
   atomicRatioToUnixRatio (atomicRatio) {
     return atomicRatio
       .minus(this.start.atomicRatio)
-      .times(new Rat(1_000_000_000_000n))
-      .times(this.slope.unixMillisPerAtomicPico)
+      .times(new Rat(1_000n))
+      .times(this.slope.unixMillisPerAtomic)
       .plus(this.start.unixRatio.times(new Rat(1000n)))
       .divide(new Rat(1000n))
   }
@@ -87,7 +87,7 @@ class Segment {
   }
 
   unixRatioOnSegment (unixRatio) {
-    return this.slope.unixMillisPerAtomicPico.eq(new Rat(0n))
+    return this.slope.unixMillisPerAtomic.eq(new Rat(0n))
       ? this.start.unixRatio.eq(unixRatio)
       : this.start.unixRatio.le(unixRatio) && (
         this.end.unixRatio === Infinity ||

--- a/src/segment.js
+++ b/src/segment.js
@@ -42,7 +42,7 @@ class Segment {
     }
   }
 
-  unixRatioToAtomicMillisRatioRange (unixRatio) {
+  unixRatioToAtomicPicosRatioRange (unixRatio) {
     const unixMillisRatio = unixRatio.times(new Rat(1000n))
     if (this.slope.unixMillisPerAtomicPico.eq(new Rat(0n))) {
       if (!unixMillisRatio.eq(this.start.unixMillisRatio)) {
@@ -50,8 +50,8 @@ class Segment {
       }
 
       return {
-        start: this.start.atomicMillisRatio,
-        end: this.end.atomicMillisRatio,
+        start: this.start.atomicPicosRatio,
+        end: this.end.atomicPicosRatio,
         closed: false
       }
     }
@@ -60,11 +60,10 @@ class Segment {
       .minus(this.start.unixMillisRatio)
       .divide(this.slope.unixMillisPerAtomicPico)
       .plus(this.start.atomicPicosRatio)
-    const atomicMillisRatio = atomicPicosRatio.divide(new Rat(picosPerMilli))
 
     return {
-      start: atomicMillisRatio,
-      end: atomicMillisRatio,
+      start: atomicPicosRatio,
+      end: atomicPicosRatio,
       closed: true
     }
   }

--- a/src/segment.js
+++ b/src/segment.js
@@ -94,8 +94,7 @@ class Segment {
   // the segment. Valid Unix instants are the valid TAI instants, transformed linearly from TAI to
   // Unix by the segment.
 
-  atomicPicosOnSegment (atomicPicos) {
-    const atomicPicosRatio = new Rat(atomicPicos)
+  atomicPicosRatioOnSegment (atomicPicosRatio) {
     return this.start.atomicPicosRatio.le(atomicPicosRatio) && (
       this.end.atomicPicosRatio === Infinity ||
       this.end.atomicPicosRatio

--- a/src/segment.js
+++ b/src/segment.js
@@ -27,13 +27,14 @@ class Segment {
     this.end.atomicPicos = end.atomicPicos
     if (this.end.atomicPicos === Infinity) {
       this.end.atomicPicosRatio = Infinity
-      this.end.unixMillisRatio = Infinity
+      this.end.unixRatio = Infinity
     } else {
       this.end.atomicPicosRatio = new Rat(this.end.atomicPicos)
-      this.end.unixMillisRatio = this.end.atomicPicosRatio
+      this.end.unixRatio = this.end.atomicPicosRatio
         .minus(this.start.atomicPicosRatio)
         .times(this.slope.unixMillisPerAtomicPico)
         .plus(this.start.unixRatio.times(new Rat(1000n)))
+        .divide(new Rat(1000n))
     }
   }
 
@@ -91,8 +92,8 @@ class Segment {
     return this.slope.unixMillisPerAtomicPico.eq(new Rat(0n))
       ? this.start.unixRatio.times(new Rat(1000n)).eq(unixMillisRatio)
       : this.start.unixRatio.times(new Rat(1000n)).le(unixMillisRatio) && (
-        this.end.unixMillisRatio === Infinity ||
-        this.end.unixMillisRatio
+        this.end.unixRatio === Infinity ||
+        this.end.unixRatio.times(new Rat(1000n))
           .gt(unixMillisRatio)
       )
   }

--- a/src/segment.js
+++ b/src/segment.js
@@ -94,8 +94,7 @@ class Segment {
   // the segment. Valid Unix instants are the valid TAI instants, transformed linearly from TAI to
   // Unix by the segment.
 
-  atomicMillisOnSegment (atomicMillis) {
-    const atomicPicos = BigInt(atomicMillis) * picosPerMilli
+  atomicPicosOnSegment (atomicPicos) {
     const atomicPicosRatio = new Rat(atomicPicos)
     return this.start.atomicPicosRatio.le(atomicPicosRatio) && (
       this.end.atomicPicosRatio === Infinity ||

--- a/src/segment.js
+++ b/src/segment.js
@@ -45,9 +45,7 @@ class Segment {
     }
   }
 
-  unixMillisToAtomicMillisRange (unixMillis) {
-    const unixMillisRatio = new Rat(BigInt(unixMillis))
-
+  unixMillisRatioToAtomicMillisRange (unixMillisRatio) {
     if (this.slope.unixMillisPerAtomicPico.eq(new Rat(0n))) {
       if (!unixMillisRatio.eq(this.start.unixMillisRatio)) {
         throw Error('This Unix time never happened')

--- a/src/segment.js
+++ b/src/segment.js
@@ -22,7 +22,6 @@ class Segment {
     this.start.atomicPicos = start.atomicPicos
     this.start.atomicPicosRatio = new Rat(this.start.atomicPicos)
     this.start.atomicMillisRatio = this.start.atomicPicosRatio.divide(new Rat(picosPerMilli))
-    this.start.atomicMillis = Number(this.start.atomicMillisRatio.trunc()) // inexact
     this.start.unixMillisRatio = new Rat(BigInt(start.unixMillis))
 
     // End is exclusive.
@@ -32,12 +31,10 @@ class Segment {
     if (this.end.atomicPicos === Infinity) {
       this.end.atomicPicosRatio = Infinity
       this.end.atomicMillisRatio = Infinity
-      this.end.atomicMillis = Infinity
       this.end.unixMillisRatio = Infinity
     } else {
       this.end.atomicPicosRatio = new Rat(this.end.atomicPicos)
       this.end.atomicMillisRatio = this.end.atomicPicosRatio.divide(new Rat(picosPerMilli))
-      this.end.atomicMillis = Number(this.end.atomicMillisRatio.trunc())
       this.end.unixMillisRatio = this.end.atomicPicosRatio
         .minus(this.start.atomicPicosRatio)
         .times(this.slope.unixMillisPerAtomicPico)

--- a/src/segment.js
+++ b/src/segment.js
@@ -24,12 +24,13 @@ class Segment {
     // `atomicPicos` is exact, no exact integer `unixMillis` is possible in most cases
     this.end = {}
     if (end.atomicPicos === Infinity) {
-      this.end.atomicPicosRatio = Infinity
+      this.end.atomicRatio = Infinity
       this.end.unixRatio = Infinity
     } else {
-      this.end.atomicPicosRatio = new Rat(end.atomicPicos)
-      this.end.unixRatio = this.end.atomicPicosRatio
-        .minus(this.start.atomicRatio.times(new Rat(1_000_000_000_000n)))
+      this.end.atomicRatio = new Rat(end.atomicPicos, 1_000_000_000_000n)
+      this.end.unixRatio = this.end.atomicRatio
+        .minus(this.start.atomicRatio)
+        .times(new Rat(1_000_000_000_000n))
         .times(this.slope.unixMillisPerAtomicPico)
         .plus(this.start.unixRatio.times(new Rat(1000n)))
         .divide(new Rat(1000n))
@@ -45,7 +46,7 @@ class Segment {
 
       return {
         start: this.start.atomicRatio,
-        end: this.end.atomicPicosRatio.divide(new Rat(1_000_000_000_000n)),
+        end: this.end.atomicRatio,
         closed: false
       }
     }
@@ -78,11 +79,10 @@ class Segment {
   // Unix by the segment.
 
   atomicRatioOnSegment (atomicRatio) {
-    const atomicPicosRatio = atomicRatio.times(new Rat(1_000_000_000_000n))
     return this.start.atomicRatio.le(atomicRatio) && (
-      this.end.atomicPicosRatio === Infinity ||
-      this.end.atomicPicosRatio
-        .gt(atomicPicosRatio)
+      this.end.atomicRatio === Infinity ||
+      this.end.atomicRatio
+        .gt(atomicRatio)
     )
   }
 

--- a/src/segment.js
+++ b/src/segment.js
@@ -23,8 +23,7 @@ class Segment {
     this.start.atomicPicosRatio = new Rat(this.start.atomicPicos)
     this.start.atomicMillisRatio = this.start.atomicPicosRatio.divide(new Rat(picosPerMilli))
     this.start.atomicMillis = Number(this.start.atomicMillisRatio.trunc()) // inexact
-    this.start.unixMillis = start.unixMillis
-    this.start.unixMillisRatio = new Rat(BigInt(this.start.unixMillis))
+    this.start.unixMillisRatio = new Rat(BigInt(start.unixMillis))
 
     // End is exclusive.
     // `atomicPicos` is exact, no exact integer `unixMillis` is possible in most cases
@@ -35,7 +34,6 @@ class Segment {
       this.end.atomicMillisRatio = Infinity
       this.end.atomicMillis = Infinity
       this.end.unixMillisRatio = Infinity
-      this.end.unixMillis = Infinity
     } else {
       this.end.atomicPicosRatio = new Rat(this.end.atomicPicos)
       this.end.atomicMillisRatio = this.end.atomicPicosRatio.divide(new Rat(picosPerMilli))
@@ -44,7 +42,6 @@ class Segment {
         .minus(this.start.atomicPicosRatio)
         .times(this.slope.unixMillisPerAtomicPico)
         .plus(this.start.unixMillisRatio)
-      this.end.unixMillis = Number(this.end.unixMillisRatio.trunc()) // inexact
     }
   }
 

--- a/src/segment.js
+++ b/src/segment.js
@@ -45,7 +45,8 @@ class Segment {
     }
   }
 
-  unixMillisRatioToAtomicMillisRange (unixMillisRatio) {
+  unixRatioToAtomicMillisRange (unixRatio) {
+    const unixMillisRatio = unixRatio.times(new Rat(1000n))
     if (this.slope.unixMillisPerAtomicPico.eq(new Rat(0n))) {
       if (!unixMillisRatio.eq(this.start.unixMillisRatio)) {
         throw Error('This Unix time never happened')

--- a/src/segment.js
+++ b/src/segment.js
@@ -74,11 +74,12 @@ class Segment {
     }
   }
 
-  atomicRatioToUnixMillisRatio (atomicRatio) {
+  atomicRatioToUnixRatio (atomicRatio) {
     return atomicRatio.times(new Rat(1_000_000_000_000n))
       .minus(this.start.atomicPicosRatio)
       .times(this.slope.unixMillisPerAtomicPico)
       .plus(this.start.unixMillisRatio)
+      .divide(new Rat(1000n))
   }
 
   // Bounds checks. Each segment has an inclusive-exclusive range of validity.

--- a/src/segment.js
+++ b/src/segment.js
@@ -94,7 +94,8 @@ class Segment {
   // the segment. Valid Unix instants are the valid TAI instants, transformed linearly from TAI to
   // Unix by the segment.
 
-  atomicPicosRatioOnSegment (atomicPicosRatio) {
+  atomicRatioOnSegment (atomicRatio) {
+    const atomicPicosRatio = atomicRatio.times(new Rat(1_000_000_000_000n))
     return this.start.atomicPicosRatio.le(atomicPicosRatio) && (
       this.end.atomicPicosRatio === Infinity ||
       this.end.atomicPicosRatio

--- a/src/segment.js
+++ b/src/segment.js
@@ -17,8 +17,7 @@ class Segment {
     // Start is inclusive.
     // `atomicPicos` and `unixMillis` are exact.
     this.start = {}
-    this.start.atomicPicos = start.atomicPicos
-    this.start.atomicPicosRatio = new Rat(this.start.atomicPicos)
+    this.start.atomicPicosRatio = new Rat(start.atomicPicos)
     this.start.unixRatio = new Rat(BigInt(start.unixMillis), 1000n)
 
     // End is exclusive.

--- a/src/segment.js
+++ b/src/segment.js
@@ -88,13 +88,11 @@ class Segment {
   }
 
   unixRatioOnSegment (unixRatio) {
-    const unixMillisRatio = unixRatio.times(new Rat(1000n))
     return this.slope.unixMillisPerAtomicPico.eq(new Rat(0n))
-      ? this.start.unixRatio.times(new Rat(1000n)).eq(unixMillisRatio)
-      : this.start.unixRatio.times(new Rat(1000n)).le(unixMillisRatio) && (
+      ? this.start.unixRatio.eq(unixRatio)
+      : this.start.unixRatio.le(unixRatio) && (
         this.end.unixRatio === Infinity ||
-        this.end.unixRatio.times(new Rat(1000n))
-          .gt(unixMillisRatio)
+        this.end.unixRatio.gt(unixRatio)
       )
   }
 }

--- a/src/segment.js
+++ b/src/segment.js
@@ -23,12 +23,11 @@ class Segment {
     // End is exclusive.
     // `atomicPicos` is exact, no exact integer `unixMillis` is possible in most cases
     this.end = {}
-    this.end.atomicPicos = end.atomicPicos
-    if (this.end.atomicPicos === Infinity) {
+    if (end.atomicPicos === Infinity) {
       this.end.atomicPicosRatio = Infinity
       this.end.unixRatio = Infinity
     } else {
-      this.end.atomicPicosRatio = new Rat(this.end.atomicPicos)
+      this.end.atomicPicosRatio = new Rat(end.atomicPicos)
       this.end.unixRatio = this.end.atomicPicosRatio
         .minus(this.start.atomicPicosRatio)
         .times(this.slope.unixMillisPerAtomicPico)

--- a/src/segment.js
+++ b/src/segment.js
@@ -37,7 +37,7 @@ class Segment {
     }
   }
 
-  unixRatioToAtomicPicosRatioRange (unixRatio) {
+  unixRatioToAtomicRatioRange (unixRatio) {
     const unixMillisRatio = unixRatio.times(new Rat(1000n))
     if (this.slope.unixMillisPerAtomicPico.eq(new Rat(0n))) {
       if (!unixMillisRatio.eq(this.start.unixMillisRatio)) {
@@ -45,8 +45,8 @@ class Segment {
       }
 
       return {
-        start: this.start.atomicPicosRatio,
-        end: this.end.atomicPicosRatio,
+        start: this.start.atomicPicosRatio.divide(new Rat(1_000_000_000_000n)),
+        end: this.end.atomicPicosRatio.divide(new Rat(1_000_000_000_000n)),
         closed: false
       }
     }
@@ -55,6 +55,7 @@ class Segment {
       .minus(this.start.unixMillisRatio)
       .divide(this.slope.unixMillisPerAtomicPico)
       .plus(this.start.atomicPicosRatio)
+      .divide(new Rat(1_000_000_000_000n))
 
     return {
       start: atomicPicosRatio,

--- a/src/segment.js
+++ b/src/segment.js
@@ -74,14 +74,11 @@ class Segment {
     }
   }
 
-  atomicRatioToUnixMillis (atomicRatio) {
-    const unixMillisRatio = atomicRatio.times(new Rat(1_000_000_000_000n))
+  atomicRatioToUnixMillisRatio (atomicRatio) {
+    return atomicRatio.times(new Rat(1_000_000_000_000n))
       .minus(this.start.atomicPicosRatio)
       .times(this.slope.unixMillisPerAtomicPico)
       .plus(this.start.unixMillisRatio)
-    const unixMillis = Number(unixMillisRatio.trunc())
-
-    return unixMillis
   }
 
   // Bounds checks. Each segment has an inclusive-exclusive range of validity.

--- a/src/segment.js
+++ b/src/segment.js
@@ -104,7 +104,8 @@ class Segment {
     )
   }
 
-  unixMillisRatioOnSegment (unixMillisRatio) {
+  unixRatioOnSegment (unixRatio) {
+    const unixMillisRatio = unixRatio.times(new Rat(1000n))
     return this.slope.unixMillisPerAtomicPico.eq(new Rat(0n))
       ? this.start.unixMillisRatio.eq(unixMillisRatio)
       : this.start.unixMillisRatio.le(unixMillisRatio) && (

--- a/src/segment.js
+++ b/src/segment.js
@@ -74,8 +74,7 @@ class Segment {
     }
   }
 
-  atomicPicosToUnixMillis (atomicPicos) {
-    const atomicPicosRatio = new Rat(atomicPicos)
+  atomicPicosRatioToUnixMillis (atomicPicosRatio) {
     const unixMillisRatio = atomicPicosRatio
       .minus(this.start.atomicPicosRatio)
       .times(this.slope.unixMillisPerAtomicPico)

--- a/src/segment.js
+++ b/src/segment.js
@@ -15,13 +15,11 @@ class Segment {
     }
 
     // Start is inclusive.
-    // `atomicPicos` and `unixMillis` are exact.
     this.start = {}
     this.start.atomicRatio = new Rat(start.atomicPicos, 1_000_000_000_000n)
     this.start.unixRatio = new Rat(BigInt(start.unixMillis), 1000n)
 
     // End is exclusive.
-    // `atomicPicos` is exact, no exact integer `unixMillis` is possible in most cases
     this.end = {}
     if (end.atomicPicos === Infinity) {
       this.end.atomicRatio = Infinity

--- a/src/segment.js
+++ b/src/segment.js
@@ -104,8 +104,7 @@ class Segment {
     )
   }
 
-  unixMillisOnSegment (unixMillis) {
-    const unixMillisRatio = new Rat(BigInt(unixMillis))
+  unixMillisRatioOnSegment (unixMillisRatio) {
     return this.slope.unixMillisPerAtomicPico.eq(new Rat(0n))
       ? this.start.unixMillisRatio.eq(unixMillisRatio)
       : this.start.unixMillisRatio.le(unixMillisRatio) && (

--- a/src/segment.js
+++ b/src/segment.js
@@ -74,8 +74,8 @@ class Segment {
     }
   }
 
-  atomicPicosRatioToUnixMillis (atomicPicosRatio) {
-    const unixMillisRatio = atomicPicosRatio
+  atomicRatioToUnixMillis (atomicRatio) {
+    const unixMillisRatio = atomicRatio.times(new Rat(1_000_000_000_000n))
       .minus(this.start.atomicPicosRatio)
       .times(this.slope.unixMillisPerAtomicPico)
       .plus(this.start.unixMillisRatio)

--- a/src/segment.js
+++ b/src/segment.js
@@ -74,8 +74,7 @@ class Segment {
     }
   }
 
-  atomicMillisToUnixMillis (atomicMillis) {
-    const atomicPicos = BigInt(atomicMillis) * picosPerMilli
+  atomicPicosToUnixMillis (atomicPicos) {
     const atomicPicosRatio = new Rat(atomicPicos)
     const unixMillisRatio = atomicPicosRatio
       .minus(this.start.atomicPicosRatio)

--- a/src/segment.js
+++ b/src/segment.js
@@ -1,7 +1,5 @@
 const { Rat } = require('./rat')
 
-const picosPerMilli = 1000n * 1000n * 1000n
-
 // A segment is a closed linear relationship between TAI and Unix time.
 // It should be able to handle arbitrary ratios between the two.
 // For precision, we deal with ratios of BigInts.
@@ -21,7 +19,6 @@ class Segment {
     this.start = {}
     this.start.atomicPicos = start.atomicPicos
     this.start.atomicPicosRatio = new Rat(this.start.atomicPicos)
-    this.start.atomicMillisRatio = this.start.atomicPicosRatio.divide(new Rat(picosPerMilli))
     this.start.unixMillisRatio = new Rat(BigInt(start.unixMillis))
 
     // End is exclusive.
@@ -30,11 +27,9 @@ class Segment {
     this.end.atomicPicos = end.atomicPicos
     if (this.end.atomicPicos === Infinity) {
       this.end.atomicPicosRatio = Infinity
-      this.end.atomicMillisRatio = Infinity
       this.end.unixMillisRatio = Infinity
     } else {
       this.end.atomicPicosRatio = new Rat(this.end.atomicPicos)
-      this.end.atomicMillisRatio = this.end.atomicPicosRatio.divide(new Rat(picosPerMilli))
       this.end.unixMillisRatio = this.end.atomicPicosRatio
         .minus(this.start.atomicPicosRatio)
         .times(this.slope.unixMillisPerAtomicPico)

--- a/src/segment.js
+++ b/src/segment.js
@@ -45,7 +45,7 @@ class Segment {
     }
   }
 
-  unixRatioToAtomicMillisRange (unixRatio) {
+  unixRatioToAtomicMillisRatioRange (unixRatio) {
     const unixMillisRatio = unixRatio.times(new Rat(1000n))
     if (this.slope.unixMillisPerAtomicPico.eq(new Rat(0n))) {
       if (!unixMillisRatio.eq(this.start.unixMillisRatio)) {
@@ -53,8 +53,8 @@ class Segment {
       }
 
       return {
-        start: this.start.atomicMillis,
-        end: this.end.atomicMillis,
+        start: this.start.atomicMillisRatio,
+        end: this.end.atomicMillisRatio,
         closed: false
       }
     }
@@ -64,11 +64,10 @@ class Segment {
       .divide(this.slope.unixMillisPerAtomicPico)
       .plus(this.start.atomicPicosRatio)
     const atomicMillisRatio = atomicPicosRatio.divide(new Rat(picosPerMilli))
-    const atomicMillis = Number(atomicMillisRatio.trunc())
 
     return {
-      start: atomicMillis,
-      end: atomicMillis,
+      start: atomicMillisRatio,
+      end: atomicMillisRatio,
       closed: true
     }
   }

--- a/src/segment.spec.js
+++ b/src/segment.spec.js
@@ -37,7 +37,7 @@ describe('Segment', () => {
       expect(segment.unixRatioOnSegment(new Rat(0n))).toBe(true)
       expect(segment.unixMillisToAtomicMillisRange(0))
         .toEqual({ start: 0, end: 0, closed: true })
-      expect(segment.atomicPicosOnSegment(0n)).toBe(true)
+      expect(segment.atomicPicosRatioOnSegment(new Rat(0n))).toBe(true)
       expect(segment.atomicMillisToUnixMillis(0)).toBe(0)
     })
 
@@ -49,7 +49,7 @@ describe('Segment', () => {
           end: Date.UTC(2021, MAY, 16, 12, 11, 10, 9),
           closed: true
         })
-     expect(segment.atomicPicosOnSegment(BigInt(Date.UTC(2021, MAY, 16, 12, 11, 10, 9)) * picosPerMilli)).toBe(true)
+     expect(segment.atomicPicosRatioOnSegment(new Rat(BigInt(Date.UTC(2021, MAY, 16, 12, 11, 10, 9)) * picosPerMilli))).toBe(true)
       expect(segment.atomicMillisToUnixMillis(Date.UTC(2021, MAY, 16, 12, 11, 10, 9)))
         .toBe(Date.UTC(2021, MAY, 16, 12, 11, 10, 9))
     })
@@ -58,7 +58,7 @@ describe('Segment', () => {
       expect(segment.unixRatioOnSegment(new Rat(-1n, 1000n))).toBe(false)
       expect(segment.unixMillisToAtomicMillisRange(-1))
         .toEqual({ start: -1, end: -1, closed: true })
-      expect(segment.atomicPicosOnSegment(-1_000_000_000n)).toBe(false)
+      expect(segment.atomicPicosRatioOnSegment(new Rat(-1_000_000_000n))).toBe(false)
       expect(segment.atomicMillisToUnixMillis(-1)).toBe(-1)
     })
   })
@@ -75,7 +75,7 @@ describe('Segment', () => {
       expect(segment.unixRatioOnSegment(new Rat(0n))).toBe(true)
       expect(segment.unixMillisToAtomicMillisRange(0))
         .toEqual({ start: 0, end: 0, closed: true })
-      expect(segment.atomicPicosOnSegment(0n)).toBe(true)
+      expect(segment.atomicPicosRatioOnSegment(new Rat(0n))).toBe(true)
       expect(segment.atomicMillisToUnixMillis(0)).toBe(0)
     })
 
@@ -83,7 +83,7 @@ describe('Segment', () => {
       expect(segment.unixRatioOnSegment(new Rat(501n, 1000n))).toBe(true)
       expect(segment.unixMillisToAtomicMillisRange(501))
         .toEqual({ start: 1002, end: 1002, closed: true })
-      expect(segment.atomicPicosOnSegment(1_002_000_000_000n)).toBe(true)
+      expect(segment.atomicPicosRatioOnSegment(new Rat(1_002_000_000_000n))).toBe(true)
       expect(segment.atomicMillisToUnixMillis(1002)).toBe(501)
     })
 
@@ -92,9 +92,9 @@ describe('Segment', () => {
       expect(segment.unixMillisToAtomicMillisRange(999))
         .toEqual({ start: 1998, end: 1998, closed: true })
 
-      expect(segment.atomicPicosOnSegment(1_998_000_000_000n)).toBe(true)
+      expect(segment.atomicPicosRatioOnSegment(new Rat(1_998_000_000_000n))).toBe(true)
       expect(segment.atomicMillisToUnixMillis(1998)).toBe(999)
-      expect(segment.atomicPicosOnSegment(1_999_000_000_000n)).toBe(true)
+      expect(segment.atomicPicosRatioOnSegment(new Rat(1_999_000_000_000n))).toBe(true)
       expect(segment.atomicMillisToUnixMillis(1999)).toBe(999) // truncated
     })
 
@@ -102,7 +102,7 @@ describe('Segment', () => {
       expect(segment.unixRatioOnSegment(new Rat(1n))).toBe(false)
       expect(segment.unixMillisToAtomicMillisRange(1000))
         .toEqual({ start: 2000, end: 2000, closed: true })
-      expect(segment.atomicPicosOnSegment(2_000_000_000_000n)).toBe(false)
+      expect(segment.atomicPicosRatioOnSegment(new Rat(2_000_000_000_000n))).toBe(false)
       expect(segment.atomicMillisToUnixMillis(2000)).toBe(1000)
     })
   })
@@ -119,14 +119,14 @@ describe('Segment', () => {
       expect(segment.unixRatioOnSegment(new Rat(0n))).toBe(true)
       expect(segment.unixMillisToAtomicMillisRange(0))
         .toEqual({ start: 0, end: 2000, closed: false })
-      expect(segment.atomicPicosOnSegment(0n)).toBe(true)
+      expect(segment.atomicPicosRatioOnSegment(new Rat(0n))).toBe(true)
       expect(segment.atomicMillisToUnixMillis(0)).toBe(0)
     })
 
     it('later in TAI', () => {
-      expect(segment.atomicPicosOnSegment(1_999_000_000_000n)).toBe(true)
+      expect(segment.atomicPicosRatioOnSegment(new Rat(1_999_000_000_000n))).toBe(true)
       expect(segment.atomicMillisToUnixMillis(1999)).toBe(0)
-      expect(segment.atomicPicosOnSegment(2_000_000_000_000n)).toBe(false)
+      expect(segment.atomicPicosRatioOnSegment(new Rat(2_000_000_000_000n))).toBe(false)
       expect(segment.atomicMillisToUnixMillis(2000)).toBe(0)
     })
 

--- a/src/segment.spec.js
+++ b/src/segment.spec.js
@@ -4,6 +4,7 @@ const { Segment } = require('./segment')
 const { Rat } = require('./rat')
 
 const MAY = 4
+const picosPerMilli = 1000n * 1000n * 1000n
 
 describe('Segment', () => {
   it('disallows rays which run backwards', () => {
@@ -36,7 +37,7 @@ describe('Segment', () => {
       expect(segment.unixRatioOnSegment(new Rat(0n))).toBe(true)
       expect(segment.unixMillisToAtomicMillisRange(0))
         .toEqual({ start: 0, end: 0, closed: true })
-      expect(segment.atomicMillisOnSegment(0)).toBe(true)
+      expect(segment.atomicPicosOnSegment(0n)).toBe(true)
       expect(segment.atomicMillisToUnixMillis(0)).toBe(0)
     })
 
@@ -48,7 +49,7 @@ describe('Segment', () => {
           end: Date.UTC(2021, MAY, 16, 12, 11, 10, 9),
           closed: true
         })
-      expect(segment.atomicMillisOnSegment(Date.UTC(2021, MAY, 16, 12, 11, 10, 9))).toBe(true)
+     expect(segment.atomicPicosOnSegment(BigInt(Date.UTC(2021, MAY, 16, 12, 11, 10, 9)) * picosPerMilli)).toBe(true)
       expect(segment.atomicMillisToUnixMillis(Date.UTC(2021, MAY, 16, 12, 11, 10, 9)))
         .toBe(Date.UTC(2021, MAY, 16, 12, 11, 10, 9))
     })
@@ -57,7 +58,7 @@ describe('Segment', () => {
       expect(segment.unixRatioOnSegment(new Rat(-1n, 1000n))).toBe(false)
       expect(segment.unixMillisToAtomicMillisRange(-1))
         .toEqual({ start: -1, end: -1, closed: true })
-      expect(segment.atomicMillisOnSegment(-1)).toBe(false)
+      expect(segment.atomicPicosOnSegment(-1_000_000_000n)).toBe(false)
       expect(segment.atomicMillisToUnixMillis(-1)).toBe(-1)
     })
   })
@@ -74,7 +75,7 @@ describe('Segment', () => {
       expect(segment.unixRatioOnSegment(new Rat(0n))).toBe(true)
       expect(segment.unixMillisToAtomicMillisRange(0))
         .toEqual({ start: 0, end: 0, closed: true })
-      expect(segment.atomicMillisOnSegment(0)).toBe(true)
+      expect(segment.atomicPicosOnSegment(0n)).toBe(true)
       expect(segment.atomicMillisToUnixMillis(0)).toBe(0)
     })
 
@@ -82,7 +83,7 @@ describe('Segment', () => {
       expect(segment.unixRatioOnSegment(new Rat(501n, 1000n))).toBe(true)
       expect(segment.unixMillisToAtomicMillisRange(501))
         .toEqual({ start: 1002, end: 1002, closed: true })
-      expect(segment.atomicMillisOnSegment(1002)).toBe(true)
+      expect(segment.atomicPicosOnSegment(1_002_000_000_000n)).toBe(true)
       expect(segment.atomicMillisToUnixMillis(1002)).toBe(501)
     })
 
@@ -91,9 +92,9 @@ describe('Segment', () => {
       expect(segment.unixMillisToAtomicMillisRange(999))
         .toEqual({ start: 1998, end: 1998, closed: true })
 
-      expect(segment.atomicMillisOnSegment(1998)).toBe(true)
+      expect(segment.atomicPicosOnSegment(1_998_000_000_000n)).toBe(true)
       expect(segment.atomicMillisToUnixMillis(1998)).toBe(999)
-      expect(segment.atomicMillisOnSegment(1999)).toBe(true)
+      expect(segment.atomicPicosOnSegment(1_999_000_000_000n)).toBe(true)
       expect(segment.atomicMillisToUnixMillis(1999)).toBe(999) // truncated
     })
 
@@ -101,7 +102,7 @@ describe('Segment', () => {
       expect(segment.unixRatioOnSegment(new Rat(1n))).toBe(false)
       expect(segment.unixMillisToAtomicMillisRange(1000))
         .toEqual({ start: 2000, end: 2000, closed: true })
-      expect(segment.atomicMillisOnSegment(2000)).toBe(false)
+      expect(segment.atomicPicosOnSegment(2_000_000_000_000n)).toBe(false)
       expect(segment.atomicMillisToUnixMillis(2000)).toBe(1000)
     })
   })
@@ -118,14 +119,14 @@ describe('Segment', () => {
       expect(segment.unixRatioOnSegment(new Rat(0n))).toBe(true)
       expect(segment.unixMillisToAtomicMillisRange(0))
         .toEqual({ start: 0, end: 2000, closed: false })
-      expect(segment.atomicMillisOnSegment(0)).toBe(true)
+      expect(segment.atomicPicosOnSegment(0n)).toBe(true)
       expect(segment.atomicMillisToUnixMillis(0)).toBe(0)
     })
 
     it('later in TAI', () => {
-      expect(segment.atomicMillisOnSegment(1999)).toBe(true)
+      expect(segment.atomicPicosOnSegment(1_999_000_000_000n)).toBe(true)
       expect(segment.atomicMillisToUnixMillis(1999)).toBe(0)
-      expect(segment.atomicMillisOnSegment(2000)).toBe(false)
+      expect(segment.atomicPicosOnSegment(2_000_000_000_000n)).toBe(false)
       expect(segment.atomicMillisToUnixMillis(2000)).toBe(0)
     })
 

--- a/src/segment.spec.js
+++ b/src/segment.spec.js
@@ -34,7 +34,7 @@ describe('Segment', () => {
 
     it('zero point', () => {
       expect(segment.unixRatioOnSegment(new Rat(0n))).toBe(true)
-      expect(segment.unixRatioToAtomicMillisRatioRange(new Rat(0n)))
+      expect(segment.unixRatioToAtomicPicosRatioRange(new Rat(0n)))
         .toEqual({ start: new Rat(0n), end: new Rat(0n), closed: true })
       expect(segment.atomicRatioOnSegment(new Rat(0n))).toBe(true)
       expect(segment.atomicRatioToUnixRatio(new Rat(0n))).toEqual(new Rat(0n))
@@ -42,10 +42,10 @@ describe('Segment', () => {
 
     it('modern day', () => {
       expect(segment.unixRatioOnSegment(new Rat(BigInt(Date.UTC(2021, MAY, 16, 12, 11, 10, 9)), 1000n))).toBe(true)
-      expect(segment.unixRatioToAtomicMillisRatioRange(new Rat(BigInt(Date.UTC(2021, MAY, 16, 12, 11, 10, 9)), 1000n)))
+      expect(segment.unixRatioToAtomicPicosRatioRange(new Rat(BigInt(Date.UTC(2021, MAY, 16, 12, 11, 10, 9)), 1000n)))
         .toEqual({
-          start: new Rat(BigInt(Date.UTC(2021, MAY, 16, 12, 11, 10, 9))),
-          end: new Rat(BigInt(Date.UTC(2021, MAY, 16, 12, 11, 10, 9))),
+          start: new Rat(BigInt(Date.UTC(2021, MAY, 16, 12, 11, 10, 9)) * 1_000_000_000n),
+          end: new Rat(BigInt(Date.UTC(2021, MAY, 16, 12, 11, 10, 9)) * 1_000_000_000n),
           closed: true
         })
       expect(segment.atomicRatioOnSegment(new Rat(BigInt(Date.UTC(2021, MAY, 16, 12, 11, 10, 9)), 1000n))).toBe(true)
@@ -55,8 +55,8 @@ describe('Segment', () => {
 
     it('before start point', () => {
       expect(segment.unixRatioOnSegment(new Rat(-1n, 1000n))).toBe(false)
-      expect(segment.unixRatioToAtomicMillisRatioRange(new Rat(-1n, 1000n)))
-        .toEqual({ start: new Rat(-1n), end: new Rat(-1n), closed: true })
+      expect(segment.unixRatioToAtomicPicosRatioRange(new Rat(-1n, 1000n)))
+        .toEqual({ start: new Rat(-1_000_000_000n), end: new Rat(-1000_000_000n), closed: true })
       expect(segment.atomicRatioOnSegment(new Rat(-1n, 1000n))).toBe(false)
       expect(segment.atomicRatioToUnixRatio(new Rat(-1n, 1000n))).toEqual(new Rat(-1n, 1000n))
     })
@@ -72,7 +72,7 @@ describe('Segment', () => {
 
     it('zero point', () => {
       expect(segment.unixRatioOnSegment(new Rat(0n))).toBe(true)
-      expect(segment.unixRatioToAtomicMillisRatioRange(new Rat(0n)))
+      expect(segment.unixRatioToAtomicPicosRatioRange(new Rat(0n)))
         .toEqual({ start: new Rat(0n), end: new Rat(0n), closed: true })
       expect(segment.atomicRatioOnSegment(new Rat(0n))).toBe(true)
       expect(segment.atomicRatioToUnixRatio(new Rat(0n))).toEqual(new Rat(0n))
@@ -80,16 +80,16 @@ describe('Segment', () => {
 
     it('a little later', () => {
       expect(segment.unixRatioOnSegment(new Rat(501n, 1000n))).toBe(true)
-      expect(segment.unixRatioToAtomicMillisRatioRange(new Rat(501n, 1000n)))
-        .toEqual({ start: new Rat(1002n), end: new Rat(1002n), closed: true })
+      expect(segment.unixRatioToAtomicPicosRatioRange(new Rat(501n, 1000n)))
+        .toEqual({ start: new Rat(1_002_000_000_000n), end: new Rat(1_002_000_000_000n), closed: true })
       expect(segment.atomicRatioOnSegment(new Rat(1_002n, 1000n))).toBe(true)
       expect(segment.atomicRatioToUnixRatio(new Rat(1_002n, 1000n))).toEqual(new Rat(501n, 1000n))
     })
 
     it('right before end point', () => {
       expect(segment.unixRatioOnSegment(new Rat(999n, 1000n))).toBe(true)
-      expect(segment.unixRatioToAtomicMillisRatioRange(new Rat(999n, 1000n)))
-        .toEqual({ start: new Rat(1998n), end: new Rat(1998n), closed: true })
+      expect(segment.unixRatioToAtomicPicosRatioRange(new Rat(999n, 1000n)))
+        .toEqual({ start: new Rat(1_998_000_000_000n), end: new Rat(1_998_000_000_000n), closed: true })
 
       expect(segment.atomicRatioOnSegment(new Rat(1_998n, 1000n))).toBe(true)
       expect(segment.atomicRatioToUnixRatio(new Rat(1_998n, 1000n))).toEqual(new Rat(999n, 1000n))
@@ -99,8 +99,8 @@ describe('Segment', () => {
 
     it('end point', () => {
       expect(segment.unixRatioOnSegment(new Rat(1n))).toBe(false)
-      expect(segment.unixRatioToAtomicMillisRatioRange(new Rat(1n)))
-        .toEqual({ start: new Rat(2000n), end: new Rat(2000n), closed: true })
+      expect(segment.unixRatioToAtomicPicosRatioRange(new Rat(1n)))
+        .toEqual({ start: new Rat(2_000_000_000_000n), end: new Rat(2_000_000_000_000n), closed: true })
       expect(segment.atomicRatioOnSegment(new Rat(2n))).toBe(false)
       expect(segment.atomicRatioToUnixRatio(new Rat(2n))).toEqual(new Rat(1n))
     })
@@ -116,8 +116,8 @@ describe('Segment', () => {
 
     it('zero point', () => {
       expect(segment.unixRatioOnSegment(new Rat(0n))).toBe(true)
-      expect(segment.unixRatioToAtomicMillisRatioRange(new Rat(0n)))
-        .toEqual({ start: new Rat(0n), end: new Rat(2000n), closed: false })
+      expect(segment.unixRatioToAtomicPicosRatioRange(new Rat(0n)))
+        .toEqual({ start: new Rat(0n), end: new Rat(2_000_000_000_000n), closed: false })
       expect(segment.atomicRatioOnSegment(new Rat(0n))).toBe(true)
       expect(segment.atomicRatioToUnixRatio(new Rat(0n))).toEqual(new Rat(0n))
     })
@@ -131,7 +131,7 @@ describe('Segment', () => {
 
     it('later in Unix time', () => {
       expect(segment.unixRatioOnSegment(new Rat(1n))).toBe(false)
-      expect(() => segment.unixRatioToAtomicMillisRatioRange(new Rat(-1n, 1000n)))
+      expect(() => segment.unixRatioToAtomicPicosRatioRange(new Rat(-1n, 1000n)))
         .toThrowError('This Unix time never happened')
     })
   })

--- a/src/segment.spec.js
+++ b/src/segment.spec.js
@@ -38,7 +38,7 @@ describe('Segment', () => {
       expect(segment.unixMillisToAtomicMillisRange(0))
         .toEqual({ start: 0, end: 0, closed: true })
       expect(segment.atomicRatioOnSegment(new Rat(0n))).toBe(true)
-      expect(segment.atomicMillisToUnixMillis(0)).toBe(0)
+      expect(segment.atomicPicosToUnixMillis(0n)).toBe(0)
     })
 
     it('modern day', () => {
@@ -49,8 +49,8 @@ describe('Segment', () => {
           end: Date.UTC(2021, MAY, 16, 12, 11, 10, 9),
           closed: true
         })
-     expect(segment.atomicRatioOnSegment(new Rat(BigInt(Date.UTC(2021, MAY, 16, 12, 11, 10, 9)), 1000n))).toBe(true)
-      expect(segment.atomicMillisToUnixMillis(Date.UTC(2021, MAY, 16, 12, 11, 10, 9)))
+      expect(segment.atomicRatioOnSegment(new Rat(BigInt(Date.UTC(2021, MAY, 16, 12, 11, 10, 9)), 1000n))).toBe(true)
+      expect(segment.atomicPicosToUnixMillis(BigInt(Date.UTC(2021, MAY, 16, 12, 11, 10, 9)) * picosPerMilli))
         .toBe(Date.UTC(2021, MAY, 16, 12, 11, 10, 9))
     })
 
@@ -59,7 +59,7 @@ describe('Segment', () => {
       expect(segment.unixMillisToAtomicMillisRange(-1))
         .toEqual({ start: -1, end: -1, closed: true })
       expect(segment.atomicRatioOnSegment(new Rat(-1n, 1000n))).toBe(false)
-      expect(segment.atomicMillisToUnixMillis(-1)).toBe(-1)
+      expect(segment.atomicPicosToUnixMillis(-1_000_000_000n)).toBe(-1)
     })
   })
 
@@ -76,7 +76,7 @@ describe('Segment', () => {
       expect(segment.unixMillisToAtomicMillisRange(0))
         .toEqual({ start: 0, end: 0, closed: true })
       expect(segment.atomicRatioOnSegment(new Rat(0n))).toBe(true)
-      expect(segment.atomicMillisToUnixMillis(0)).toBe(0)
+      expect(segment.atomicPicosToUnixMillis(0n)).toBe(0)
     })
 
     it('a little later', () => {
@@ -84,7 +84,7 @@ describe('Segment', () => {
       expect(segment.unixMillisToAtomicMillisRange(501))
         .toEqual({ start: 1002, end: 1002, closed: true })
       expect(segment.atomicRatioOnSegment(new Rat(1_002n, 1000n))).toBe(true)
-      expect(segment.atomicMillisToUnixMillis(1002)).toBe(501)
+      expect(segment.atomicPicosToUnixMillis(1_002_000_000_000n)).toBe(501)
     })
 
     it('right before end point', () => {
@@ -93,9 +93,9 @@ describe('Segment', () => {
         .toEqual({ start: 1998, end: 1998, closed: true })
 
       expect(segment.atomicRatioOnSegment(new Rat(1_998n, 1000n))).toBe(true)
-      expect(segment.atomicMillisToUnixMillis(1998)).toBe(999)
+      expect(segment.atomicPicosToUnixMillis(1_998_000_000_000n)).toBe(999)
       expect(segment.atomicRatioOnSegment(new Rat(1_999n, 1000n))).toBe(true)
-      expect(segment.atomicMillisToUnixMillis(1999)).toBe(999) // truncated
+      expect(segment.atomicPicosToUnixMillis(1_999_000_000_000n)).toBe(999) // truncated
     })
 
     it('end point', () => {
@@ -103,7 +103,7 @@ describe('Segment', () => {
       expect(segment.unixMillisToAtomicMillisRange(1000))
         .toEqual({ start: 2000, end: 2000, closed: true })
       expect(segment.atomicRatioOnSegment(new Rat(2n))).toBe(false)
-      expect(segment.atomicMillisToUnixMillis(2000)).toBe(1000)
+      expect(segment.atomicPicosToUnixMillis(2_000_000_000_000n)).toBe(1000)
     })
   })
 
@@ -120,14 +120,14 @@ describe('Segment', () => {
       expect(segment.unixMillisToAtomicMillisRange(0))
         .toEqual({ start: 0, end: 2000, closed: false })
       expect(segment.atomicRatioOnSegment(new Rat(0n))).toBe(true)
-      expect(segment.atomicMillisToUnixMillis(0)).toBe(0)
+      expect(segment.atomicPicosToUnixMillis(0n)).toBe(0)
     })
 
     it('later in TAI', () => {
       expect(segment.atomicRatioOnSegment(new Rat(1_999n, 1000n))).toBe(true)
-      expect(segment.atomicMillisToUnixMillis(1999)).toBe(0)
+      expect(segment.atomicPicosToUnixMillis(1_999_000_000_000n)).toBe(0)
       expect(segment.atomicRatioOnSegment(new Rat(2_000n, 1000n))).toBe(false)
-      expect(segment.atomicMillisToUnixMillis(2000)).toBe(0)
+      expect(segment.atomicPicosToUnixMillis(2_000_000_000_000n)).toBe(0)
     })
 
     it('later in Unix time', () => {

--- a/src/segment.spec.js
+++ b/src/segment.spec.js
@@ -38,7 +38,7 @@ describe('Segment', () => {
       expect(segment.unixMillisToAtomicMillisRange(0))
         .toEqual({ start: 0, end: 0, closed: true })
       expect(segment.atomicRatioOnSegment(new Rat(0n))).toBe(true)
-      expect(segment.atomicPicosRatioToUnixMillis(new Rat(0n))).toBe(0)
+      expect(segment.atomicRatioToUnixMillis(new Rat(0n))).toBe(0)
     })
 
     it('modern day', () => {
@@ -50,7 +50,7 @@ describe('Segment', () => {
           closed: true
         })
       expect(segment.atomicRatioOnSegment(new Rat(BigInt(Date.UTC(2021, MAY, 16, 12, 11, 10, 9)), 1000n))).toBe(true)
-      expect(segment.atomicPicosRatioToUnixMillis(new Rat(BigInt(Date.UTC(2021, MAY, 16, 12, 11, 10, 9)) * picosPerMilli)))
+      expect(segment.atomicRatioToUnixMillis(new Rat(BigInt(Date.UTC(2021, MAY, 16, 12, 11, 10, 9)), 1000n)))
         .toBe(Date.UTC(2021, MAY, 16, 12, 11, 10, 9))
     })
 
@@ -59,7 +59,7 @@ describe('Segment', () => {
       expect(segment.unixMillisToAtomicMillisRange(-1))
         .toEqual({ start: -1, end: -1, closed: true })
       expect(segment.atomicRatioOnSegment(new Rat(-1n, 1000n))).toBe(false)
-      expect(segment.atomicPicosRatioToUnixMillis(new Rat(-1_000_000_000n))).toBe(-1)
+      expect(segment.atomicRatioToUnixMillis(new Rat(-1n, 1000n))).toBe(-1)
     })
   })
 
@@ -76,7 +76,7 @@ describe('Segment', () => {
       expect(segment.unixMillisToAtomicMillisRange(0))
         .toEqual({ start: 0, end: 0, closed: true })
       expect(segment.atomicRatioOnSegment(new Rat(0n))).toBe(true)
-      expect(segment.atomicPicosRatioToUnixMillis(new Rat(0n))).toBe(0)
+      expect(segment.atomicRatioToUnixMillis(new Rat(0n))).toBe(0)
     })
 
     it('a little later', () => {
@@ -84,7 +84,7 @@ describe('Segment', () => {
       expect(segment.unixMillisToAtomicMillisRange(501))
         .toEqual({ start: 1002, end: 1002, closed: true })
       expect(segment.atomicRatioOnSegment(new Rat(1_002n, 1000n))).toBe(true)
-      expect(segment.atomicPicosRatioToUnixMillis(new Rat(1_002_000_000_000n))).toBe(501)
+      expect(segment.atomicRatioToUnixMillis(new Rat(1_002n, 1000n))).toBe(501)
     })
 
     it('right before end point', () => {
@@ -93,9 +93,9 @@ describe('Segment', () => {
         .toEqual({ start: 1998, end: 1998, closed: true })
 
       expect(segment.atomicRatioOnSegment(new Rat(1_998n, 1000n))).toBe(true)
-      expect(segment.atomicPicosRatioToUnixMillis(new Rat(1_998_000_000_000n))).toBe(999)
+      expect(segment.atomicRatioToUnixMillis(new Rat(1_998n, 1000n))).toBe(999)
       expect(segment.atomicRatioOnSegment(new Rat(1_999n, 1000n))).toBe(true)
-      expect(segment.atomicPicosRatioToUnixMillis(new Rat(1_999_000_000_000n))).toBe(999) // truncated
+      expect(segment.atomicRatioToUnixMillis(new Rat(1_999n, 1000n))).toBe(999) // truncated
     })
 
     it('end point', () => {
@@ -103,7 +103,7 @@ describe('Segment', () => {
       expect(segment.unixMillisToAtomicMillisRange(1000))
         .toEqual({ start: 2000, end: 2000, closed: true })
       expect(segment.atomicRatioOnSegment(new Rat(2n))).toBe(false)
-      expect(segment.atomicPicosRatioToUnixMillis(new Rat(2_000_000_000_000n))).toBe(1000)
+      expect(segment.atomicRatioToUnixMillis(new Rat(2n))).toBe(1000)
     })
   })
 
@@ -120,14 +120,14 @@ describe('Segment', () => {
       expect(segment.unixMillisToAtomicMillisRange(0))
         .toEqual({ start: 0, end: 2000, closed: false })
       expect(segment.atomicRatioOnSegment(new Rat(0n))).toBe(true)
-      expect(segment.atomicPicosRatioToUnixMillis(new Rat(0n))).toBe(0)
+      expect(segment.atomicRatioToUnixMillis(new Rat(0n))).toBe(0)
     })
 
     it('later in TAI', () => {
       expect(segment.atomicRatioOnSegment(new Rat(1_999n, 1000n))).toBe(true)
-      expect(segment.atomicPicosRatioToUnixMillis(new Rat(1_999_000_000_000n))).toBe(0)
+      expect(segment.atomicRatioToUnixMillis(new Rat(1_999n, 1000n))).toBe(0)
       expect(segment.atomicRatioOnSegment(new Rat(2_000n, 1000n))).toBe(false)
-      expect(segment.atomicPicosRatioToUnixMillis(new Rat(2_000_000_000_000n))).toBe(0)
+      expect(segment.atomicRatioToUnixMillis(new Rat(2_000n, 1000n))).toBe(0)
     })
 
     it('later in Unix time', () => {

--- a/src/segment.spec.js
+++ b/src/segment.spec.js
@@ -38,7 +38,7 @@ describe('Segment', () => {
       expect(segment.unixMillisToAtomicMillisRange(0))
         .toEqual({ start: 0, end: 0, closed: true })
       expect(segment.atomicRatioOnSegment(new Rat(0n))).toBe(true)
-      expect(segment.atomicPicosToUnixMillis(0n)).toBe(0)
+      expect(segment.atomicPicosRatioToUnixMillis(new Rat(0n))).toBe(0)
     })
 
     it('modern day', () => {
@@ -50,7 +50,7 @@ describe('Segment', () => {
           closed: true
         })
       expect(segment.atomicRatioOnSegment(new Rat(BigInt(Date.UTC(2021, MAY, 16, 12, 11, 10, 9)), 1000n))).toBe(true)
-      expect(segment.atomicPicosToUnixMillis(BigInt(Date.UTC(2021, MAY, 16, 12, 11, 10, 9)) * picosPerMilli))
+      expect(segment.atomicPicosRatioToUnixMillis(new Rat(BigInt(Date.UTC(2021, MAY, 16, 12, 11, 10, 9)) * picosPerMilli)))
         .toBe(Date.UTC(2021, MAY, 16, 12, 11, 10, 9))
     })
 
@@ -59,7 +59,7 @@ describe('Segment', () => {
       expect(segment.unixMillisToAtomicMillisRange(-1))
         .toEqual({ start: -1, end: -1, closed: true })
       expect(segment.atomicRatioOnSegment(new Rat(-1n, 1000n))).toBe(false)
-      expect(segment.atomicPicosToUnixMillis(-1_000_000_000n)).toBe(-1)
+      expect(segment.atomicPicosRatioToUnixMillis(new Rat(-1_000_000_000n))).toBe(-1)
     })
   })
 
@@ -76,7 +76,7 @@ describe('Segment', () => {
       expect(segment.unixMillisToAtomicMillisRange(0))
         .toEqual({ start: 0, end: 0, closed: true })
       expect(segment.atomicRatioOnSegment(new Rat(0n))).toBe(true)
-      expect(segment.atomicPicosToUnixMillis(0n)).toBe(0)
+      expect(segment.atomicPicosRatioToUnixMillis(new Rat(0n))).toBe(0)
     })
 
     it('a little later', () => {
@@ -84,7 +84,7 @@ describe('Segment', () => {
       expect(segment.unixMillisToAtomicMillisRange(501))
         .toEqual({ start: 1002, end: 1002, closed: true })
       expect(segment.atomicRatioOnSegment(new Rat(1_002n, 1000n))).toBe(true)
-      expect(segment.atomicPicosToUnixMillis(1_002_000_000_000n)).toBe(501)
+      expect(segment.atomicPicosRatioToUnixMillis(new Rat(1_002_000_000_000n))).toBe(501)
     })
 
     it('right before end point', () => {
@@ -93,9 +93,9 @@ describe('Segment', () => {
         .toEqual({ start: 1998, end: 1998, closed: true })
 
       expect(segment.atomicRatioOnSegment(new Rat(1_998n, 1000n))).toBe(true)
-      expect(segment.atomicPicosToUnixMillis(1_998_000_000_000n)).toBe(999)
+      expect(segment.atomicPicosRatioToUnixMillis(new Rat(1_998_000_000_000n))).toBe(999)
       expect(segment.atomicRatioOnSegment(new Rat(1_999n, 1000n))).toBe(true)
-      expect(segment.atomicPicosToUnixMillis(1_999_000_000_000n)).toBe(999) // truncated
+      expect(segment.atomicPicosRatioToUnixMillis(new Rat(1_999_000_000_000n))).toBe(999) // truncated
     })
 
     it('end point', () => {
@@ -103,7 +103,7 @@ describe('Segment', () => {
       expect(segment.unixMillisToAtomicMillisRange(1000))
         .toEqual({ start: 2000, end: 2000, closed: true })
       expect(segment.atomicRatioOnSegment(new Rat(2n))).toBe(false)
-      expect(segment.atomicPicosToUnixMillis(2_000_000_000_000n)).toBe(1000)
+      expect(segment.atomicPicosRatioToUnixMillis(new Rat(2_000_000_000_000n))).toBe(1000)
     })
   })
 
@@ -120,14 +120,14 @@ describe('Segment', () => {
       expect(segment.unixMillisToAtomicMillisRange(0))
         .toEqual({ start: 0, end: 2000, closed: false })
       expect(segment.atomicRatioOnSegment(new Rat(0n))).toBe(true)
-      expect(segment.atomicPicosToUnixMillis(0n)).toBe(0)
+      expect(segment.atomicPicosRatioToUnixMillis(new Rat(0n))).toBe(0)
     })
 
     it('later in TAI', () => {
       expect(segment.atomicRatioOnSegment(new Rat(1_999n, 1000n))).toBe(true)
-      expect(segment.atomicPicosToUnixMillis(1_999_000_000_000n)).toBe(0)
+      expect(segment.atomicPicosRatioToUnixMillis(new Rat(1_999_000_000_000n))).toBe(0)
       expect(segment.atomicRatioOnSegment(new Rat(2_000n, 1000n))).toBe(false)
-      expect(segment.atomicPicosToUnixMillis(2_000_000_000_000n)).toBe(0)
+      expect(segment.atomicPicosRatioToUnixMillis(new Rat(2_000_000_000_000n))).toBe(0)
     })
 
     it('later in Unix time', () => {

--- a/src/segment.spec.js
+++ b/src/segment.spec.js
@@ -33,7 +33,7 @@ describe('Segment', () => {
     )
 
     it('zero point', () => {
-      expect(segment.unixMillisRatioOnSegment(new Rat(0n))).toBe(true)
+      expect(segment.unixRatioOnSegment(new Rat(0n))).toBe(true)
       expect(segment.unixMillisToAtomicMillisRange(0))
         .toEqual({ start: 0, end: 0, closed: true })
       expect(segment.atomicMillisOnSegment(0)).toBe(true)
@@ -41,7 +41,7 @@ describe('Segment', () => {
     })
 
     it('modern day', () => {
-      expect(segment.unixMillisRatioOnSegment(new Rat(BigInt(Date.UTC(2021, MAY, 16, 12, 11, 10, 9))))).toBe(true)
+      expect(segment.unixRatioOnSegment(new Rat(BigInt(Date.UTC(2021, MAY, 16, 12, 11, 10, 9)), 1000n))).toBe(true)
       expect(segment.unixMillisToAtomicMillisRange(Date.UTC(2021, MAY, 16, 12, 11, 10, 9)))
         .toEqual({
           start: Date.UTC(2021, MAY, 16, 12, 11, 10, 9),
@@ -54,7 +54,7 @@ describe('Segment', () => {
     })
 
     it('before start point', () => {
-      expect(segment.unixMillisRatioOnSegment(new Rat(-1n))).toBe(false)
+      expect(segment.unixRatioOnSegment(new Rat(-1n, 1000n))).toBe(false)
       expect(segment.unixMillisToAtomicMillisRange(-1))
         .toEqual({ start: -1, end: -1, closed: true })
       expect(segment.atomicMillisOnSegment(-1)).toBe(false)
@@ -71,7 +71,7 @@ describe('Segment', () => {
     )
 
     it('zero point', () => {
-      expect(segment.unixMillisRatioOnSegment(new Rat(0n))).toBe(true)
+      expect(segment.unixRatioOnSegment(new Rat(0n))).toBe(true)
       expect(segment.unixMillisToAtomicMillisRange(0))
         .toEqual({ start: 0, end: 0, closed: true })
       expect(segment.atomicMillisOnSegment(0)).toBe(true)
@@ -79,7 +79,7 @@ describe('Segment', () => {
     })
 
     it('a little later', () => {
-      expect(segment.unixMillisRatioOnSegment(new Rat(501n))).toBe(true)
+      expect(segment.unixRatioOnSegment(new Rat(501n, 1000n))).toBe(true)
       expect(segment.unixMillisToAtomicMillisRange(501))
         .toEqual({ start: 1002, end: 1002, closed: true })
       expect(segment.atomicMillisOnSegment(1002)).toBe(true)
@@ -87,7 +87,7 @@ describe('Segment', () => {
     })
 
     it('right before end point', () => {
-      expect(segment.unixMillisRatioOnSegment(new Rat(999n))).toBe(true)
+      expect(segment.unixRatioOnSegment(new Rat(999n, 1000n))).toBe(true)
       expect(segment.unixMillisToAtomicMillisRange(999))
         .toEqual({ start: 1998, end: 1998, closed: true })
 
@@ -98,7 +98,7 @@ describe('Segment', () => {
     })
 
     it('end point', () => {
-      expect(segment.unixMillisRatioOnSegment(new Rat(1000n))).toBe(false)
+      expect(segment.unixRatioOnSegment(new Rat(1n))).toBe(false)
       expect(segment.unixMillisToAtomicMillisRange(1000))
         .toEqual({ start: 2000, end: 2000, closed: true })
       expect(segment.atomicMillisOnSegment(2000)).toBe(false)
@@ -115,7 +115,7 @@ describe('Segment', () => {
     )
 
     it('zero point', () => {
-      expect(segment.unixMillisRatioOnSegment(new Rat(0n))).toBe(true)
+      expect(segment.unixRatioOnSegment(new Rat(0n))).toBe(true)
       expect(segment.unixMillisToAtomicMillisRange(0))
         .toEqual({ start: 0, end: 2000, closed: false })
       expect(segment.atomicMillisOnSegment(0)).toBe(true)
@@ -130,7 +130,7 @@ describe('Segment', () => {
     })
 
     it('later in Unix time', () => {
-      expect(segment.unixMillisRatioOnSegment(new Rat(1n))).toBe(false)
+      expect(segment.unixRatioOnSegment(new Rat(1n))).toBe(false)
       expect(() => segment.unixMillisToAtomicMillisRange(-1))
         .toThrowError('This Unix time never happened')
     })

--- a/src/segment.spec.js
+++ b/src/segment.spec.js
@@ -35,7 +35,7 @@ describe('Segment', () => {
 
     it('zero point', () => {
       expect(segment.unixRatioOnSegment(new Rat(0n))).toBe(true)
-      expect(segment.unixMillisToAtomicMillisRange(0))
+      expect(segment.unixMillisRatioToAtomicMillisRange(new Rat(0n)))
         .toEqual({ start: 0, end: 0, closed: true })
       expect(segment.atomicRatioOnSegment(new Rat(0n))).toBe(true)
       expect(segment.atomicRatioToUnixRatio(new Rat(0n))).toEqual(new Rat(0n))
@@ -43,7 +43,7 @@ describe('Segment', () => {
 
     it('modern day', () => {
       expect(segment.unixRatioOnSegment(new Rat(BigInt(Date.UTC(2021, MAY, 16, 12, 11, 10, 9)), 1000n))).toBe(true)
-      expect(segment.unixMillisToAtomicMillisRange(Date.UTC(2021, MAY, 16, 12, 11, 10, 9)))
+      expect(segment.unixMillisRatioToAtomicMillisRange(new Rat(BigInt(Date.UTC(2021, MAY, 16, 12, 11, 10, 9)))))
         .toEqual({
           start: Date.UTC(2021, MAY, 16, 12, 11, 10, 9),
           end: Date.UTC(2021, MAY, 16, 12, 11, 10, 9),
@@ -56,7 +56,7 @@ describe('Segment', () => {
 
     it('before start point', () => {
       expect(segment.unixRatioOnSegment(new Rat(-1n, 1000n))).toBe(false)
-      expect(segment.unixMillisToAtomicMillisRange(-1))
+      expect(segment.unixMillisRatioToAtomicMillisRange(new Rat(-1n)))
         .toEqual({ start: -1, end: -1, closed: true })
       expect(segment.atomicRatioOnSegment(new Rat(-1n, 1000n))).toBe(false)
       expect(segment.atomicRatioToUnixRatio(new Rat(-1n, 1000n))).toEqual(new Rat(-1n, 1000n))
@@ -73,7 +73,7 @@ describe('Segment', () => {
 
     it('zero point', () => {
       expect(segment.unixRatioOnSegment(new Rat(0n))).toBe(true)
-      expect(segment.unixMillisToAtomicMillisRange(0))
+      expect(segment.unixMillisRatioToAtomicMillisRange(new Rat(0n)))
         .toEqual({ start: 0, end: 0, closed: true })
       expect(segment.atomicRatioOnSegment(new Rat(0n))).toBe(true)
       expect(segment.atomicRatioToUnixRatio(new Rat(0n))).toEqual(new Rat(0n))
@@ -81,7 +81,7 @@ describe('Segment', () => {
 
     it('a little later', () => {
       expect(segment.unixRatioOnSegment(new Rat(501n, 1000n))).toBe(true)
-      expect(segment.unixMillisToAtomicMillisRange(501))
+      expect(segment.unixMillisRatioToAtomicMillisRange(new Rat(501n)))
         .toEqual({ start: 1002, end: 1002, closed: true })
       expect(segment.atomicRatioOnSegment(new Rat(1_002n, 1000n))).toBe(true)
       expect(segment.atomicRatioToUnixRatio(new Rat(1_002n, 1000n))).toEqual(new Rat(501n, 1000n))
@@ -89,7 +89,7 @@ describe('Segment', () => {
 
     it('right before end point', () => {
       expect(segment.unixRatioOnSegment(new Rat(999n, 1000n))).toBe(true)
-      expect(segment.unixMillisToAtomicMillisRange(999))
+      expect(segment.unixMillisRatioToAtomicMillisRange(new Rat(999n)))
         .toEqual({ start: 1998, end: 1998, closed: true })
 
       expect(segment.atomicRatioOnSegment(new Rat(1_998n, 1000n))).toBe(true)
@@ -100,7 +100,7 @@ describe('Segment', () => {
 
     it('end point', () => {
       expect(segment.unixRatioOnSegment(new Rat(1n))).toBe(false)
-      expect(segment.unixMillisToAtomicMillisRange(1000))
+      expect(segment.unixMillisRatioToAtomicMillisRange(new Rat(1000n)))
         .toEqual({ start: 2000, end: 2000, closed: true })
       expect(segment.atomicRatioOnSegment(new Rat(2n))).toBe(false)
       expect(segment.atomicRatioToUnixRatio(new Rat(2n))).toEqual(new Rat(1n))
@@ -117,7 +117,7 @@ describe('Segment', () => {
 
     it('zero point', () => {
       expect(segment.unixRatioOnSegment(new Rat(0n))).toBe(true)
-      expect(segment.unixMillisToAtomicMillisRange(0))
+      expect(segment.unixMillisRatioToAtomicMillisRange(new Rat(0n)))
         .toEqual({ start: 0, end: 2000, closed: false })
       expect(segment.atomicRatioOnSegment(new Rat(0n))).toBe(true)
       expect(segment.atomicRatioToUnixRatio(new Rat(0n))).toEqual(new Rat(0n))
@@ -132,7 +132,7 @@ describe('Segment', () => {
 
     it('later in Unix time', () => {
       expect(segment.unixRatioOnSegment(new Rat(1n))).toBe(false)
-      expect(() => segment.unixMillisToAtomicMillisRange(-1))
+      expect(() => segment.unixMillisRatioToAtomicMillisRange(new Rat(-1n)))
         .toThrowError('This Unix time never happened')
     })
   })

--- a/src/segment.spec.js
+++ b/src/segment.spec.js
@@ -35,7 +35,7 @@ describe('Segment', () => {
 
     it('zero point', () => {
       expect(segment.unixRatioOnSegment(new Rat(0n))).toBe(true)
-      expect(segment.unixMillisRatioToAtomicMillisRange(new Rat(0n)))
+      expect(segment.unixRatioToAtomicMillisRange(new Rat(0n)))
         .toEqual({ start: 0, end: 0, closed: true })
       expect(segment.atomicRatioOnSegment(new Rat(0n))).toBe(true)
       expect(segment.atomicRatioToUnixRatio(new Rat(0n))).toEqual(new Rat(0n))
@@ -43,7 +43,7 @@ describe('Segment', () => {
 
     it('modern day', () => {
       expect(segment.unixRatioOnSegment(new Rat(BigInt(Date.UTC(2021, MAY, 16, 12, 11, 10, 9)), 1000n))).toBe(true)
-      expect(segment.unixMillisRatioToAtomicMillisRange(new Rat(BigInt(Date.UTC(2021, MAY, 16, 12, 11, 10, 9)))))
+      expect(segment.unixRatioToAtomicMillisRange(new Rat(BigInt(Date.UTC(2021, MAY, 16, 12, 11, 10, 9)), 1000n)))
         .toEqual({
           start: Date.UTC(2021, MAY, 16, 12, 11, 10, 9),
           end: Date.UTC(2021, MAY, 16, 12, 11, 10, 9),
@@ -56,7 +56,7 @@ describe('Segment', () => {
 
     it('before start point', () => {
       expect(segment.unixRatioOnSegment(new Rat(-1n, 1000n))).toBe(false)
-      expect(segment.unixMillisRatioToAtomicMillisRange(new Rat(-1n)))
+      expect(segment.unixRatioToAtomicMillisRange(new Rat(-1n, 1000n)))
         .toEqual({ start: -1, end: -1, closed: true })
       expect(segment.atomicRatioOnSegment(new Rat(-1n, 1000n))).toBe(false)
       expect(segment.atomicRatioToUnixRatio(new Rat(-1n, 1000n))).toEqual(new Rat(-1n, 1000n))
@@ -73,7 +73,7 @@ describe('Segment', () => {
 
     it('zero point', () => {
       expect(segment.unixRatioOnSegment(new Rat(0n))).toBe(true)
-      expect(segment.unixMillisRatioToAtomicMillisRange(new Rat(0n)))
+      expect(segment.unixRatioToAtomicMillisRange(new Rat(0n)))
         .toEqual({ start: 0, end: 0, closed: true })
       expect(segment.atomicRatioOnSegment(new Rat(0n))).toBe(true)
       expect(segment.atomicRatioToUnixRatio(new Rat(0n))).toEqual(new Rat(0n))
@@ -81,7 +81,7 @@ describe('Segment', () => {
 
     it('a little later', () => {
       expect(segment.unixRatioOnSegment(new Rat(501n, 1000n))).toBe(true)
-      expect(segment.unixMillisRatioToAtomicMillisRange(new Rat(501n)))
+      expect(segment.unixRatioToAtomicMillisRange(new Rat(501n, 1000n)))
         .toEqual({ start: 1002, end: 1002, closed: true })
       expect(segment.atomicRatioOnSegment(new Rat(1_002n, 1000n))).toBe(true)
       expect(segment.atomicRatioToUnixRatio(new Rat(1_002n, 1000n))).toEqual(new Rat(501n, 1000n))
@@ -89,7 +89,7 @@ describe('Segment', () => {
 
     it('right before end point', () => {
       expect(segment.unixRatioOnSegment(new Rat(999n, 1000n))).toBe(true)
-      expect(segment.unixMillisRatioToAtomicMillisRange(new Rat(999n)))
+      expect(segment.unixRatioToAtomicMillisRange(new Rat(999n, 1000n)))
         .toEqual({ start: 1998, end: 1998, closed: true })
 
       expect(segment.atomicRatioOnSegment(new Rat(1_998n, 1000n))).toBe(true)
@@ -100,7 +100,7 @@ describe('Segment', () => {
 
     it('end point', () => {
       expect(segment.unixRatioOnSegment(new Rat(1n))).toBe(false)
-      expect(segment.unixMillisRatioToAtomicMillisRange(new Rat(1000n)))
+      expect(segment.unixRatioToAtomicMillisRange(new Rat(1n)))
         .toEqual({ start: 2000, end: 2000, closed: true })
       expect(segment.atomicRatioOnSegment(new Rat(2n))).toBe(false)
       expect(segment.atomicRatioToUnixRatio(new Rat(2n))).toEqual(new Rat(1n))
@@ -117,7 +117,7 @@ describe('Segment', () => {
 
     it('zero point', () => {
       expect(segment.unixRatioOnSegment(new Rat(0n))).toBe(true)
-      expect(segment.unixMillisRatioToAtomicMillisRange(new Rat(0n)))
+      expect(segment.unixRatioToAtomicMillisRange(new Rat(0n)))
         .toEqual({ start: 0, end: 2000, closed: false })
       expect(segment.atomicRatioOnSegment(new Rat(0n))).toBe(true)
       expect(segment.atomicRatioToUnixRatio(new Rat(0n))).toEqual(new Rat(0n))
@@ -132,7 +132,7 @@ describe('Segment', () => {
 
     it('later in Unix time', () => {
       expect(segment.unixRatioOnSegment(new Rat(1n))).toBe(false)
-      expect(() => segment.unixMillisRatioToAtomicMillisRange(new Rat(-1n)))
+      expect(() => segment.unixRatioToAtomicMillisRange(new Rat(-1n, 1000n)))
         .toThrowError('This Unix time never happened')
     })
   })

--- a/src/segment.spec.js
+++ b/src/segment.spec.js
@@ -1,6 +1,7 @@
 /* eslint-env jest */
 
 const { Segment } = require('./segment')
+const { Rat } = require('./rat')
 
 const MAY = 4
 
@@ -32,7 +33,7 @@ describe('Segment', () => {
     )
 
     it('zero point', () => {
-      expect(segment.unixMillisOnSegment(0)).toBe(true)
+      expect(segment.unixMillisRatioOnSegment(new Rat(0n))).toBe(true)
       expect(segment.unixMillisToAtomicMillisRange(0))
         .toEqual({ start: 0, end: 0, closed: true })
       expect(segment.atomicMillisOnSegment(0)).toBe(true)
@@ -40,7 +41,7 @@ describe('Segment', () => {
     })
 
     it('modern day', () => {
-      expect(segment.unixMillisOnSegment(Date.UTC(2021, MAY, 16, 12, 11, 10, 9))).toBe(true)
+      expect(segment.unixMillisRatioOnSegment(new Rat(BigInt(Date.UTC(2021, MAY, 16, 12, 11, 10, 9))))).toBe(true)
       expect(segment.unixMillisToAtomicMillisRange(Date.UTC(2021, MAY, 16, 12, 11, 10, 9)))
         .toEqual({
           start: Date.UTC(2021, MAY, 16, 12, 11, 10, 9),
@@ -53,7 +54,7 @@ describe('Segment', () => {
     })
 
     it('before start point', () => {
-      expect(segment.unixMillisOnSegment(-1)).toBe(false)
+      expect(segment.unixMillisRatioOnSegment(new Rat(-1n))).toBe(false)
       expect(segment.unixMillisToAtomicMillisRange(-1))
         .toEqual({ start: -1, end: -1, closed: true })
       expect(segment.atomicMillisOnSegment(-1)).toBe(false)
@@ -70,7 +71,7 @@ describe('Segment', () => {
     )
 
     it('zero point', () => {
-      expect(segment.unixMillisOnSegment(0)).toBe(true)
+      expect(segment.unixMillisRatioOnSegment(new Rat(0n))).toBe(true)
       expect(segment.unixMillisToAtomicMillisRange(0))
         .toEqual({ start: 0, end: 0, closed: true })
       expect(segment.atomicMillisOnSegment(0)).toBe(true)
@@ -78,7 +79,7 @@ describe('Segment', () => {
     })
 
     it('a little later', () => {
-      expect(segment.unixMillisOnSegment(501)).toBe(true)
+      expect(segment.unixMillisRatioOnSegment(new Rat(501n))).toBe(true)
       expect(segment.unixMillisToAtomicMillisRange(501))
         .toEqual({ start: 1002, end: 1002, closed: true })
       expect(segment.atomicMillisOnSegment(1002)).toBe(true)
@@ -86,7 +87,7 @@ describe('Segment', () => {
     })
 
     it('right before end point', () => {
-      expect(segment.unixMillisOnSegment(999)).toBe(true)
+      expect(segment.unixMillisRatioOnSegment(new Rat(999n))).toBe(true)
       expect(segment.unixMillisToAtomicMillisRange(999))
         .toEqual({ start: 1998, end: 1998, closed: true })
 
@@ -97,7 +98,7 @@ describe('Segment', () => {
     })
 
     it('end point', () => {
-      expect(segment.unixMillisOnSegment(1000)).toBe(false)
+      expect(segment.unixMillisRatioOnSegment(new Rat(1000n))).toBe(false)
       expect(segment.unixMillisToAtomicMillisRange(1000))
         .toEqual({ start: 2000, end: 2000, closed: true })
       expect(segment.atomicMillisOnSegment(2000)).toBe(false)
@@ -114,7 +115,7 @@ describe('Segment', () => {
     )
 
     it('zero point', () => {
-      expect(segment.unixMillisOnSegment(0)).toBe(true)
+      expect(segment.unixMillisRatioOnSegment(new Rat(0n))).toBe(true)
       expect(segment.unixMillisToAtomicMillisRange(0))
         .toEqual({ start: 0, end: 2000, closed: false })
       expect(segment.atomicMillisOnSegment(0)).toBe(true)
@@ -129,7 +130,7 @@ describe('Segment', () => {
     })
 
     it('later in Unix time', () => {
-      expect(segment.unixMillisOnSegment(1)).toBe(false)
+      expect(segment.unixMillisRatioOnSegment(new Rat(1n))).toBe(false)
       expect(() => segment.unixMillisToAtomicMillisRange(-1))
         .toThrowError('This Unix time never happened')
     })

--- a/src/segment.spec.js
+++ b/src/segment.spec.js
@@ -38,7 +38,7 @@ describe('Segment', () => {
       expect(segment.unixMillisToAtomicMillisRange(0))
         .toEqual({ start: 0, end: 0, closed: true })
       expect(segment.atomicRatioOnSegment(new Rat(0n))).toBe(true)
-      expect(segment.atomicRatioToUnixMillis(new Rat(0n))).toBe(0)
+      expect(segment.atomicRatioToUnixMillisRatio(new Rat(0n))).toEqual(new Rat(0n))
     })
 
     it('modern day', () => {
@@ -50,8 +50,8 @@ describe('Segment', () => {
           closed: true
         })
       expect(segment.atomicRatioOnSegment(new Rat(BigInt(Date.UTC(2021, MAY, 16, 12, 11, 10, 9)), 1000n))).toBe(true)
-      expect(segment.atomicRatioToUnixMillis(new Rat(BigInt(Date.UTC(2021, MAY, 16, 12, 11, 10, 9)), 1000n)))
-        .toBe(Date.UTC(2021, MAY, 16, 12, 11, 10, 9))
+      expect(segment.atomicRatioToUnixMillisRatio(new Rat(BigInt(Date.UTC(2021, MAY, 16, 12, 11, 10, 9)), 1000n)))
+        .toEqual(new Rat(BigInt(Date.UTC(2021, MAY, 16, 12, 11, 10, 9))))
     })
 
     it('before start point', () => {
@@ -59,7 +59,7 @@ describe('Segment', () => {
       expect(segment.unixMillisToAtomicMillisRange(-1))
         .toEqual({ start: -1, end: -1, closed: true })
       expect(segment.atomicRatioOnSegment(new Rat(-1n, 1000n))).toBe(false)
-      expect(segment.atomicRatioToUnixMillis(new Rat(-1n, 1000n))).toBe(-1)
+      expect(segment.atomicRatioToUnixMillisRatio(new Rat(-1n, 1000n))).toEqual(new Rat(-1n))
     })
   })
 
@@ -76,7 +76,7 @@ describe('Segment', () => {
       expect(segment.unixMillisToAtomicMillisRange(0))
         .toEqual({ start: 0, end: 0, closed: true })
       expect(segment.atomicRatioOnSegment(new Rat(0n))).toBe(true)
-      expect(segment.atomicRatioToUnixMillis(new Rat(0n))).toBe(0)
+      expect(segment.atomicRatioToUnixMillisRatio(new Rat(0n))).toEqual(new Rat(0n))
     })
 
     it('a little later', () => {
@@ -84,7 +84,7 @@ describe('Segment', () => {
       expect(segment.unixMillisToAtomicMillisRange(501))
         .toEqual({ start: 1002, end: 1002, closed: true })
       expect(segment.atomicRatioOnSegment(new Rat(1_002n, 1000n))).toBe(true)
-      expect(segment.atomicRatioToUnixMillis(new Rat(1_002n, 1000n))).toBe(501)
+      expect(segment.atomicRatioToUnixMillisRatio(new Rat(1_002n, 1000n))).toEqual(new Rat(501n))
     })
 
     it('right before end point', () => {
@@ -93,9 +93,9 @@ describe('Segment', () => {
         .toEqual({ start: 1998, end: 1998, closed: true })
 
       expect(segment.atomicRatioOnSegment(new Rat(1_998n, 1000n))).toBe(true)
-      expect(segment.atomicRatioToUnixMillis(new Rat(1_998n, 1000n))).toBe(999)
+      expect(segment.atomicRatioToUnixMillisRatio(new Rat(1_998n, 1000n))).toEqual(new Rat(999n))
       expect(segment.atomicRatioOnSegment(new Rat(1_999n, 1000n))).toBe(true)
-      expect(segment.atomicRatioToUnixMillis(new Rat(1_999n, 1000n))).toBe(999) // truncated
+      expect(segment.atomicRatioToUnixMillisRatio(new Rat(1_999n, 1000n))).toEqual(new Rat(1999n, 2n)) // truncates to 999ms
     })
 
     it('end point', () => {
@@ -103,7 +103,7 @@ describe('Segment', () => {
       expect(segment.unixMillisToAtomicMillisRange(1000))
         .toEqual({ start: 2000, end: 2000, closed: true })
       expect(segment.atomicRatioOnSegment(new Rat(2n))).toBe(false)
-      expect(segment.atomicRatioToUnixMillis(new Rat(2n))).toBe(1000)
+      expect(segment.atomicRatioToUnixMillisRatio(new Rat(2n))).toEqual(new Rat(1000n))
     })
   })
 
@@ -120,14 +120,14 @@ describe('Segment', () => {
       expect(segment.unixMillisToAtomicMillisRange(0))
         .toEqual({ start: 0, end: 2000, closed: false })
       expect(segment.atomicRatioOnSegment(new Rat(0n))).toBe(true)
-      expect(segment.atomicRatioToUnixMillis(new Rat(0n))).toBe(0)
+      expect(segment.atomicRatioToUnixMillisRatio(new Rat(0n))).toEqual(new Rat(0n))
     })
 
     it('later in TAI', () => {
       expect(segment.atomicRatioOnSegment(new Rat(1_999n, 1000n))).toBe(true)
-      expect(segment.atomicRatioToUnixMillis(new Rat(1_999n, 1000n))).toBe(0)
+      expect(segment.atomicRatioToUnixMillisRatio(new Rat(1_999n, 1000n))).toEqual(new Rat(0n))
       expect(segment.atomicRatioOnSegment(new Rat(2_000n, 1000n))).toBe(false)
-      expect(segment.atomicRatioToUnixMillis(new Rat(2_000n, 1000n))).toBe(0)
+      expect(segment.atomicRatioToUnixMillisRatio(new Rat(2_000n, 1000n))).toEqual(new Rat(0n))
     })
 
     it('later in Unix time', () => {

--- a/src/segment.spec.js
+++ b/src/segment.spec.js
@@ -37,7 +37,7 @@ describe('Segment', () => {
       expect(segment.unixRatioOnSegment(new Rat(0n))).toBe(true)
       expect(segment.unixMillisToAtomicMillisRange(0))
         .toEqual({ start: 0, end: 0, closed: true })
-      expect(segment.atomicPicosRatioOnSegment(new Rat(0n))).toBe(true)
+      expect(segment.atomicRatioOnSegment(new Rat(0n))).toBe(true)
       expect(segment.atomicMillisToUnixMillis(0)).toBe(0)
     })
 
@@ -49,7 +49,7 @@ describe('Segment', () => {
           end: Date.UTC(2021, MAY, 16, 12, 11, 10, 9),
           closed: true
         })
-     expect(segment.atomicPicosRatioOnSegment(new Rat(BigInt(Date.UTC(2021, MAY, 16, 12, 11, 10, 9)) * picosPerMilli))).toBe(true)
+     expect(segment.atomicRatioOnSegment(new Rat(BigInt(Date.UTC(2021, MAY, 16, 12, 11, 10, 9)), 1000n))).toBe(true)
       expect(segment.atomicMillisToUnixMillis(Date.UTC(2021, MAY, 16, 12, 11, 10, 9)))
         .toBe(Date.UTC(2021, MAY, 16, 12, 11, 10, 9))
     })
@@ -58,7 +58,7 @@ describe('Segment', () => {
       expect(segment.unixRatioOnSegment(new Rat(-1n, 1000n))).toBe(false)
       expect(segment.unixMillisToAtomicMillisRange(-1))
         .toEqual({ start: -1, end: -1, closed: true })
-      expect(segment.atomicPicosRatioOnSegment(new Rat(-1_000_000_000n))).toBe(false)
+      expect(segment.atomicRatioOnSegment(new Rat(-1n, 1000n))).toBe(false)
       expect(segment.atomicMillisToUnixMillis(-1)).toBe(-1)
     })
   })
@@ -75,7 +75,7 @@ describe('Segment', () => {
       expect(segment.unixRatioOnSegment(new Rat(0n))).toBe(true)
       expect(segment.unixMillisToAtomicMillisRange(0))
         .toEqual({ start: 0, end: 0, closed: true })
-      expect(segment.atomicPicosRatioOnSegment(new Rat(0n))).toBe(true)
+      expect(segment.atomicRatioOnSegment(new Rat(0n))).toBe(true)
       expect(segment.atomicMillisToUnixMillis(0)).toBe(0)
     })
 
@@ -83,7 +83,7 @@ describe('Segment', () => {
       expect(segment.unixRatioOnSegment(new Rat(501n, 1000n))).toBe(true)
       expect(segment.unixMillisToAtomicMillisRange(501))
         .toEqual({ start: 1002, end: 1002, closed: true })
-      expect(segment.atomicPicosRatioOnSegment(new Rat(1_002_000_000_000n))).toBe(true)
+      expect(segment.atomicRatioOnSegment(new Rat(1_002n, 1000n))).toBe(true)
       expect(segment.atomicMillisToUnixMillis(1002)).toBe(501)
     })
 
@@ -92,9 +92,9 @@ describe('Segment', () => {
       expect(segment.unixMillisToAtomicMillisRange(999))
         .toEqual({ start: 1998, end: 1998, closed: true })
 
-      expect(segment.atomicPicosRatioOnSegment(new Rat(1_998_000_000_000n))).toBe(true)
+      expect(segment.atomicRatioOnSegment(new Rat(1_998n, 1000n))).toBe(true)
       expect(segment.atomicMillisToUnixMillis(1998)).toBe(999)
-      expect(segment.atomicPicosRatioOnSegment(new Rat(1_999_000_000_000n))).toBe(true)
+      expect(segment.atomicRatioOnSegment(new Rat(1_999n, 1000n))).toBe(true)
       expect(segment.atomicMillisToUnixMillis(1999)).toBe(999) // truncated
     })
 
@@ -102,7 +102,7 @@ describe('Segment', () => {
       expect(segment.unixRatioOnSegment(new Rat(1n))).toBe(false)
       expect(segment.unixMillisToAtomicMillisRange(1000))
         .toEqual({ start: 2000, end: 2000, closed: true })
-      expect(segment.atomicPicosRatioOnSegment(new Rat(2_000_000_000_000n))).toBe(false)
+      expect(segment.atomicRatioOnSegment(new Rat(2n))).toBe(false)
       expect(segment.atomicMillisToUnixMillis(2000)).toBe(1000)
     })
   })
@@ -119,14 +119,14 @@ describe('Segment', () => {
       expect(segment.unixRatioOnSegment(new Rat(0n))).toBe(true)
       expect(segment.unixMillisToAtomicMillisRange(0))
         .toEqual({ start: 0, end: 2000, closed: false })
-      expect(segment.atomicPicosRatioOnSegment(new Rat(0n))).toBe(true)
+      expect(segment.atomicRatioOnSegment(new Rat(0n))).toBe(true)
       expect(segment.atomicMillisToUnixMillis(0)).toBe(0)
     })
 
     it('later in TAI', () => {
-      expect(segment.atomicPicosRatioOnSegment(new Rat(1_999_000_000_000n))).toBe(true)
+      expect(segment.atomicRatioOnSegment(new Rat(1_999n, 1000n))).toBe(true)
       expect(segment.atomicMillisToUnixMillis(1999)).toBe(0)
-      expect(segment.atomicPicosRatioOnSegment(new Rat(2_000_000_000_000n))).toBe(false)
+      expect(segment.atomicRatioOnSegment(new Rat(2_000n, 1000n))).toBe(false)
       expect(segment.atomicMillisToUnixMillis(2000)).toBe(0)
     })
 

--- a/src/segment.spec.js
+++ b/src/segment.spec.js
@@ -34,7 +34,7 @@ describe('Segment', () => {
 
     it('zero point', () => {
       expect(segment.unixRatioOnSegment(new Rat(0n))).toBe(true)
-      expect(segment.unixRatioToAtomicPicosRatioRange(new Rat(0n)))
+      expect(segment.unixRatioToAtomicRatioRange(new Rat(0n)))
         .toEqual({ start: new Rat(0n), end: new Rat(0n), closed: true })
       expect(segment.atomicRatioOnSegment(new Rat(0n))).toBe(true)
       expect(segment.atomicRatioToUnixRatio(new Rat(0n))).toEqual(new Rat(0n))
@@ -42,10 +42,10 @@ describe('Segment', () => {
 
     it('modern day', () => {
       expect(segment.unixRatioOnSegment(new Rat(BigInt(Date.UTC(2021, MAY, 16, 12, 11, 10, 9)), 1000n))).toBe(true)
-      expect(segment.unixRatioToAtomicPicosRatioRange(new Rat(BigInt(Date.UTC(2021, MAY, 16, 12, 11, 10, 9)), 1000n)))
+      expect(segment.unixRatioToAtomicRatioRange(new Rat(BigInt(Date.UTC(2021, MAY, 16, 12, 11, 10, 9)), 1000n)))
         .toEqual({
-          start: new Rat(BigInt(Date.UTC(2021, MAY, 16, 12, 11, 10, 9)) * 1_000_000_000n),
-          end: new Rat(BigInt(Date.UTC(2021, MAY, 16, 12, 11, 10, 9)) * 1_000_000_000n),
+          start: new Rat(BigInt(Date.UTC(2021, MAY, 16, 12, 11, 10, 9)), 1000n),
+          end: new Rat(BigInt(Date.UTC(2021, MAY, 16, 12, 11, 10, 9)), 1000n),
           closed: true
         })
       expect(segment.atomicRatioOnSegment(new Rat(BigInt(Date.UTC(2021, MAY, 16, 12, 11, 10, 9)), 1000n))).toBe(true)
@@ -55,8 +55,8 @@ describe('Segment', () => {
 
     it('before start point', () => {
       expect(segment.unixRatioOnSegment(new Rat(-1n, 1000n))).toBe(false)
-      expect(segment.unixRatioToAtomicPicosRatioRange(new Rat(-1n, 1000n)))
-        .toEqual({ start: new Rat(-1_000_000_000n), end: new Rat(-1000_000_000n), closed: true })
+      expect(segment.unixRatioToAtomicRatioRange(new Rat(-1n, 1000n)))
+        .toEqual({ start: new Rat(-1n, 1000n), end: new Rat(-1n, 1000n), closed: true })
       expect(segment.atomicRatioOnSegment(new Rat(-1n, 1000n))).toBe(false)
       expect(segment.atomicRatioToUnixRatio(new Rat(-1n, 1000n))).toEqual(new Rat(-1n, 1000n))
     })
@@ -72,7 +72,7 @@ describe('Segment', () => {
 
     it('zero point', () => {
       expect(segment.unixRatioOnSegment(new Rat(0n))).toBe(true)
-      expect(segment.unixRatioToAtomicPicosRatioRange(new Rat(0n)))
+      expect(segment.unixRatioToAtomicRatioRange(new Rat(0n)))
         .toEqual({ start: new Rat(0n), end: new Rat(0n), closed: true })
       expect(segment.atomicRatioOnSegment(new Rat(0n))).toBe(true)
       expect(segment.atomicRatioToUnixRatio(new Rat(0n))).toEqual(new Rat(0n))
@@ -80,16 +80,16 @@ describe('Segment', () => {
 
     it('a little later', () => {
       expect(segment.unixRatioOnSegment(new Rat(501n, 1000n))).toBe(true)
-      expect(segment.unixRatioToAtomicPicosRatioRange(new Rat(501n, 1000n)))
-        .toEqual({ start: new Rat(1_002_000_000_000n), end: new Rat(1_002_000_000_000n), closed: true })
+      expect(segment.unixRatioToAtomicRatioRange(new Rat(501n, 1000n)))
+        .toEqual({ start: new Rat(1_002n, 1000n), end: new Rat(1_002n, 1000n), closed: true })
       expect(segment.atomicRatioOnSegment(new Rat(1_002n, 1000n))).toBe(true)
       expect(segment.atomicRatioToUnixRatio(new Rat(1_002n, 1000n))).toEqual(new Rat(501n, 1000n))
     })
 
     it('right before end point', () => {
       expect(segment.unixRatioOnSegment(new Rat(999n, 1000n))).toBe(true)
-      expect(segment.unixRatioToAtomicPicosRatioRange(new Rat(999n, 1000n)))
-        .toEqual({ start: new Rat(1_998_000_000_000n), end: new Rat(1_998_000_000_000n), closed: true })
+      expect(segment.unixRatioToAtomicRatioRange(new Rat(999n, 1000n)))
+        .toEqual({ start: new Rat(1_998n, 1000n), end: new Rat(1_998n, 1000n), closed: true })
 
       expect(segment.atomicRatioOnSegment(new Rat(1_998n, 1000n))).toBe(true)
       expect(segment.atomicRatioToUnixRatio(new Rat(1_998n, 1000n))).toEqual(new Rat(999n, 1000n))
@@ -99,8 +99,8 @@ describe('Segment', () => {
 
     it('end point', () => {
       expect(segment.unixRatioOnSegment(new Rat(1n))).toBe(false)
-      expect(segment.unixRatioToAtomicPicosRatioRange(new Rat(1n)))
-        .toEqual({ start: new Rat(2_000_000_000_000n), end: new Rat(2_000_000_000_000n), closed: true })
+      expect(segment.unixRatioToAtomicRatioRange(new Rat(1n)))
+        .toEqual({ start: new Rat(2_000n, 1000n), end: new Rat(2_000n, 1000n), closed: true })
       expect(segment.atomicRatioOnSegment(new Rat(2n))).toBe(false)
       expect(segment.atomicRatioToUnixRatio(new Rat(2n))).toEqual(new Rat(1n))
     })
@@ -116,8 +116,8 @@ describe('Segment', () => {
 
     it('zero point', () => {
       expect(segment.unixRatioOnSegment(new Rat(0n))).toBe(true)
-      expect(segment.unixRatioToAtomicPicosRatioRange(new Rat(0n)))
-        .toEqual({ start: new Rat(0n), end: new Rat(2_000_000_000_000n), closed: false })
+      expect(segment.unixRatioToAtomicRatioRange(new Rat(0n)))
+        .toEqual({ start: new Rat(0n), end: new Rat(2_000n, 1000n), closed: false })
       expect(segment.atomicRatioOnSegment(new Rat(0n))).toBe(true)
       expect(segment.atomicRatioToUnixRatio(new Rat(0n))).toEqual(new Rat(0n))
     })
@@ -131,7 +131,7 @@ describe('Segment', () => {
 
     it('later in Unix time', () => {
       expect(segment.unixRatioOnSegment(new Rat(1n))).toBe(false)
-      expect(() => segment.unixRatioToAtomicPicosRatioRange(new Rat(-1n, 1000n)))
+      expect(() => segment.unixRatioToAtomicRatioRange(new Rat(-1n, 1000n)))
         .toThrowError('This Unix time never happened')
     })
   })

--- a/src/segment.spec.js
+++ b/src/segment.spec.js
@@ -38,7 +38,7 @@ describe('Segment', () => {
       expect(segment.unixMillisToAtomicMillisRange(0))
         .toEqual({ start: 0, end: 0, closed: true })
       expect(segment.atomicRatioOnSegment(new Rat(0n))).toBe(true)
-      expect(segment.atomicRatioToUnixMillisRatio(new Rat(0n))).toEqual(new Rat(0n))
+      expect(segment.atomicRatioToUnixRatio(new Rat(0n))).toEqual(new Rat(0n))
     })
 
     it('modern day', () => {
@@ -50,8 +50,8 @@ describe('Segment', () => {
           closed: true
         })
       expect(segment.atomicRatioOnSegment(new Rat(BigInt(Date.UTC(2021, MAY, 16, 12, 11, 10, 9)), 1000n))).toBe(true)
-      expect(segment.atomicRatioToUnixMillisRatio(new Rat(BigInt(Date.UTC(2021, MAY, 16, 12, 11, 10, 9)), 1000n)))
-        .toEqual(new Rat(BigInt(Date.UTC(2021, MAY, 16, 12, 11, 10, 9))))
+      expect(segment.atomicRatioToUnixRatio(new Rat(BigInt(Date.UTC(2021, MAY, 16, 12, 11, 10, 9)), 1000n)))
+        .toEqual(new Rat(BigInt(Date.UTC(2021, MAY, 16, 12, 11, 10, 9)), 1000n))
     })
 
     it('before start point', () => {
@@ -59,7 +59,7 @@ describe('Segment', () => {
       expect(segment.unixMillisToAtomicMillisRange(-1))
         .toEqual({ start: -1, end: -1, closed: true })
       expect(segment.atomicRatioOnSegment(new Rat(-1n, 1000n))).toBe(false)
-      expect(segment.atomicRatioToUnixMillisRatio(new Rat(-1n, 1000n))).toEqual(new Rat(-1n))
+      expect(segment.atomicRatioToUnixRatio(new Rat(-1n, 1000n))).toEqual(new Rat(-1n, 1000n))
     })
   })
 
@@ -76,7 +76,7 @@ describe('Segment', () => {
       expect(segment.unixMillisToAtomicMillisRange(0))
         .toEqual({ start: 0, end: 0, closed: true })
       expect(segment.atomicRatioOnSegment(new Rat(0n))).toBe(true)
-      expect(segment.atomicRatioToUnixMillisRatio(new Rat(0n))).toEqual(new Rat(0n))
+      expect(segment.atomicRatioToUnixRatio(new Rat(0n))).toEqual(new Rat(0n))
     })
 
     it('a little later', () => {
@@ -84,7 +84,7 @@ describe('Segment', () => {
       expect(segment.unixMillisToAtomicMillisRange(501))
         .toEqual({ start: 1002, end: 1002, closed: true })
       expect(segment.atomicRatioOnSegment(new Rat(1_002n, 1000n))).toBe(true)
-      expect(segment.atomicRatioToUnixMillisRatio(new Rat(1_002n, 1000n))).toEqual(new Rat(501n))
+      expect(segment.atomicRatioToUnixRatio(new Rat(1_002n, 1000n))).toEqual(new Rat(501n, 1000n))
     })
 
     it('right before end point', () => {
@@ -93,9 +93,9 @@ describe('Segment', () => {
         .toEqual({ start: 1998, end: 1998, closed: true })
 
       expect(segment.atomicRatioOnSegment(new Rat(1_998n, 1000n))).toBe(true)
-      expect(segment.atomicRatioToUnixMillisRatio(new Rat(1_998n, 1000n))).toEqual(new Rat(999n))
+      expect(segment.atomicRatioToUnixRatio(new Rat(1_998n, 1000n))).toEqual(new Rat(999n, 1000n))
       expect(segment.atomicRatioOnSegment(new Rat(1_999n, 1000n))).toBe(true)
-      expect(segment.atomicRatioToUnixMillisRatio(new Rat(1_999n, 1000n))).toEqual(new Rat(1999n, 2n)) // truncates to 999ms
+      expect(segment.atomicRatioToUnixRatio(new Rat(1_999n, 1000n))).toEqual(new Rat(1999n, 2000n)) // truncates to 999ms
     })
 
     it('end point', () => {
@@ -103,7 +103,7 @@ describe('Segment', () => {
       expect(segment.unixMillisToAtomicMillisRange(1000))
         .toEqual({ start: 2000, end: 2000, closed: true })
       expect(segment.atomicRatioOnSegment(new Rat(2n))).toBe(false)
-      expect(segment.atomicRatioToUnixMillisRatio(new Rat(2n))).toEqual(new Rat(1000n))
+      expect(segment.atomicRatioToUnixRatio(new Rat(2n))).toEqual(new Rat(1n))
     })
   })
 
@@ -120,14 +120,14 @@ describe('Segment', () => {
       expect(segment.unixMillisToAtomicMillisRange(0))
         .toEqual({ start: 0, end: 2000, closed: false })
       expect(segment.atomicRatioOnSegment(new Rat(0n))).toBe(true)
-      expect(segment.atomicRatioToUnixMillisRatio(new Rat(0n))).toEqual(new Rat(0n))
+      expect(segment.atomicRatioToUnixRatio(new Rat(0n))).toEqual(new Rat(0n))
     })
 
     it('later in TAI', () => {
       expect(segment.atomicRatioOnSegment(new Rat(1_999n, 1000n))).toBe(true)
-      expect(segment.atomicRatioToUnixMillisRatio(new Rat(1_999n, 1000n))).toEqual(new Rat(0n))
+      expect(segment.atomicRatioToUnixRatio(new Rat(1_999n, 1000n))).toEqual(new Rat(0n))
       expect(segment.atomicRatioOnSegment(new Rat(2_000n, 1000n))).toBe(false)
-      expect(segment.atomicRatioToUnixMillisRatio(new Rat(2_000n, 1000n))).toEqual(new Rat(0n))
+      expect(segment.atomicRatioToUnixRatio(new Rat(2_000n, 1000n))).toEqual(new Rat(0n))
     })
 
     it('later in Unix time', () => {

--- a/src/segment.spec.js
+++ b/src/segment.spec.js
@@ -4,7 +4,6 @@ const { Segment } = require('./segment')
 const { Rat } = require('./rat')
 
 const MAY = 4
-const picosPerMilli = 1000n * 1000n * 1000n
 
 describe('Segment', () => {
   it('disallows rays which run backwards', () => {
@@ -35,18 +34,18 @@ describe('Segment', () => {
 
     it('zero point', () => {
       expect(segment.unixRatioOnSegment(new Rat(0n))).toBe(true)
-      expect(segment.unixRatioToAtomicMillisRange(new Rat(0n)))
-        .toEqual({ start: 0, end: 0, closed: true })
+      expect(segment.unixRatioToAtomicMillisRatioRange(new Rat(0n)))
+        .toEqual({ start: new Rat(0n), end: new Rat(0n), closed: true })
       expect(segment.atomicRatioOnSegment(new Rat(0n))).toBe(true)
       expect(segment.atomicRatioToUnixRatio(new Rat(0n))).toEqual(new Rat(0n))
     })
 
     it('modern day', () => {
       expect(segment.unixRatioOnSegment(new Rat(BigInt(Date.UTC(2021, MAY, 16, 12, 11, 10, 9)), 1000n))).toBe(true)
-      expect(segment.unixRatioToAtomicMillisRange(new Rat(BigInt(Date.UTC(2021, MAY, 16, 12, 11, 10, 9)), 1000n)))
+      expect(segment.unixRatioToAtomicMillisRatioRange(new Rat(BigInt(Date.UTC(2021, MAY, 16, 12, 11, 10, 9)), 1000n)))
         .toEqual({
-          start: Date.UTC(2021, MAY, 16, 12, 11, 10, 9),
-          end: Date.UTC(2021, MAY, 16, 12, 11, 10, 9),
+          start: new Rat(BigInt(Date.UTC(2021, MAY, 16, 12, 11, 10, 9))),
+          end: new Rat(BigInt(Date.UTC(2021, MAY, 16, 12, 11, 10, 9))),
           closed: true
         })
       expect(segment.atomicRatioOnSegment(new Rat(BigInt(Date.UTC(2021, MAY, 16, 12, 11, 10, 9)), 1000n))).toBe(true)
@@ -56,8 +55,8 @@ describe('Segment', () => {
 
     it('before start point', () => {
       expect(segment.unixRatioOnSegment(new Rat(-1n, 1000n))).toBe(false)
-      expect(segment.unixRatioToAtomicMillisRange(new Rat(-1n, 1000n)))
-        .toEqual({ start: -1, end: -1, closed: true })
+      expect(segment.unixRatioToAtomicMillisRatioRange(new Rat(-1n, 1000n)))
+        .toEqual({ start: new Rat(-1n), end: new Rat(-1n), closed: true })
       expect(segment.atomicRatioOnSegment(new Rat(-1n, 1000n))).toBe(false)
       expect(segment.atomicRatioToUnixRatio(new Rat(-1n, 1000n))).toEqual(new Rat(-1n, 1000n))
     })
@@ -73,24 +72,24 @@ describe('Segment', () => {
 
     it('zero point', () => {
       expect(segment.unixRatioOnSegment(new Rat(0n))).toBe(true)
-      expect(segment.unixRatioToAtomicMillisRange(new Rat(0n)))
-        .toEqual({ start: 0, end: 0, closed: true })
+      expect(segment.unixRatioToAtomicMillisRatioRange(new Rat(0n)))
+        .toEqual({ start: new Rat(0n), end: new Rat(0n), closed: true })
       expect(segment.atomicRatioOnSegment(new Rat(0n))).toBe(true)
       expect(segment.atomicRatioToUnixRatio(new Rat(0n))).toEqual(new Rat(0n))
     })
 
     it('a little later', () => {
       expect(segment.unixRatioOnSegment(new Rat(501n, 1000n))).toBe(true)
-      expect(segment.unixRatioToAtomicMillisRange(new Rat(501n, 1000n)))
-        .toEqual({ start: 1002, end: 1002, closed: true })
+      expect(segment.unixRatioToAtomicMillisRatioRange(new Rat(501n, 1000n)))
+        .toEqual({ start: new Rat(1002n), end: new Rat(1002n), closed: true })
       expect(segment.atomicRatioOnSegment(new Rat(1_002n, 1000n))).toBe(true)
       expect(segment.atomicRatioToUnixRatio(new Rat(1_002n, 1000n))).toEqual(new Rat(501n, 1000n))
     })
 
     it('right before end point', () => {
       expect(segment.unixRatioOnSegment(new Rat(999n, 1000n))).toBe(true)
-      expect(segment.unixRatioToAtomicMillisRange(new Rat(999n, 1000n)))
-        .toEqual({ start: 1998, end: 1998, closed: true })
+      expect(segment.unixRatioToAtomicMillisRatioRange(new Rat(999n, 1000n)))
+        .toEqual({ start: new Rat(1998n), end: new Rat(1998n), closed: true })
 
       expect(segment.atomicRatioOnSegment(new Rat(1_998n, 1000n))).toBe(true)
       expect(segment.atomicRatioToUnixRatio(new Rat(1_998n, 1000n))).toEqual(new Rat(999n, 1000n))
@@ -100,8 +99,8 @@ describe('Segment', () => {
 
     it('end point', () => {
       expect(segment.unixRatioOnSegment(new Rat(1n))).toBe(false)
-      expect(segment.unixRatioToAtomicMillisRange(new Rat(1n)))
-        .toEqual({ start: 2000, end: 2000, closed: true })
+      expect(segment.unixRatioToAtomicMillisRatioRange(new Rat(1n)))
+        .toEqual({ start: new Rat(2000n), end: new Rat(2000n), closed: true })
       expect(segment.atomicRatioOnSegment(new Rat(2n))).toBe(false)
       expect(segment.atomicRatioToUnixRatio(new Rat(2n))).toEqual(new Rat(1n))
     })
@@ -117,8 +116,8 @@ describe('Segment', () => {
 
     it('zero point', () => {
       expect(segment.unixRatioOnSegment(new Rat(0n))).toBe(true)
-      expect(segment.unixRatioToAtomicMillisRange(new Rat(0n)))
-        .toEqual({ start: 0, end: 2000, closed: false })
+      expect(segment.unixRatioToAtomicMillisRatioRange(new Rat(0n)))
+        .toEqual({ start: new Rat(0n), end: new Rat(2000n), closed: false })
       expect(segment.atomicRatioOnSegment(new Rat(0n))).toBe(true)
       expect(segment.atomicRatioToUnixRatio(new Rat(0n))).toEqual(new Rat(0n))
     })
@@ -132,7 +131,7 @@ describe('Segment', () => {
 
     it('later in Unix time', () => {
       expect(segment.unixRatioOnSegment(new Rat(1n))).toBe(false)
-      expect(() => segment.unixRatioToAtomicMillisRange(new Rat(-1n, 1000n)))
+      expect(() => segment.unixRatioToAtomicMillisRatioRange(new Rat(-1n, 1000n)))
         .toThrowError('This Unix time never happened')
     })
   })


### PR DESCRIPTION
This is part of a series of operations intended to make `t-a-i` better support JavaScript's forthcoming [Temporal API](https://tc39.es/proposal-temporal/docs/), which *somewhat* resembles `t-a-i`'s, but (among other things) deals with *nanoseconds*, where we deal with milliseconds in the external API and picoseconds in our internals. Ultimately I hope to expose APIs where you can submit any precise *ratio* of BigInts and receive a converted ratio in response - which you can then truncate to any degree of precision you wish, be it millisecond, microsecond, nanosecond or picosecond. It will then be possible to implement Temporal APIs around this. I hope. In any case these initial changes are for the simpler...