### PR TITLE
Stratify exact and inexact APIs a little

### DIFF
--- a/src/converter.js
+++ b/src/converter.js
@@ -46,12 +46,14 @@ const Converter = (data, model) => {
         const prev = ranges[ranges.length - 1]
 
         // Previous range ends where current one starts, so try to combine the two.
-        // The previous range should have `closed: false` but it doesn't actually make a difference.
+        // The previous range should have `open: true` but it doesn't actually make a difference.
         if (prev.end.eq(range.start)) {
           ranges[ranges.length - 1] = {
             start: prev.start,
-            end: range.end,
-            closed: range.closed
+            end: range.end
+          }
+          if ('open' in range) {
+            ranges[ranges.length - 1].open = range.open
           }
           continue
         }
@@ -61,7 +63,7 @@ const Converter = (data, model) => {
     }
 
     /* istanbul ignore if */
-    if (ranges.some(range => range.closed !== true)) {
+    if (ranges.some(range => 'open' in range)) {
       throw Error('Failed to close all open ranges, this should be impossible')
     }
 

--- a/src/converter.js
+++ b/src/converter.js
@@ -10,7 +10,7 @@
 // map to multiple TAI times. We can return an array of these, or just the result from the latest
 // segment (according to its numbering).
 
-const { MODELS, exactToMillis, munge } = require('./munge')
+const { MODELS, munge } = require('./munge')
 const { Rat } = require('./rat.js')
 
 const Converter = (data, model) => {
@@ -31,8 +31,12 @@ const Converter = (data, model) => {
     return NaN
   }
 
-  const atomicMillisToUnixMillis = atomicMillis =>
-    exactToMillis(atomicToUnix(Rat.fromMillis(atomicMillis)))
+  const atomicMillisToUnixMillis = atomicMillis => {
+    const unix = atomicToUnix(Rat.fromMillis(atomicMillis))
+    return Number.isNaN(unix)
+      ? unix
+      : unix.toMillis()
+  }
 
   const unixToAtomic = unix => {
     const ranges = []
@@ -75,8 +79,8 @@ const Converter = (data, model) => {
   const unixMillisToAtomicMillis = (unixMillis, options = {}) => {
     const ranges = unixToAtomic(Rat.fromMillis(unixMillis))
       .map(range => [
-        exactToMillis(range.start),
-        exactToMillis(range.end)
+        range.start.toMillis(),
+        range.end.toMillis()
       ])
 
     if (options.array === true) {

--- a/src/converter.js
+++ b/src/converter.js
@@ -10,7 +10,8 @@
 // map to multiple TAI times. We can return an array of these, or just the result from the latest
 // segment (according to its numbering).
 
-const { MODELS, millisToExact, exactToMillis, munge } = require('./munge')
+const { MODELS, exactToMillis, munge } = require('./munge')
+const { Rat } = require('./rat.js')
 
 const Converter = (data, model) => {
   const segments = munge(data, model)
@@ -31,7 +32,7 @@ const Converter = (data, model) => {
   }
 
   const atomicMillisToUnixMillis = atomicMillis =>
-    exactToMillis(atomicToUnix(millisToExact(atomicMillis)))
+    exactToMillis(atomicToUnix(Rat.fromMillis(atomicMillis)))
 
   const unixToAtomic = unix => {
     const ranges = []
@@ -72,7 +73,7 @@ const Converter = (data, model) => {
   }
 
   const unixMillisToAtomicMillis = (unixMillis, options = {}) => {
-    const ranges = unixToAtomic(millisToExact(unixMillis))
+    const ranges = unixToAtomic(Rat.fromMillis(unixMillis))
       .map(range => [
         exactToMillis(range.start),
         exactToMillis(range.end)

--- a/src/converter.js
+++ b/src/converter.js
@@ -17,34 +17,23 @@ const Converter = (data, model) => {
 
   // This conversion always has the same behaviour,
   // and there's no work required in handling the output
-  const atomicToUnix = atomicMillis => {
-    if (!Number.isInteger(atomicMillis)) {
-      throw Error(`Not an integer: ${atomicMillis}`)
-    }
-
-    const atomic = millisToExact(atomicMillis)
-
+  const atomicToUnix = atomic => {
     for (const segment of segments) {
       if (!segment.atomicOnSegment(atomic)) {
         continue
       }
 
-      const unix = segment.atomicToUnix(atomic)
-
-      return exactToMillis(unix)
+      return segment.atomicToUnix(atomic)
     }
 
     // Pre-1961, or BREAK model and we hit a break
     return NaN
   }
 
-  const unixToAtomic = (unixMillis, options = {}) => {
-    if (!Number.isInteger(unixMillis)) {
-      throw Error(`Not an integer: ${unixMillis}`)
-    }
+  const atomicMillisToUnixMillis = atomicMillis =>
+    exactToMillis(atomicToUnix(millisToExact(atomicMillis)))
 
-    const unix = millisToExact(unixMillis)
-
+  const unixToAtomic = unix => {
     const ranges = []
     for (const segment of segments) {
       if (!segment.unixOnSegment(unix)) {
@@ -52,15 +41,13 @@ const Converter = (data, model) => {
       }
 
       const range = segment.unixToAtomicRange(unix)
-      range.start = exactToMillis(range.start)
-      range.end = exactToMillis(range.end)
 
       if (ranges.length - 1 in ranges) {
         const prev = ranges[ranges.length - 1]
 
         // Previous range ends where current one starts, so try to combine the two.
         // The previous range should have `closed: false` but it doesn't actually make a difference.
-        if (prev.end === range.start) {
+        if (prev.end.eq(range.start)) {
           ranges[ranges.length - 1] = {
             start: prev.start,
             end: range.end,
@@ -78,27 +65,31 @@ const Converter = (data, model) => {
       throw Error('Failed to close all open ranges, this should be impossible')
     }
 
+    // Always return an array of ranges, caller can prune this output if desired
+    return ranges
+  }
+
+  const unixMillisToAtomicMillis = (unixMillis, options = {}) => {
+    const ranges = unixToAtomic(millisToExact(unixMillis))
+      .map(range => [
+        exactToMillis(range.start),
+        exactToMillis(range.end)
+      ])
+
     if (options.array === true) {
-      return ranges.map(range =>
-        options.range === true
-          ? [range.start, range.end]
-          : range.end
-      )
+      return options.range === true ? ranges : ranges.map(range => range[1])
     }
 
     const i = ranges.length - 1
-    const range = i in ranges
-      ? ranges[i]
-      : { start: NaN, end: NaN }
-
-    return options.range === true
-      ? [range.start, range.end]
-      : range.end
+    const lastRange = i in ranges ? ranges[i] : [NaN, NaN]
+    return options.range === true ? lastRange : lastRange[1]
   }
 
   return {
+    atomicToUnix,
+    atomicMillisToUnixMillis,
     unixToAtomic,
-    atomicToUnix
+    unixMillisToAtomicMillis
   }
 }
 

--- a/src/converter.spec.js
+++ b/src/converter.spec.js
@@ -52,14 +52,14 @@ describe('Converter', () => {
       it('fails when the atomic count is out of bounds', () => {
         expect(converter.atomicToUnix(new Rat(0n))).toEqual(new Rat(0n))
         expect(converter.atomicMillisToUnixMillis(0)).toBe(0)
-        expect(converter.atomicToUnix(new Rat(-1n, 1000n))).toBe(NaN)
+        expect(converter.atomicToUnix(new Rat(-1n, 1_000n))).toBe(NaN)
         expect(converter.atomicMillisToUnixMillis(-1)).toBe(NaN)
       })
 
       it('fails when the Unix count is out of bounds', () => {
         expect(converter.unixToAtomic(new Rat(0n))).toEqual([{ start: new Rat(0n), end: new Rat(0n) }])
         expect(converter.unixMillisToAtomicMillis(0)).toBe(0)
-        expect(converter.unixToAtomic(new Rat(-1n, 1000n))).toEqual([])
+        expect(converter.unixToAtomic(new Rat(-1n, 1_000n))).toEqual([])
         expect(converter.unixMillisToAtomicMillis(-1)).toBe(NaN)
       })
 

--- a/src/converter.spec.js
+++ b/src/converter.spec.js
@@ -1172,16 +1172,220 @@ describe('Converter', () => {
       })
 
       describe('BREAK', () => {
-        it('disallows a zero-length segment between breaks', () => {
-          expect(() => Converter(data, MODELS.BREAK))
-            .toThrowError('Segment length must be positive')
+        const converter = Converter(data, MODELS.BREAK)
+
+        it('unixToAtomic', () => {
+          expect(converter.unixToAtomic(Rat.fromMillis(0)))
+            .toEqual([{
+              start: Rat.fromMillis(0),
+              end: Rat.fromMillis(0)
+            }])
+
+          // STALL POINT
+          expect(converter.unixToAtomic(Rat.fromMillis(999)))
+            .toEqual([{
+              start: Rat.fromMillis(999),
+              end: Rat.fromMillis(999)
+            }])
+          expect(converter.unixToAtomic(Rat.fromMillis(1000)))
+            .toEqual([{
+              start: Rat.fromMillis(3000),
+              end: Rat.fromMillis(3000)
+            }])
+          expect(converter.unixToAtomic(Rat.fromMillis(1001)))
+            .toEqual([{
+              start: Rat.fromMillis(3001),
+              end: Rat.fromMillis(3001)
+            }])
+        })
+
+        it('unixMillisToAtomicMillis (range mode)', () => {
+          expect(converter.unixMillisToAtomicMillis(0, { range: true }))
+            .toEqual([
+              0,
+              0
+            ])
+
+          // STALL POINT
+          expect(converter.unixMillisToAtomicMillis(999, { range: true }))
+            .toEqual([
+              999,
+              999
+            ])
+          expect(converter.unixMillisToAtomicMillis(1000, { range: true }))
+            .toEqual([
+              3000,
+              3000
+            ])
+          expect(converter.unixMillisToAtomicMillis(1001, { range: true }))
+            .toEqual([
+              3001,
+              3001
+            ])
+        })
+
+        it('unixMillisToAtomicMillis', () => {
+          expect(converter.unixMillisToAtomicMillis(0))
+            .toBe(0)
+
+          // STALL POINT
+          expect(converter.unixMillisToAtomicMillis(999))
+            .toBe(999)
+          expect(converter.unixMillisToAtomicMillis(1000))
+            .toBe(3000)
+          expect(converter.unixMillisToAtomicMillis(1001))
+            .toBe(3001)
+        })
+
+        it('atomicToUnix', () => {
+          expect(converter.atomicToUnix(Rat.fromMillis(0)))
+            .toEqual(Rat.fromMillis(0))
+
+          // STALL STARTS
+          expect(converter.atomicToUnix(Rat.fromMillis(999)))
+            .toEqual(Rat.fromMillis(999))
+          expect(converter.atomicToUnix(Rat.fromMillis(1000)))
+            .toBe(NaN)
+          expect(converter.atomicToUnix(Rat.fromMillis(1001)))
+            .toBe(NaN)
+
+          // STALL ENDS
+          expect(converter.atomicToUnix(Rat.fromMillis(2999)))
+            .toBe(NaN)
+          expect(converter.atomicToUnix(Rat.fromMillis(3000)))
+            .toEqual(Rat.fromMillis(1000))
+          expect(converter.atomicToUnix(Rat.fromMillis(3001)))
+            .toEqual(Rat.fromMillis(1001))
+        })
+
+        it('atomicMillisToUnixMillis', () => {
+          expect(converter.atomicMillisToUnixMillis(0))
+            .toBe(0)
+
+          // STALL STARTS
+          expect(converter.atomicMillisToUnixMillis(999))
+            .toBe(999)
+          expect(converter.atomicMillisToUnixMillis(1000))
+            .toBe(NaN)
+          expect(converter.atomicMillisToUnixMillis(1001))
+            .toBe(NaN)
+
+          // STALL ENDS
+          expect(converter.atomicMillisToUnixMillis(2999))
+            .toBe(NaN)
+          expect(converter.atomicMillisToUnixMillis(3000))
+            .toEqual(1000)
+          expect(converter.atomicMillisToUnixMillis(3001))
+            .toEqual(1001)
         })
       })
 
       describe('STALL', () => {
-        it('disallows a zero-length segment between stalls', () => {
-          expect(() => Converter(data, MODELS.STALL))
-            .toThrowError('Segment length must be positive')
+        const converter = Converter(data, MODELS.STALL)
+
+        it('unixToAtomic', () => {
+          expect(converter.unixToAtomic(Rat.fromMillis(0)))
+            .toEqual([{
+              start: Rat.fromMillis(0),
+              end: Rat.fromMillis(0)
+            }])
+
+          // STALL POINT
+          expect(converter.unixToAtomic(Rat.fromMillis(999)))
+            .toEqual([{
+              start: Rat.fromMillis(999),
+              end: Rat.fromMillis(999)
+            }])
+          expect(converter.unixToAtomic(Rat.fromMillis(1000)))
+            .toEqual([{
+              start: Rat.fromMillis(1000),
+              end: Rat.fromMillis(3000)
+            }])
+          expect(converter.unixToAtomic(Rat.fromMillis(1001)))
+            .toEqual([{
+              start: Rat.fromMillis(3001),
+              end: Rat.fromMillis(3001)
+            }])
+        })
+
+        it('unixMillisToAtomicMillis (range mode)', () => {
+          expect(converter.unixMillisToAtomicMillis(0, { range: true }))
+            .toEqual([
+              0,
+              0
+            ])
+
+          // STALL POINT
+          expect(converter.unixMillisToAtomicMillis(999, { range: true }))
+            .toEqual([
+              999,
+              999
+            ])
+          expect(converter.unixMillisToAtomicMillis(1000, { range: true }))
+            .toEqual([
+              1000,
+              3000
+            ])
+          expect(converter.unixMillisToAtomicMillis(1001, { range: true }))
+            .toEqual([
+              3001,
+              3001
+            ])
+        })
+
+        it('unixMillisToAtomicMillis', () => {
+          expect(converter.unixMillisToAtomicMillis(0))
+            .toBe(0)
+
+          // STALL POINT
+          expect(converter.unixMillisToAtomicMillis(999))
+            .toBe(999)
+          expect(converter.unixMillisToAtomicMillis(1000))
+            .toBe(3000)
+          expect(converter.unixMillisToAtomicMillis(1001))
+            .toBe(3001)
+        })
+
+        it('atomicToUnix', () => {
+          expect(converter.atomicToUnix(Rat.fromMillis(0)))
+            .toEqual(Rat.fromMillis(0))
+
+          // STALL STARTS
+          expect(converter.atomicToUnix(Rat.fromMillis(999)))
+            .toEqual(Rat.fromMillis(999))
+          expect(converter.atomicToUnix(Rat.fromMillis(1000)))
+            .toEqual(Rat.fromMillis(1000))
+          expect(converter.atomicToUnix(Rat.fromMillis(1001)))
+            .toEqual(Rat.fromMillis(1000))
+
+          // STALL ENDS
+          expect(converter.atomicToUnix(Rat.fromMillis(2999)))
+            .toEqual(Rat.fromMillis(1000))
+          expect(converter.atomicToUnix(Rat.fromMillis(3000)))
+            .toEqual(Rat.fromMillis(1000))
+          expect(converter.atomicToUnix(Rat.fromMillis(3001)))
+            .toEqual(Rat.fromMillis(1001))
+        })
+
+        it('atomicMillisToUnixMillis', () => {
+          expect(converter.atomicMillisToUnixMillis(0))
+            .toBe(0)
+
+          // STALL STARTS
+          expect(converter.atomicMillisToUnixMillis(999))
+            .toBe(999)
+          expect(converter.atomicMillisToUnixMillis(1000))
+            .toBe(1000)
+          expect(converter.atomicMillisToUnixMillis(1001))
+            .toBe(1000)
+
+          // STALL ENDS
+          expect(converter.atomicMillisToUnixMillis(2999))
+            .toEqual(1000)
+          expect(converter.atomicMillisToUnixMillis(3000))
+            .toEqual(1000)
+          expect(converter.atomicMillisToUnixMillis(3001))
+            .toEqual(1001)
         })
       })
     })

--- a/src/converter.spec.js
+++ b/src/converter.spec.js
@@ -19,7 +19,7 @@ describe('Converter', () => {
       const converter = Converter(data, MODELS.OVERRUN)
 
       it('manages basic conversions', () => {
-        expect(converter.unixToAtomic(new Rat(0n))).toEqual([{ start: new Rat(0n), end: new Rat(0n), closed: true }])
+        expect(converter.unixToAtomic(new Rat(0n))).toEqual([{ start: new Rat(0n), end: new Rat(0n) }])
         expect(converter.unixMillisToAtomicMillis(0, { range: true, array: true })).toEqual([[0, 0]])
         expect(converter.unixMillisToAtomicMillis(0, { range: true })).toEqual([0, 0])
         expect(converter.unixMillisToAtomicMillis(0, { array: true })).toEqual([0])
@@ -33,7 +33,7 @@ describe('Converter', () => {
       const converter = Converter(data, MODELS.BREAK)
 
       it('manages basic conversions', () => {
-        expect(converter.unixToAtomic(new Rat(0n))).toEqual([{ start: new Rat(0n), end: new Rat(0n), closed: true }])
+        expect(converter.unixToAtomic(new Rat(0n))).toEqual([{ start: new Rat(0n), end: new Rat(0n) }])
         expect(converter.unixMillisToAtomicMillis(0)).toEqual(0)
         expect(converter.atomicToUnix(new Rat(0n))).toEqual(new Rat(0n))
         expect(converter.atomicMillisToUnixMillis(0)).toBe(0)
@@ -58,14 +58,14 @@ describe('Converter', () => {
       })
 
       it('fails when the Unix count is out of bounds', () => {
-        expect(converter.unixToAtomic(new Rat(0n))).toEqual([{ start: new Rat(0n), end: new Rat(0n), closed: true }])
+        expect(converter.unixToAtomic(new Rat(0n))).toEqual([{ start: new Rat(0n), end: new Rat(0n) }])
         expect(converter.unixMillisToAtomicMillis(0)).toBe(0)
         expect(converter.unixToAtomic(new Rat(-1n, 1000n))).toEqual([])
         expect(converter.unixMillisToAtomicMillis(-1)).toBe(NaN)
       })
 
       it('manages basic conversions', () => {
-        expect(converter.unixToAtomic(new Rat(0n))).toEqual([{ start: new Rat(0n), end: new Rat(0n), closed: true }])
+        expect(converter.unixToAtomic(new Rat(0n))).toEqual([{ start: new Rat(0n), end: new Rat(0n) }])
         expect(converter.unixMillisToAtomicMillis(0, { range: true, array: true })).toEqual([[0, 0]])
         expect(converter.unixMillisToAtomicMillis(0, { range: true })).toEqual([0, 0])
         expect(converter.unixMillisToAtomicMillis(0, { array: true })).toEqual([0])
@@ -79,7 +79,7 @@ describe('Converter', () => {
       const converter = Converter(data, MODELS.SMEAR)
 
       it('manages basic conversions', () => {
-        expect(converter.unixToAtomic(new Rat(0n))).toEqual([{ start: new Rat(0n), end: new Rat(0n), closed: true }])
+        expect(converter.unixToAtomic(new Rat(0n))).toEqual([{ start: new Rat(0n), end: new Rat(0n) }])
         expect(converter.unixMillisToAtomicMillis(0)).toEqual(0)
         expect(converter.atomicToUnix(new Rat(0n))).toEqual(new Rat(0n))
         expect(converter.atomicMillisToUnixMillis(0)).toBe(0)
@@ -100,60 +100,50 @@ describe('Converter', () => {
         expect(converter.unixToAtomic(new Rat(0n)))
           .toEqual([{
             start: new Rat(0n),
-            end: new Rat(0n),
-            closed: true
+            end: new Rat(0n)
           }])
 
         // BIFURCATION
         expect(converter.unixToAtomic(millisToExact(Date.UTC(1979, DEC, 31, 23, 59, 59, 999))))
           .toEqual([{
             start: millisToExact(Date.UTC(1979, DEC, 31, 23, 59, 59, 999)),
-            end: millisToExact(Date.UTC(1979, DEC, 31, 23, 59, 59, 999)),
-            closed: true
+            end: millisToExact(Date.UTC(1979, DEC, 31, 23, 59, 59, 999))
           }])
         expect(converter.unixToAtomic(millisToExact(Date.UTC(1980, JAN, 1, 0, 0, 0, 0))))
           .toEqual([{
             start: millisToExact(Date.UTC(1980, JAN, 1, 0, 0, 0, 0)),
-            end: millisToExact(Date.UTC(1980, JAN, 1, 0, 0, 0, 0)),
-            closed: true
+            end: millisToExact(Date.UTC(1980, JAN, 1, 0, 0, 0, 0))
           }, {
             start: millisToExact(Date.UTC(1980, JAN, 1, 0, 0, 1)),
-            end: millisToExact(Date.UTC(1980, JAN, 1, 0, 0, 1)),
-            closed: true
+            end: millisToExact(Date.UTC(1980, JAN, 1, 0, 0, 1))
           }])
         expect(converter.unixToAtomic(millisToExact(Date.UTC(1980, JAN, 1, 0, 0, 0, 1))))
           .toEqual([{
             start: millisToExact(Date.UTC(1980, JAN, 1, 0, 0, 0, 1)),
-            end: millisToExact(Date.UTC(1980, JAN, 1, 0, 0, 0, 1)),
-            closed: true
+            end: millisToExact(Date.UTC(1980, JAN, 1, 0, 0, 0, 1))
           }, {
             start: millisToExact(Date.UTC(1980, JAN, 1, 0, 0, 1, 1)),
-            end: millisToExact(Date.UTC(1980, JAN, 1, 0, 0, 1, 1)),
-            closed: true
+            end: millisToExact(Date.UTC(1980, JAN, 1, 0, 0, 1, 1))
           }])
 
         // COLLAPSE
         expect(converter.unixToAtomic(millisToExact(Date.UTC(1980, JAN, 1, 0, 0, 0, 999))))
           .toEqual([{
             start: millisToExact(Date.UTC(1980, JAN, 1, 0, 0, 0, 999)),
-            end: millisToExact(Date.UTC(1980, JAN, 1, 0, 0, 0, 999)),
-            closed: true
+            end: millisToExact(Date.UTC(1980, JAN, 1, 0, 0, 0, 999))
           }, {
             start: millisToExact(Date.UTC(1980, JAN, 1, 0, 0, 1, 999)),
-            end: millisToExact(Date.UTC(1980, JAN, 1, 0, 0, 1, 999)),
-            closed: true
+            end: millisToExact(Date.UTC(1980, JAN, 1, 0, 0, 1, 999))
           }])
         expect(converter.unixToAtomic(millisToExact(Date.UTC(1980, JAN, 1, 0, 0, 1, 0))))
           .toEqual([{
             start: millisToExact(Date.UTC(1980, JAN, 1, 0, 0, 2, 0)),
-            end: millisToExact(Date.UTC(1980, JAN, 1, 0, 0, 2, 0)),
-            closed: true
+            end: millisToExact(Date.UTC(1980, JAN, 1, 0, 0, 2, 0))
           }])
         expect(converter.unixToAtomic(millisToExact(Date.UTC(1980, JAN, 1, 0, 0, 1, 1))))
           .toEqual([{
             start: millisToExact(Date.UTC(1980, JAN, 1, 0, 0, 2, 1)),
-            end: millisToExact(Date.UTC(1980, JAN, 1, 0, 0, 2, 1)),
-            closed: true
+            end: millisToExact(Date.UTC(1980, JAN, 1, 0, 0, 2, 1))
           }])
       })
 
@@ -263,47 +253,40 @@ describe('Converter', () => {
         expect(converter.unixToAtomic(new Rat(0n)))
           .toEqual([{
             start: new Rat(0n),
-            end: new Rat(0n),
-            closed: true
+            end: new Rat(0n)
           }])
 
         // FORWARD JUMP
         expect(converter.unixToAtomic(millisToExact(Date.UTC(1979, DEC, 31, 23, 59, 59, 999))))
           .toEqual([{
             start: millisToExact(Date.UTC(1979, DEC, 31, 23, 59, 59, 999)),
-            end: millisToExact(Date.UTC(1979, DEC, 31, 23, 59, 59, 999)),
-            closed: true
+            end: millisToExact(Date.UTC(1979, DEC, 31, 23, 59, 59, 999))
           }])
         expect(converter.unixToAtomic(millisToExact(Date.UTC(1980, JAN, 1, 0, 0, 0, 0))))
           .toEqual([{
             start: millisToExact(Date.UTC(1980, JAN, 1, 0, 0, 1, 0)),
-            end: millisToExact(Date.UTC(1980, JAN, 1, 0, 0, 1, 0)),
-            closed: true
+            end: millisToExact(Date.UTC(1980, JAN, 1, 0, 0, 1, 0))
           }])
         expect(converter.unixToAtomic(millisToExact(Date.UTC(1980, JAN, 1, 0, 0, 0, 1))))
           .toEqual([{
             start: millisToExact(Date.UTC(1980, JAN, 1, 0, 0, 1, 1)),
-            end: millisToExact(Date.UTC(1980, JAN, 1, 0, 0, 1, 1)),
-            closed: true
+            end: millisToExact(Date.UTC(1980, JAN, 1, 0, 0, 1, 1))
           }])
 
         expect(converter.unixToAtomic(millisToExact(Date.UTC(1980, JAN, 1, 0, 0, 0, 999))))
           .toEqual([{
             start: millisToExact(Date.UTC(1980, JAN, 1, 0, 0, 1, 999)),
-            end: millisToExact(Date.UTC(1980, JAN, 1, 0, 0, 1, 999)),
-            closed: true
+            end: millisToExact(Date.UTC(1980, JAN, 1, 0, 0, 1, 999))
           }])
         expect(converter.unixToAtomic(millisToExact(Date.UTC(1980, JAN, 1, 0, 0, 1, 0))))
           .toEqual([{
             start: millisToExact(Date.UTC(1980, JAN, 1, 0, 0, 2, 0)),
-            end: millisToExact(Date.UTC(1980, JAN, 1, 0, 0, 2, 0)),
-            closed: true
+            end: millisToExact(Date.UTC(1980, JAN, 1, 0, 0, 2, 0))
           }])
         expect(converter.unixToAtomic(millisToExact(Date.UTC(1980, JAN, 1, 0, 0, 1, 1))))
           .toEqual([{
             start: millisToExact(Date.UTC(1980, JAN, 1, 0, 0, 2, 1)),
-            end: millisToExact(Date.UTC(1980, JAN, 1, 0, 0, 2, 1)),
-            closed: true
+            end: millisToExact(Date.UTC(1980, JAN, 1, 0, 0, 2, 1))
           }])
       })
 
@@ -377,28 +360,24 @@ describe('Converter', () => {
         expect(converter.unixToAtomic(new Rat(0n)))
           .toEqual([{
             start: new Rat(0n),
-            end: new Rat(0n),
-            closed: true
+            end: new Rat(0n)
           }])
 
         // STALL POINT
         expect(converter.unixToAtomic(millisToExact(Date.UTC(1979, DEC, 31, 23, 59, 59, 999))))
           .toEqual([{
             start: millisToExact(Date.UTC(1979, DEC, 31, 23, 59, 59, 999)),
-            end: millisToExact(Date.UTC(1979, DEC, 31, 23, 59, 59, 999)),
-            closed: true
+            end: millisToExact(Date.UTC(1979, DEC, 31, 23, 59, 59, 999))
           }])
         expect(converter.unixToAtomic(millisToExact(Date.UTC(1980, JAN, 1, 0, 0, 0, 0))))
           .toEqual([{
             start: millisToExact(Date.UTC(1980, JAN, 1, 0, 0, 0, 0)),
-            end: millisToExact(Date.UTC(1980, JAN, 1, 0, 0, 1, 0)),
-            closed: true
+            end: millisToExact(Date.UTC(1980, JAN, 1, 0, 0, 1, 0))
           }])
         expect(converter.unixToAtomic(millisToExact(Date.UTC(1980, JAN, 1, 0, 0, 0, 1))))
           .toEqual([{
             start: millisToExact(Date.UTC(1980, JAN, 1, 0, 0, 1, 1)),
-            end: millisToExact(Date.UTC(1980, JAN, 1, 0, 0, 1, 1)),
-            closed: true
+            end: millisToExact(Date.UTC(1980, JAN, 1, 0, 0, 1, 1))
           }])
       })
 
@@ -487,56 +466,48 @@ describe('Converter', () => {
         expect(converter.unixToAtomic(new Rat(0n)))
           .toEqual([{
             start: new Rat(0n),
-            end: new Rat(0n),
-            closed: true
+            end: new Rat(0n)
           }])
 
         // SMEAR STARTS, ATOMIC TIME "RUNS A LITTLE FASTER" THAN UNIX (actually Unix is slower)
         expect(converter.unixToAtomic(millisToExact(Date.UTC(1979, DEC, 31, 11, 59, 59, 999))))
           .toEqual([{
             start: millisToExact(Date.UTC(1979, DEC, 31, 11, 59, 59, 999)),
-            end: millisToExact(Date.UTC(1979, DEC, 31, 11, 59, 59, 999)),
-            closed: true
+            end: millisToExact(Date.UTC(1979, DEC, 31, 11, 59, 59, 999))
           }])
         expect(converter.unixToAtomic(millisToExact(Date.UTC(1979, DEC, 31, 12, 0, 0, 0))))
           .toEqual([{
             start: millisToExact(Date.UTC(1979, DEC, 31, 12, 0, 0, 0)),
-            end: millisToExact(Date.UTC(1979, DEC, 31, 12, 0, 0, 0)),
-            closed: true
+            end: millisToExact(Date.UTC(1979, DEC, 31, 12, 0, 0, 0))
           }])
         expect(converter.unixToAtomic(millisToExact(Date.UTC(1979, DEC, 31, 12, 0, 0, 1))))
           .toEqual([{
             start: millisToExact(Date.UTC(1979, DEC, 31, 12, 0, 0, 1)).plus(new Rat(1n, 86_400_000n)),
-            end: millisToExact(Date.UTC(1979, DEC, 31, 12, 0, 0, 1)).plus(new Rat(1n, 86_400_000n)),
-            closed: true
+            end: millisToExact(Date.UTC(1979, DEC, 31, 12, 0, 0, 1)).plus(new Rat(1n, 86_400_000n))
           }])
 
         // SMEAR MIDPOINT
         expect(converter.unixToAtomic(millisToExact(Date.UTC(1980, JAN, 1, 0, 0, 0, 0))))
           .toEqual([{
             start: millisToExact(Date.UTC(1980, JAN, 1, 0, 0, 0, 500)),
-            end: millisToExact(Date.UTC(1980, JAN, 1, 0, 0, 0, 500)),
-            closed: true
+            end: millisToExact(Date.UTC(1980, JAN, 1, 0, 0, 0, 500))
           }])
 
         // SMEAR ENDS, ATOMIC IS A FULL SECOND AHEAD (actually Unix is a full second behind)
         expect(converter.unixToAtomic(millisToExact(Date.UTC(1980, JAN, 1, 11, 59, 59, 999))))
           .toEqual([{
             start: millisToExact(Date.UTC(1980, JAN, 1, 11, 59, 59, 999)).plus(new Rat(86_399_999n, 86_400_000n)),
-            end: millisToExact(Date.UTC(1980, JAN, 1, 11, 59, 59, 999)).plus(new Rat(86_399_999n, 86_400_000n)),
-            closed: true
+            end: millisToExact(Date.UTC(1980, JAN, 1, 11, 59, 59, 999)).plus(new Rat(86_399_999n, 86_400_000n))
           }])
         expect(converter.unixToAtomic(millisToExact(Date.UTC(1980, JAN, 1, 12, 0, 0, 0))))
           .toEqual([{
             start: millisToExact(Date.UTC(1980, JAN, 1, 12, 0, 1, 0)),
-            end: millisToExact(Date.UTC(1980, JAN, 1, 12, 0, 1, 0)),
-            closed: true
+            end: millisToExact(Date.UTC(1980, JAN, 1, 12, 0, 1, 0))
           }])
         expect(converter.unixToAtomic(millisToExact(Date.UTC(1980, JAN, 1, 12, 0, 0, 1))))
           .toEqual([{
             start: millisToExact(Date.UTC(1980, JAN, 1, 12, 0, 1, 1)),
-            end: millisToExact(Date.UTC(1980, JAN, 1, 12, 0, 1, 1)),
-            closed: true
+            end: millisToExact(Date.UTC(1980, JAN, 1, 12, 0, 1, 1))
           }])
       })
 
@@ -630,16 +601,14 @@ describe('Converter', () => {
         expect(converter.unixToAtomic(new Rat(0n)))
           .toEqual([{
             start: new Rat(0n),
-            end: new Rat(0n),
-            closed: true
+            end: new Rat(0n)
           }])
 
         // START OF MISSING TIME
         expect(converter.unixToAtomic(millisToExact(Date.UTC(1979, DEC, 31, 23, 59, 58, 999))))
           .toEqual([{
             start: millisToExact(Date.UTC(1979, DEC, 31, 23, 59, 58, 999)),
-            end: millisToExact(Date.UTC(1979, DEC, 31, 23, 59, 58, 999)),
-            closed: true
+            end: millisToExact(Date.UTC(1979, DEC, 31, 23, 59, 58, 999))
           }])
         expect(converter.unixToAtomic(millisToExact(Date.UTC(1979, DEC, 31, 23, 59, 59, 0))))
           .toEqual([
@@ -655,14 +624,12 @@ describe('Converter', () => {
         expect(converter.unixToAtomic(millisToExact(Date.UTC(1980, JAN, 1, 0, 0, 0, 0))))
           .toEqual([{
             start: millisToExact(Date.UTC(1979, DEC, 31, 23, 59, 59, 0)),
-            end: millisToExact(Date.UTC(1979, DEC, 31, 23, 59, 59, 0)),
-            closed: true
+            end: millisToExact(Date.UTC(1979, DEC, 31, 23, 59, 59, 0))
           }])
         expect(converter.unixToAtomic(millisToExact(Date.UTC(1980, JAN, 1, 0, 0, 0, 1))))
           .toEqual([{
             start: millisToExact(Date.UTC(1979, DEC, 31, 23, 59, 59, 1)),
-            end: millisToExact(Date.UTC(1979, DEC, 31, 23, 59, 59, 1)),
-            closed: true
+            end: millisToExact(Date.UTC(1979, DEC, 31, 23, 59, 59, 1))
           }])
       })
 
@@ -751,16 +718,14 @@ describe('Converter', () => {
         expect(converter.unixToAtomic(new Rat(0n)))
           .toEqual([{
             start: new Rat(0n),
-            end: new Rat(0n),
-            closed: true
+            end: new Rat(0n)
           }])
 
         // START OF MISSING TIME
         expect(converter.unixToAtomic(millisToExact(Date.UTC(1979, DEC, 31, 23, 59, 58, 999))))
           .toEqual([{
             start: millisToExact(Date.UTC(1979, DEC, 31, 23, 59, 58, 999)),
-            end: millisToExact(Date.UTC(1979, DEC, 31, 23, 59, 58, 999)),
-            closed: true
+            end: millisToExact(Date.UTC(1979, DEC, 31, 23, 59, 58, 999))
           }])
         expect(converter.unixToAtomic(millisToExact(Date.UTC(1979, DEC, 31, 23, 59, 59, 0))))
           .toEqual([
@@ -776,14 +741,12 @@ describe('Converter', () => {
         expect(converter.unixToAtomic(millisToExact(Date.UTC(1980, JAN, 1, 0, 0, 0, 0))))
           .toEqual([{
             start: millisToExact(Date.UTC(1979, DEC, 31, 23, 59, 59, 0)),
-            end: millisToExact(Date.UTC(1979, DEC, 31, 23, 59, 59, 0)),
-            closed: true
+            end: millisToExact(Date.UTC(1979, DEC, 31, 23, 59, 59, 0))
           }])
         expect(converter.unixToAtomic(millisToExact(Date.UTC(1980, JAN, 1, 0, 0, 0, 1))))
           .toEqual([{
             start: millisToExact(Date.UTC(1979, DEC, 31, 23, 59, 59, 1)),
-            end: millisToExact(Date.UTC(1979, DEC, 31, 23, 59, 59, 1)),
-            closed: true
+            end: millisToExact(Date.UTC(1979, DEC, 31, 23, 59, 59, 1))
           }])
       })
 
@@ -842,16 +805,14 @@ describe('Converter', () => {
         expect(converter.unixToAtomic(new Rat(0n)))
           .toEqual([{
             start: new Rat(0n),
-            end: new Rat(0n),
-            closed: true
+            end: new Rat(0n)
           }])
 
         // START OF MISSING TIME
         expect(converter.unixToAtomic(millisToExact(Date.UTC(1979, DEC, 31, 23, 59, 58, 999))))
           .toEqual([{
             start: millisToExact(Date.UTC(1979, DEC, 31, 23, 59, 58, 999)),
-            end: millisToExact(Date.UTC(1979, DEC, 31, 23, 59, 58, 999)),
-            closed: true
+            end: millisToExact(Date.UTC(1979, DEC, 31, 23, 59, 58, 999))
           }])
         expect(converter.unixToAtomic(millisToExact(Date.UTC(1979, DEC, 31, 23, 59, 59, 0))))
           .toEqual([
@@ -867,14 +828,12 @@ describe('Converter', () => {
         expect(converter.unixToAtomic(millisToExact(Date.UTC(1980, JAN, 1, 0, 0, 0, 0))))
           .toEqual([{
             start: millisToExact(Date.UTC(1979, DEC, 31, 23, 59, 59, 0)),
-            end: millisToExact(Date.UTC(1979, DEC, 31, 23, 59, 59, 0)),
-            closed: true
+            end: millisToExact(Date.UTC(1979, DEC, 31, 23, 59, 59, 0))
           }])
         expect(converter.unixToAtomic(millisToExact(Date.UTC(1980, JAN, 1, 0, 0, 0, 1))))
           .toEqual([{
             start: millisToExact(Date.UTC(1979, DEC, 31, 23, 59, 59, 1)),
-            end: millisToExact(Date.UTC(1979, DEC, 31, 23, 59, 59, 1)),
-            closed: true
+            end: millisToExact(Date.UTC(1979, DEC, 31, 23, 59, 59, 1))
           }])
       })
 
@@ -975,56 +934,48 @@ describe('Converter', () => {
         expect(converter.unixToAtomic(new Rat(0n)))
           .toEqual([{
             start: new Rat(0n),
-            end: new Rat(0n),
-            closed: true
+            end: new Rat(0n)
           }])
 
         // SMEAR STARTS, ATOMIC "RUNS A LITTLE SLOWER" THAN UNIX (actually Unix runs faster)
         expect(converter.unixToAtomic(millisToExact(Date.UTC(1979, DEC, 31, 11, 59, 59, 999))))
           .toEqual([{
             start: millisToExact(Date.UTC(1979, DEC, 31, 11, 59, 59, 999)),
-            end: millisToExact(Date.UTC(1979, DEC, 31, 11, 59, 59, 999)),
-            closed: true
+            end: millisToExact(Date.UTC(1979, DEC, 31, 11, 59, 59, 999))
           }])
         expect(converter.unixToAtomic(millisToExact(Date.UTC(1979, DEC, 31, 12, 0, 0, 0))))
           .toEqual([{
             start: millisToExact(Date.UTC(1979, DEC, 31, 12, 0, 0, 0)),
-            end: millisToExact(Date.UTC(1979, DEC, 31, 12, 0, 0, 0)),
-            closed: true
+            end: millisToExact(Date.UTC(1979, DEC, 31, 12, 0, 0, 0))
           }])
         expect(converter.unixToAtomic(millisToExact(Date.UTC(1979, DEC, 31, 12, 0, 0, 1))))
           .toEqual([{
             start: millisToExact(Date.UTC(1979, DEC, 31, 12, 0, 0, 1)).minus(new Rat(1n, 86_400_000n)),
-            end: millisToExact(Date.UTC(1979, DEC, 31, 12, 0, 0, 1)).minus(new Rat(1n, 86_400_000n)),
-            closed: true
+            end: millisToExact(Date.UTC(1979, DEC, 31, 12, 0, 0, 1)).minus(new Rat(1n, 86_400_000n))
           }])
 
         // SMEAR MIDPOINT
         expect(converter.unixToAtomic(millisToExact(Date.UTC(1980, JAN, 1, 0, 0, 0, 0))))
           .toEqual([{
             start: millisToExact(Date.UTC(1979, DEC, 31, 23, 59, 59, 500)),
-            end: millisToExact(Date.UTC(1979, DEC, 31, 23, 59, 59, 500)),
-            closed: true
+            end: millisToExact(Date.UTC(1979, DEC, 31, 23, 59, 59, 500))
           }])
 
         // SMEAR ENDS, ATOMIC IS A FULL SECOND BEHIND (actually Unix is a full second ahead)
         expect(converter.unixToAtomic(millisToExact(Date.UTC(1980, JAN, 1, 11, 59, 59, 999))))
           .toEqual([{
             start: millisToExact(Date.UTC(1980, JAN, 1, 11, 59, 59, 999)).minus(new Rat(86_399_999n, 86_400_000n)),
-            end: millisToExact(Date.UTC(1980, JAN, 1, 11, 59, 59, 999)).minus(new Rat(86_399_999n, 86_400_000n)),
-            closed: true
+            end: millisToExact(Date.UTC(1980, JAN, 1, 11, 59, 59, 999)).minus(new Rat(86_399_999n, 86_400_000n))
           }])
         expect(converter.unixToAtomic(millisToExact(Date.UTC(1980, JAN, 1, 12, 0, 0, 0))))
           .toEqual([{
             start: millisToExact(Date.UTC(1980, JAN, 1, 11, 59, 59, 0)),
-            end: millisToExact(Date.UTC(1980, JAN, 1, 11, 59, 59, 0)),
-            closed: true
+            end: millisToExact(Date.UTC(1980, JAN, 1, 11, 59, 59, 0))
           }])
         expect(converter.unixToAtomic(millisToExact(Date.UTC(1980, JAN, 1, 12, 0, 0, 1))))
           .toEqual([{
             start: millisToExact(Date.UTC(1980, JAN, 1, 11, 59, 59, 1)),
-            end: millisToExact(Date.UTC(1980, JAN, 1, 11, 59, 59, 1)),
-            closed: true
+            end: millisToExact(Date.UTC(1980, JAN, 1, 11, 59, 59, 1))
           }])
       })
 
@@ -1106,14 +1057,25 @@ describe('Converter', () => {
   })
 
   describe('insane edge cases', () => {
-    describe('when unixMillis converts to an atomicPicos which fits but an atomicMillis which does not', () => {
+    describe('precise round trips work but milliseconds do not', () => {
       it('at the start of the ray', () => {
         const data = [
           [Date.UTC(1970, JAN, 1, 0, 0, 0, 1), -0.000_1]
         ]
         const converter = Converter(data, MODELS.OVERRUN)
-        // 900_000_000n TAI picoseconds rounds down to 0 seconds, which is not in the ray
-        expect(converter.unixMillisToAtomicMillis(1, { array: true })).toEqual([0])
+
+        expect(converter.unixToAtomic(new Rat(1n, 1_000n)))
+          .toEqual([{
+            start: new Rat(900n, 1_000_000n),
+            end: new Rat(900n, 1_000_000n)
+          }])
+        expect(converter.atomicToUnix(new Rat(900n, 1_000_000n)))
+          .toEqual(new Rat(1n, 1_000n))
+
+        expect(converter.unixMillisToAtomicMillis(1, { array: true }))
+          .toEqual([0])
+        expect(converter.atomicMillisToUnixMillis(0))
+          .toBe(NaN)
       })
 
       it('at the end of the ray', () => {
@@ -1122,7 +1084,19 @@ describe('Converter', () => {
           [Date.UTC(1970, JAN, 1, 0, 0, 0, 1), -0.001_1]
         ]
         const converter = Converter(data, MODELS.OVERRUN)
-        expect(converter.unixMillisToAtomicMillis(-1, { array: true })).toEqual([-1])
+
+        expect(converter.unixToAtomic(new Rat(-1n, 1_000n)))
+          .toEqual([{
+            start: new Rat(-900n, 1_000_000n),
+            end: new Rat(-900n, 1_000_000n)
+          }])
+        expect(converter.atomicToUnix(new Rat(-900n, 1_000_000n)))
+          .toEqual(new Rat(-1n, 1_000n))
+
+        expect(converter.unixMillisToAtomicMillis(-1, { array: true }))
+          .toEqual([-1])
+        expect(converter.atomicMillisToUnixMillis(-1))
+          .toBe(NaN)
       })
     })
   })

--- a/src/converter.spec.js
+++ b/src/converter.spec.js
@@ -2,6 +2,7 @@
 
 const { Converter, MODELS } = require('./converter.js')
 const { Rat } = require('./rat.js')
+const { millisToExact } = require('./munge.js')
 
 const JAN = 0
 const OCT = 9
@@ -105,17 +106,35 @@ describe('Converter', () => {
         })
 
         it('millisecond before inserted leap second discontinuity begins', () => {
+          expect(converter.unixToAtomic(millisToExact(Date.UTC(1979, DEC, 31, 23, 59, 59, 999))))
+            .toEqual([{
+              start: millisToExact(Date.UTC(1979, DEC, 31, 23, 59, 59, 999)),
+              end: millisToExact(Date.UTC(1979, DEC, 31, 23, 59, 59, 999)),
+              closed: true
+            }])
           expect(converter.unixMillisToAtomicMillis(Date.UTC(1979, DEC, 31, 23, 59, 59, 999), { array: true }))
             .toEqual([
               Date.UTC(1979, DEC, 31, 23, 59, 59, 999)
             ])
           expect(converter.unixMillisToAtomicMillis(Date.UTC(1979, DEC, 31, 23, 59, 59, 999)))
             .toBe(Date.UTC(1979, DEC, 31, 23, 59, 59, 999))
+          expect(converter.atomicToUnix(millisToExact(Date.UTC(1979, DEC, 31, 23, 59, 59, 999))))
+            .toEqual(millisToExact(Date.UTC(1979, DEC, 31, 23, 59, 59, 999)))
           expect(converter.atomicMillisToUnixMillis(Date.UTC(1979, DEC, 31, 23, 59, 59, 999)))
             .toBe(Date.UTC(1979, DEC, 31, 23, 59, 59, 999))
         })
 
         it('first instant of the Unix time discontinuity: one Unix time is two TAI times', () => {
+          expect(converter.unixToAtomic(millisToExact(Date.UTC(1980, JAN, 1, 0, 0, 0))))
+            .toEqual([{
+              start: millisToExact(Date.UTC(1980, JAN, 1, 0, 0, 0)),
+              end: millisToExact(Date.UTC(1980, JAN, 1, 0, 0, 0)),
+              closed: true
+            }, {
+              start: millisToExact(Date.UTC(1980, JAN, 1, 0, 0, 1)),
+              end: millisToExact(Date.UTC(1980, JAN, 1, 0, 0, 1)),
+              closed: true
+            }])
           expect(converter.unixMillisToAtomicMillis(Date.UTC(1980, JAN, 1, 0, 0, 0), { array: true }))
             .toEqual([
               Date.UTC(1980, JAN, 1, 0, 0, 0),
@@ -123,6 +142,8 @@ describe('Converter', () => {
             ])
           expect(converter.unixMillisToAtomicMillis(Date.UTC(1980, JAN, 1, 0, 0, 0)))
             .toBe(Date.UTC(1980, JAN, 1, 0, 0, 1))
+          expect(converter.atomicToUnix(millisToExact(Date.UTC(1980, JAN, 1, 0, 0, 0))))
+            .toEqual(millisToExact(Date.UTC(1980, JAN, 1, 0, 0, 0)))
           expect(converter.atomicMillisToUnixMillis(Date.UTC(1980, JAN, 1, 0, 0, 0)))
             .toBe(Date.UTC(1980, JAN, 1, 0, 0, 0))
           expect(converter.atomicMillisToUnixMillis(Date.UTC(1980, JAN, 1, 0, 0, 1)))
@@ -130,6 +151,16 @@ describe('Converter', () => {
         })
 
         it('final instant of the Unix time discontinuity: one Unix time is two TAI times', () => {
+          expect(converter.unixToAtomic(millisToExact(Date.UTC(1980, JAN, 1, 0, 0, 0, 999))))
+            .toEqual([{
+              start: millisToExact(Date.UTC(1980, JAN, 1, 0, 0, 0, 999)),
+              end: millisToExact(Date.UTC(1980, JAN, 1, 0, 0, 0, 999)),
+              closed: true
+            }, {
+              start: millisToExact(Date.UTC(1980, JAN, 1, 0, 0, 1, 999)),
+              end: millisToExact(Date.UTC(1980, JAN, 1, 0, 0, 1, 999)),
+              closed: true
+            }])
           expect(converter.unixMillisToAtomicMillis(Date.UTC(1980, JAN, 1, 0, 0, 0, 999), { array: true }))
             .toEqual([
               Date.UTC(1980, JAN, 1, 0, 0, 0, 999),
@@ -137,6 +168,8 @@ describe('Converter', () => {
             ])
           expect(converter.unixMillisToAtomicMillis(Date.UTC(1980, JAN, 1, 0, 0, 0, 999)))
             .toBe(Date.UTC(1980, JAN, 1, 0, 0, 1, 999))
+          expect(converter.atomicToUnix(millisToExact(Date.UTC(1980, JAN, 1, 0, 0, 0, 999))))
+            .toEqual(millisToExact(Date.UTC(1980, JAN, 1, 0, 0, 0, 999)))
           expect(converter.atomicMillisToUnixMillis(Date.UTC(1980, JAN, 1, 0, 0, 0, 999)))
             .toBe(Date.UTC(1980, JAN, 1, 0, 0, 0, 999))
           expect(converter.atomicMillisToUnixMillis(Date.UTC(1980, JAN, 1, 0, 0, 1, 999)))
@@ -144,18 +177,62 @@ describe('Converter', () => {
         })
 
         it('millisecond after discontinuity ends', () => {
+          expect(converter.unixToAtomic(millisToExact(Date.UTC(1980, JAN, 1, 0, 0, 1))))
+            .toEqual([{
+              start: millisToExact(Date.UTC(1980, JAN, 1, 0, 0, 2)),
+              end: millisToExact(Date.UTC(1980, JAN, 1, 0, 0, 2)),
+              closed: true
+            }])
           expect(converter.unixMillisToAtomicMillis(Date.UTC(1980, JAN, 1, 0, 0, 1), { array: true }))
             .toEqual([
               Date.UTC(1980, JAN, 1, 0, 0, 2)
             ])
           expect(converter.unixMillisToAtomicMillis(Date.UTC(1980, JAN, 1, 0, 0, 1)))
             .toBe(Date.UTC(1980, JAN, 1, 0, 0, 2))
+          expect(converter.atomicToUnix(millisToExact(Date.UTC(1980, JAN, 1, 0, 0, 2))))
+            .toEqual(millisToExact(Date.UTC(1980, JAN, 1, 0, 0, 1)))
           expect(converter.atomicMillisToUnixMillis(Date.UTC(1980, JAN, 1, 0, 0, 2)))
             .toBe(Date.UTC(1980, JAN, 1, 0, 0, 1))
         })
       })
 
       describe('conversions grouped by method', () => {
+        it('unixToAtomic', () => {
+          expect(converter.unixToAtomic(new Rat(0n))).toEqual([{ start: new Rat(0n), end: new Rat(0n), closed: true }])
+          expect(converter.unixToAtomic(millisToExact(Date.UTC(1979, DEC, 31, 23, 59, 59, 999))))
+            .toEqual([{
+              start: millisToExact(Date.UTC(1979, DEC, 31, 23, 59, 59, 999)),
+              end: millisToExact(Date.UTC(1979, DEC, 31, 23, 59, 59, 999)),
+              closed: true
+            }])
+          expect(converter.unixToAtomic(millisToExact(Date.UTC(1980, JAN, 1, 0, 0, 0))))
+            .toEqual([{
+              start: millisToExact(Date.UTC(1980, JAN, 1, 0, 0, 0)),
+              end: millisToExact(Date.UTC(1980, JAN, 1, 0, 0, 0)),
+              closed: true
+            }, {
+              start: millisToExact(Date.UTC(1980, JAN, 1, 0, 0, 1)),
+              end: millisToExact(Date.UTC(1980, JAN, 1, 0, 0, 1)),
+              closed: true
+            }])
+          expect(converter.unixToAtomic(millisToExact(Date.UTC(1980, JAN, 1, 0, 0, 0, 999))))
+            .toEqual([{
+              start: millisToExact(Date.UTC(1980, JAN, 1, 0, 0, 0, 999)),
+              end: millisToExact(Date.UTC(1980, JAN, 1, 0, 0, 0, 999)),
+              closed: true
+            }, {
+              start: millisToExact(Date.UTC(1980, JAN, 1, 0, 0, 1, 999)),
+              end: millisToExact(Date.UTC(1980, JAN, 1, 0, 0, 1, 999)),
+              closed: true
+            }])
+          expect(converter.unixToAtomic(millisToExact(Date.UTC(1980, JAN, 1, 0, 0, 1))))
+            .toEqual([{
+              start: millisToExact(Date.UTC(1980, JAN, 1, 0, 0, 2)),
+              end: millisToExact(Date.UTC(1980, JAN, 1, 0, 0, 2)),
+              closed: true
+            }])
+        })
+
         it('unixMillisToAtomicMillis (array mode)', () => {
           expect(converter.unixMillisToAtomicMillis(0, { array: true })).toEqual([0])
           expect(converter.unixMillisToAtomicMillis(Date.UTC(1979, DEC, 31, 23, 59, 59, 999), { array: true }))
@@ -190,6 +267,18 @@ describe('Converter', () => {
             .toBe(Date.UTC(1980, JAN, 1, 0, 0, 2))
         })
 
+        it('atomicToUnix', () => {
+          expect(converter.atomicToUnix(new Rat(0n))).toEqual(new Rat(0n))
+          expect(converter.atomicToUnix(millisToExact(Date.UTC(1979, DEC, 31, 23, 59, 59, 999))))
+            .toEqual(millisToExact(Date.UTC(1979, DEC, 31, 23, 59, 59, 999)))
+          expect(converter.atomicToUnix(millisToExact(Date.UTC(1980, JAN, 1, 0, 0, 0))))
+            .toEqual(millisToExact(Date.UTC(1980, JAN, 1, 0, 0, 0)))
+          expect(converter.atomicToUnix(millisToExact(Date.UTC(1980, JAN, 1, 0, 0, 0, 999))))
+            .toEqual(millisToExact(Date.UTC(1980, JAN, 1, 0, 0, 0, 999)))
+          expect(converter.atomicToUnix(millisToExact(Date.UTC(1980, JAN, 1, 0, 0, 2))))
+            .toEqual(millisToExact(Date.UTC(1980, JAN, 1, 0, 0, 1)))
+        })
+
         it('atomicMillisToUnixMillis', () => {
           expect(converter.atomicMillisToUnixMillis(0)).toBe(0)
           expect(converter.atomicMillisToUnixMillis(Date.UTC(1979, DEC, 31, 23, 59, 59, 999)))
@@ -207,6 +296,8 @@ describe('Converter', () => {
         })
       })
     })
+
+    // /////////////
 
     describe('BREAK', () => {
       const converter = Converter(data, MODELS.BREAK)

--- a/src/converter.spec.js
+++ b/src/converter.spec.js
@@ -1,6 +1,7 @@
 /* eslint-env jest */
 
-const { Converter, MODELS } = require('./converter')
+const { Converter, MODELS } = require('./converter.js')
+const { Rat } = require('./rat.js')
 
 const JAN = 0
 const OCT = 9
@@ -17,11 +18,13 @@ describe('Converter', () => {
       const converter = Converter(data, MODELS.OVERRUN)
 
       it('manages basic conversions', () => {
-        expect(converter.unixToAtomic(0, { range: true, array: true })).toEqual([[0, 0]])
-        expect(converter.unixToAtomic(0, { range: true })).toEqual([0, 0])
-        expect(converter.unixToAtomic(0, { array: true })).toEqual([0])
-        expect(converter.unixToAtomic(0)).toEqual(0)
-        expect(converter.atomicToUnix(0)).toBe(0)
+        expect(converter.unixToAtomic(new Rat(0n))).toEqual([{ start: new Rat(0n), end: new Rat(0n), closed: true }])
+        expect(converter.unixMillisToAtomicMillis(0, { range: true, array: true })).toEqual([[0, 0]])
+        expect(converter.unixMillisToAtomicMillis(0, { range: true })).toEqual([0, 0])
+        expect(converter.unixMillisToAtomicMillis(0, { array: true })).toEqual([0])
+        expect(converter.unixMillisToAtomicMillis(0)).toEqual(0)
+        expect(converter.atomicToUnix(new Rat(0n))).toEqual(new Rat(0n))
+        expect(converter.atomicMillisToUnixMillis(0)).toBe(0)
       })
     })
 
@@ -29,8 +32,10 @@ describe('Converter', () => {
       const converter = Converter(data, MODELS.BREAK)
 
       it('manages basic conversions', () => {
-        expect(converter.unixToAtomic(0)).toEqual(0)
-        expect(converter.atomicToUnix(0)).toBe(0)
+        expect(converter.unixToAtomic(new Rat(0n))).toEqual([{ start: new Rat(0n), end: new Rat(0n), closed: true }])
+        expect(converter.unixMillisToAtomicMillis(0)).toEqual(0)
+        expect(converter.atomicToUnix(new Rat(0n))).toEqual(new Rat(0n))
+        expect(converter.atomicMillisToUnixMillis(0)).toBe(0)
       })
     })
 
@@ -38,28 +43,34 @@ describe('Converter', () => {
       const converter = Converter(data, MODELS.STALL)
 
       it('fails on a non-integer number of milliseconds', () => {
-        expect(() => converter.unixToAtomic(89.3)).toThrowError('Not an integer: 89.3')
-        expect(() => converter.unixToAtomic('boop')).toThrowError('Not an integer: boop')
-        expect(() => converter.atomicToUnix(Infinity)).toThrowError('Not an integer: Infinity')
-        expect(() => converter.atomicToUnix('boops')).toThrowError('Not an integer: boops')
-      })
-
-      it('fails when the Unix count is out of bounds', () => {
-        expect(converter.unixToAtomic(0)).toBe(0)
-        expect(converter.unixToAtomic(-1)).toBe(NaN)
+        expect(() => converter.unixMillisToAtomicMillis(89.3)).toThrowError('Not an integer: 89.3')
+        expect(() => converter.unixMillisToAtomicMillis('boop')).toThrowError('Not an integer: boop')
+        expect(() => converter.atomicMillisToUnixMillis(Infinity)).toThrowError('Not an integer: Infinity')
+        expect(() => converter.atomicMillisToUnixMillis('boops')).toThrowError('Not an integer: boops')
       })
 
       it('fails when the atomic count is out of bounds', () => {
-        expect(converter.atomicToUnix(0)).toBe(0)
-        expect(converter.atomicToUnix(-1)).toBe(NaN)
+        expect(converter.atomicToUnix(new Rat(0n))).toEqual(new Rat(0n))
+        expect(converter.atomicMillisToUnixMillis(0)).toBe(0)
+        expect(converter.atomicToUnix(new Rat(-1n, 1000n))).toBe(NaN)
+        expect(converter.atomicMillisToUnixMillis(-1)).toBe(NaN)
+      })
+
+      it('fails when the Unix count is out of bounds', () => {
+        expect(converter.unixToAtomic(new Rat(0n))).toEqual([{ start: new Rat(0n), end: new Rat(0n), closed: true }])
+        expect(converter.unixMillisToAtomicMillis(0)).toBe(0)
+        expect(converter.unixToAtomic(new Rat(-1n, 1000n))).toEqual([])
+        expect(converter.unixMillisToAtomicMillis(-1)).toBe(NaN)
       })
 
       it('manages basic conversions', () => {
-        expect(converter.unixToAtomic(0, { range: true, array: true })).toEqual([[0, 0]])
-        expect(converter.unixToAtomic(0, { range: true })).toEqual([0, 0])
-        expect(converter.unixToAtomic(0, { array: true })).toEqual([0])
-        expect(converter.unixToAtomic(0)).toBe(0)
-        expect(converter.atomicToUnix(0)).toBe(0)
+        expect(converter.unixToAtomic(new Rat(0n))).toEqual([{ start: new Rat(0n), end: new Rat(0n), closed: true }])
+        expect(converter.unixMillisToAtomicMillis(0, { range: true, array: true })).toEqual([[0, 0]])
+        expect(converter.unixMillisToAtomicMillis(0, { range: true })).toEqual([0, 0])
+        expect(converter.unixMillisToAtomicMillis(0, { array: true })).toEqual([0])
+        expect(converter.unixMillisToAtomicMillis(0)).toBe(0)
+        expect(converter.atomicToUnix(new Rat(0n))).toEqual(new Rat(0n))
+        expect(converter.atomicMillisToUnixMillis(0)).toBe(0)
       })
     })
 
@@ -67,8 +78,10 @@ describe('Converter', () => {
       const converter = Converter(data, MODELS.SMEAR)
 
       it('manages basic conversions', () => {
-        expect(converter.unixToAtomic(0)).toEqual(0)
-        expect(converter.atomicToUnix(0)).toBe(0)
+        expect(converter.unixToAtomic(new Rat(0n))).toEqual([{ start: new Rat(0n), end: new Rat(0n), closed: true }])
+        expect(converter.unixMillisToAtomicMillis(0)).toEqual(0)
+        expect(converter.atomicToUnix(new Rat(0n))).toEqual(new Rat(0n))
+        expect(converter.atomicMillisToUnixMillis(0)).toBe(0)
       })
     })
   })
@@ -84,110 +97,112 @@ describe('Converter', () => {
 
       describe('conversions grouped by instant', () => {
         it('start of time', () => {
-          expect(converter.unixToAtomic(0, { array: true })).toEqual([0])
-          expect(converter.unixToAtomic(0)).toBe(0)
-          expect(converter.atomicToUnix(0)).toBe(0)
+          expect(converter.unixToAtomic(new Rat(0n))).toEqual([{ start: new Rat(0n), end: new Rat(0n), closed: true }])
+          expect(converter.unixMillisToAtomicMillis(0, { array: true })).toEqual([0])
+          expect(converter.unixMillisToAtomicMillis(0)).toBe(0)
+          expect(converter.atomicToUnix(new Rat(0n))).toEqual(new Rat(0n))
+          expect(converter.atomicMillisToUnixMillis(0)).toBe(0)
         })
 
         it('millisecond before inserted leap second discontinuity begins', () => {
-          expect(converter.unixToAtomic(Date.UTC(1979, DEC, 31, 23, 59, 59, 999), { array: true }))
+          expect(converter.unixMillisToAtomicMillis(Date.UTC(1979, DEC, 31, 23, 59, 59, 999), { array: true }))
             .toEqual([
               Date.UTC(1979, DEC, 31, 23, 59, 59, 999)
             ])
-          expect(converter.unixToAtomic(Date.UTC(1979, DEC, 31, 23, 59, 59, 999)))
+          expect(converter.unixMillisToAtomicMillis(Date.UTC(1979, DEC, 31, 23, 59, 59, 999)))
             .toBe(Date.UTC(1979, DEC, 31, 23, 59, 59, 999))
-          expect(converter.atomicToUnix(Date.UTC(1979, DEC, 31, 23, 59, 59, 999)))
+          expect(converter.atomicMillisToUnixMillis(Date.UTC(1979, DEC, 31, 23, 59, 59, 999)))
             .toBe(Date.UTC(1979, DEC, 31, 23, 59, 59, 999))
         })
 
         it('first instant of the Unix time discontinuity: one Unix time is two TAI times', () => {
-          expect(converter.unixToAtomic(Date.UTC(1980, JAN, 1, 0, 0, 0), { array: true }))
+          expect(converter.unixMillisToAtomicMillis(Date.UTC(1980, JAN, 1, 0, 0, 0), { array: true }))
             .toEqual([
               Date.UTC(1980, JAN, 1, 0, 0, 0),
               Date.UTC(1980, JAN, 1, 0, 0, 1)
             ])
-          expect(converter.unixToAtomic(Date.UTC(1980, JAN, 1, 0, 0, 0)))
+          expect(converter.unixMillisToAtomicMillis(Date.UTC(1980, JAN, 1, 0, 0, 0)))
             .toBe(Date.UTC(1980, JAN, 1, 0, 0, 1))
-          expect(converter.atomicToUnix(Date.UTC(1980, JAN, 1, 0, 0, 0)))
+          expect(converter.atomicMillisToUnixMillis(Date.UTC(1980, JAN, 1, 0, 0, 0)))
             .toBe(Date.UTC(1980, JAN, 1, 0, 0, 0))
-          expect(converter.atomicToUnix(Date.UTC(1980, JAN, 1, 0, 0, 1)))
+          expect(converter.atomicMillisToUnixMillis(Date.UTC(1980, JAN, 1, 0, 0, 1)))
             .toBe(Date.UTC(1980, JAN, 1, 0, 0, 0))
         })
 
         it('final instant of the Unix time discontinuity: one Unix time is two TAI times', () => {
-          expect(converter.unixToAtomic(Date.UTC(1980, JAN, 1, 0, 0, 0, 999), { array: true }))
+          expect(converter.unixMillisToAtomicMillis(Date.UTC(1980, JAN, 1, 0, 0, 0, 999), { array: true }))
             .toEqual([
               Date.UTC(1980, JAN, 1, 0, 0, 0, 999),
               Date.UTC(1980, JAN, 1, 0, 0, 1, 999)
             ])
-          expect(converter.unixToAtomic(Date.UTC(1980, JAN, 1, 0, 0, 0, 999)))
+          expect(converter.unixMillisToAtomicMillis(Date.UTC(1980, JAN, 1, 0, 0, 0, 999)))
             .toBe(Date.UTC(1980, JAN, 1, 0, 0, 1, 999))
-          expect(converter.atomicToUnix(Date.UTC(1980, JAN, 1, 0, 0, 0, 999)))
+          expect(converter.atomicMillisToUnixMillis(Date.UTC(1980, JAN, 1, 0, 0, 0, 999)))
             .toBe(Date.UTC(1980, JAN, 1, 0, 0, 0, 999))
-          expect(converter.atomicToUnix(Date.UTC(1980, JAN, 1, 0, 0, 1, 999)))
+          expect(converter.atomicMillisToUnixMillis(Date.UTC(1980, JAN, 1, 0, 0, 1, 999)))
             .toBe(Date.UTC(1980, JAN, 1, 0, 0, 0, 999))
         })
 
         it('millisecond after discontinuity ends', () => {
-          expect(converter.unixToAtomic(Date.UTC(1980, JAN, 1, 0, 0, 1), { array: true }))
+          expect(converter.unixMillisToAtomicMillis(Date.UTC(1980, JAN, 1, 0, 0, 1), { array: true }))
             .toEqual([
               Date.UTC(1980, JAN, 1, 0, 0, 2)
             ])
-          expect(converter.unixToAtomic(Date.UTC(1980, JAN, 1, 0, 0, 1)))
+          expect(converter.unixMillisToAtomicMillis(Date.UTC(1980, JAN, 1, 0, 0, 1)))
             .toBe(Date.UTC(1980, JAN, 1, 0, 0, 2))
-          expect(converter.atomicToUnix(Date.UTC(1980, JAN, 1, 0, 0, 2)))
+          expect(converter.atomicMillisToUnixMillis(Date.UTC(1980, JAN, 1, 0, 0, 2)))
             .toBe(Date.UTC(1980, JAN, 1, 0, 0, 1))
         })
       })
 
       describe('conversions grouped by method', () => {
-        it('unixToAtomic (array mode)', () => {
-          expect(converter.unixToAtomic(0, { array: true })).toEqual([0])
-          expect(converter.unixToAtomic(Date.UTC(1979, DEC, 31, 23, 59, 59, 999), { array: true }))
+        it('unixMillisToAtomicMillis (array mode)', () => {
+          expect(converter.unixMillisToAtomicMillis(0, { array: true })).toEqual([0])
+          expect(converter.unixMillisToAtomicMillis(Date.UTC(1979, DEC, 31, 23, 59, 59, 999), { array: true }))
             .toEqual([
               Date.UTC(1979, DEC, 31, 23, 59, 59, 999)
             ])
-          expect(converter.unixToAtomic(Date.UTC(1980, JAN, 1, 0, 0, 0), { array: true }))
+          expect(converter.unixMillisToAtomicMillis(Date.UTC(1980, JAN, 1, 0, 0, 0), { array: true }))
             .toEqual([
               Date.UTC(1980, JAN, 1, 0, 0, 0),
               Date.UTC(1980, JAN, 1, 0, 0, 1)
             ])
-          expect(converter.unixToAtomic(Date.UTC(1980, JAN, 1, 0, 0, 0, 999), { array: true }))
+          expect(converter.unixMillisToAtomicMillis(Date.UTC(1980, JAN, 1, 0, 0, 0, 999), { array: true }))
             .toEqual([
               Date.UTC(1980, JAN, 1, 0, 0, 0, 999),
               Date.UTC(1980, JAN, 1, 0, 0, 1, 999)
             ])
-          expect(converter.unixToAtomic(Date.UTC(1980, JAN, 1, 0, 0, 1), { array: true }))
+          expect(converter.unixMillisToAtomicMillis(Date.UTC(1980, JAN, 1, 0, 0, 1), { array: true }))
             .toEqual([
               Date.UTC(1980, JAN, 1, 0, 0, 2)
             ])
         })
 
-        it('unixToAtomic', () => {
-          expect(converter.unixToAtomic(0)).toBe(0)
-          expect(converter.unixToAtomic(Date.UTC(1979, DEC, 31, 23, 59, 59, 999)))
+        it('unixMillisToAtomicMillis', () => {
+          expect(converter.unixMillisToAtomicMillis(0)).toBe(0)
+          expect(converter.unixMillisToAtomicMillis(Date.UTC(1979, DEC, 31, 23, 59, 59, 999)))
             .toBe(Date.UTC(1979, DEC, 31, 23, 59, 59, 999))
-          expect(converter.unixToAtomic(Date.UTC(1980, JAN, 1, 0, 0, 0)))
+          expect(converter.unixMillisToAtomicMillis(Date.UTC(1980, JAN, 1, 0, 0, 0)))
             .toBe(Date.UTC(1980, JAN, 1, 0, 0, 1))
-          expect(converter.unixToAtomic(Date.UTC(1980, JAN, 1, 0, 0, 0, 999)))
+          expect(converter.unixMillisToAtomicMillis(Date.UTC(1980, JAN, 1, 0, 0, 0, 999)))
             .toBe(Date.UTC(1980, JAN, 1, 0, 0, 1, 999))
-          expect(converter.unixToAtomic(Date.UTC(1980, JAN, 1, 0, 0, 1)))
+          expect(converter.unixMillisToAtomicMillis(Date.UTC(1980, JAN, 1, 0, 0, 1)))
             .toBe(Date.UTC(1980, JAN, 1, 0, 0, 2))
         })
 
-        it('atomicToUnix', () => {
-          expect(converter.atomicToUnix(0)).toBe(0)
-          expect(converter.atomicToUnix(Date.UTC(1979, DEC, 31, 23, 59, 59, 999)))
+        it('atomicMillisToUnixMillis', () => {
+          expect(converter.atomicMillisToUnixMillis(0)).toBe(0)
+          expect(converter.atomicMillisToUnixMillis(Date.UTC(1979, DEC, 31, 23, 59, 59, 999)))
             .toBe(Date.UTC(1979, DEC, 31, 23, 59, 59, 999))
-          expect(converter.atomicToUnix(Date.UTC(1980, JAN, 1, 0, 0, 0)))
+          expect(converter.atomicMillisToUnixMillis(Date.UTC(1980, JAN, 1, 0, 0, 0)))
             .toBe(Date.UTC(1980, JAN, 1, 0, 0, 0))
-          expect(converter.atomicToUnix(Date.UTC(1980, JAN, 1, 0, 0, 0, 999)))
+          expect(converter.atomicMillisToUnixMillis(Date.UTC(1980, JAN, 1, 0, 0, 0, 999)))
             .toBe(Date.UTC(1980, JAN, 1, 0, 0, 0, 999))
-          expect(converter.atomicToUnix(Date.UTC(1980, JAN, 1, 0, 0, 1)))
+          expect(converter.atomicMillisToUnixMillis(Date.UTC(1980, JAN, 1, 0, 0, 1)))
             .toBe(Date.UTC(1980, JAN, 1, 0, 0, 0))
-          expect(converter.atomicToUnix(Date.UTC(1980, JAN, 1, 0, 0, 1, 999)))
+          expect(converter.atomicMillisToUnixMillis(Date.UTC(1980, JAN, 1, 0, 0, 1, 999)))
             .toBe(Date.UTC(1980, JAN, 1, 0, 0, 0, 999))
-          expect(converter.atomicToUnix(Date.UTC(1980, JAN, 1, 0, 0, 2)))
+          expect(converter.atomicMillisToUnixMillis(Date.UTC(1980, JAN, 1, 0, 0, 2)))
             .toBe(Date.UTC(1980, JAN, 1, 0, 0, 1))
         })
       })
@@ -198,69 +213,69 @@ describe('Converter', () => {
 
       describe('conversions grouped by instant', () => {
         it('start of time', () => {
-          expect(converter.unixToAtomic(0)).toBe(0)
-          expect(converter.atomicToUnix(0)).toBe(0)
+          expect(converter.unixMillisToAtomicMillis(0)).toBe(0)
+          expect(converter.atomicMillisToUnixMillis(0)).toBe(0)
         })
 
         it('millisecond before inserted leap second discontinuity begins', () => {
-          expect(converter.unixToAtomic(Date.UTC(1979, DEC, 31, 23, 59, 59, 999)))
+          expect(converter.unixMillisToAtomicMillis(Date.UTC(1979, DEC, 31, 23, 59, 59, 999)))
             .toBe(Date.UTC(1979, DEC, 31, 23, 59, 59, 999))
-          expect(converter.atomicToUnix(Date.UTC(1979, DEC, 31, 23, 59, 59, 999)))
+          expect(converter.atomicMillisToUnixMillis(Date.UTC(1979, DEC, 31, 23, 59, 59, 999)))
             .toBe(Date.UTC(1979, DEC, 31, 23, 59, 59, 999))
         })
 
         it('first instant of the Unix time discontinuity: one Unix time is two TAI times', () => {
-          expect(converter.unixToAtomic(Date.UTC(1980, JAN, 1, 0, 0, 0)))
+          expect(converter.unixMillisToAtomicMillis(Date.UTC(1980, JAN, 1, 0, 0, 0)))
             .toBe(Date.UTC(1980, JAN, 1, 0, 0, 1))
-          expect(converter.atomicToUnix(Date.UTC(1980, JAN, 1, 0, 0, 0)))
+          expect(converter.atomicMillisToUnixMillis(Date.UTC(1980, JAN, 1, 0, 0, 0)))
             .toBe(NaN)
-          expect(converter.atomicToUnix(Date.UTC(1980, JAN, 1, 0, 0, 1)))
+          expect(converter.atomicMillisToUnixMillis(Date.UTC(1980, JAN, 1, 0, 0, 1)))
             .toBe(Date.UTC(1980, JAN, 1, 0, 0, 0))
         })
 
         it('final instant of the Unix time discontinuity: one Unix time is two TAI times', () => {
-          expect(converter.unixToAtomic(Date.UTC(1980, JAN, 1, 0, 0, 0, 999)))
+          expect(converter.unixMillisToAtomicMillis(Date.UTC(1980, JAN, 1, 0, 0, 0, 999)))
             .toBe(Date.UTC(1980, JAN, 1, 0, 0, 1, 999))
-          expect(converter.atomicToUnix(Date.UTC(1980, JAN, 1, 0, 0, 0, 999)))
+          expect(converter.atomicMillisToUnixMillis(Date.UTC(1980, JAN, 1, 0, 0, 0, 999)))
             .toBe(NaN)
-          expect(converter.atomicToUnix(Date.UTC(1980, JAN, 1, 0, 0, 1, 999)))
+          expect(converter.atomicMillisToUnixMillis(Date.UTC(1980, JAN, 1, 0, 0, 1, 999)))
             .toBe(Date.UTC(1980, JAN, 1, 0, 0, 0, 999))
         })
 
         it('millisecond after discontinuity ends', () => {
-          expect(converter.unixToAtomic(Date.UTC(1980, JAN, 1, 0, 0, 1)))
+          expect(converter.unixMillisToAtomicMillis(Date.UTC(1980, JAN, 1, 0, 0, 1)))
             .toBe(Date.UTC(1980, JAN, 1, 0, 0, 2))
-          expect(converter.atomicToUnix(Date.UTC(1980, JAN, 1, 0, 0, 2)))
+          expect(converter.atomicMillisToUnixMillis(Date.UTC(1980, JAN, 1, 0, 0, 2)))
             .toBe(Date.UTC(1980, JAN, 1, 0, 0, 1))
         })
       })
 
       describe('conversions grouped by method', () => {
-        it('unixToAtomic', () => {
-          expect(converter.unixToAtomic(0)).toBe(0)
-          expect(converter.unixToAtomic(Date.UTC(1979, DEC, 31, 23, 59, 59, 999)))
+        it('unixMillisToAtomicMillis', () => {
+          expect(converter.unixMillisToAtomicMillis(0)).toBe(0)
+          expect(converter.unixMillisToAtomicMillis(Date.UTC(1979, DEC, 31, 23, 59, 59, 999)))
             .toBe(Date.UTC(1979, DEC, 31, 23, 59, 59, 999))
-          expect(converter.unixToAtomic(Date.UTC(1980, JAN, 1, 0, 0, 0)))
+          expect(converter.unixMillisToAtomicMillis(Date.UTC(1980, JAN, 1, 0, 0, 0)))
             .toBe(Date.UTC(1980, JAN, 1, 0, 0, 1))
-          expect(converter.unixToAtomic(Date.UTC(1980, JAN, 1, 0, 0, 0, 999)))
+          expect(converter.unixMillisToAtomicMillis(Date.UTC(1980, JAN, 1, 0, 0, 0, 999)))
             .toBe(Date.UTC(1980, JAN, 1, 0, 0, 1, 999))
-          expect(converter.unixToAtomic(Date.UTC(1980, JAN, 1, 0, 0, 1)))
+          expect(converter.unixMillisToAtomicMillis(Date.UTC(1980, JAN, 1, 0, 0, 1)))
             .toBe(Date.UTC(1980, JAN, 1, 0, 0, 2))
         })
 
-        it('atomicToUnix', () => {
-          expect(converter.atomicToUnix(0)).toBe(0)
-          expect(converter.atomicToUnix(Date.UTC(1979, DEC, 31, 23, 59, 59, 999)))
+        it('atomicMillisToUnixMillis', () => {
+          expect(converter.atomicMillisToUnixMillis(0)).toBe(0)
+          expect(converter.atomicMillisToUnixMillis(Date.UTC(1979, DEC, 31, 23, 59, 59, 999)))
             .toBe(Date.UTC(1979, DEC, 31, 23, 59, 59, 999))
-          expect(converter.atomicToUnix(Date.UTC(1980, JAN, 1, 0, 0, 0)))
+          expect(converter.atomicMillisToUnixMillis(Date.UTC(1980, JAN, 1, 0, 0, 0)))
             .toBe(NaN)
-          expect(converter.atomicToUnix(Date.UTC(1980, JAN, 1, 0, 0, 0, 999)))
+          expect(converter.atomicMillisToUnixMillis(Date.UTC(1980, JAN, 1, 0, 0, 0, 999)))
             .toBe(NaN)
-          expect(converter.atomicToUnix(Date.UTC(1980, JAN, 1, 0, 0, 1)))
+          expect(converter.atomicMillisToUnixMillis(Date.UTC(1980, JAN, 1, 0, 0, 1)))
             .toBe(Date.UTC(1980, JAN, 1, 0, 0, 0))
-          expect(converter.atomicToUnix(Date.UTC(1980, JAN, 1, 0, 0, 1, 999)))
+          expect(converter.atomicMillisToUnixMillis(Date.UTC(1980, JAN, 1, 0, 0, 1, 999)))
             .toBe(Date.UTC(1980, JAN, 1, 0, 0, 0, 999))
-          expect(converter.atomicToUnix(Date.UTC(1980, JAN, 1, 0, 0, 2)))
+          expect(converter.atomicMillisToUnixMillis(Date.UTC(1980, JAN, 1, 0, 0, 2)))
             .toBe(Date.UTC(1980, JAN, 1, 0, 0, 1))
         })
       })
@@ -271,119 +286,119 @@ describe('Converter', () => {
 
       describe('conversions grouped by instant', () => {
         it('start of time', () => {
-          expect(converter.unixToAtomic(0, { range: true })).toEqual([0, 0])
-          expect(converter.unixToAtomic(0)).toBe(0)
-          expect(converter.atomicToUnix(0)).toBe(0)
+          expect(converter.unixMillisToAtomicMillis(0, { range: true })).toEqual([0, 0])
+          expect(converter.unixMillisToAtomicMillis(0)).toBe(0)
+          expect(converter.atomicMillisToUnixMillis(0)).toBe(0)
         })
 
         it('millisecond before inserted leap second discontinuity begins', () => {
-          expect(converter.unixToAtomic(Date.UTC(1979, DEC, 31, 23, 59, 59, 999), { range: true }))
+          expect(converter.unixMillisToAtomicMillis(Date.UTC(1979, DEC, 31, 23, 59, 59, 999), { range: true }))
             .toEqual([
               Date.UTC(1979, DEC, 31, 23, 59, 59, 999),
               Date.UTC(1979, DEC, 31, 23, 59, 59, 999)
             ])
-          expect(converter.unixToAtomic(Date.UTC(1979, DEC, 31, 23, 59, 59, 999)))
+          expect(converter.unixMillisToAtomicMillis(Date.UTC(1979, DEC, 31, 23, 59, 59, 999)))
             .toBe(Date.UTC(1979, DEC, 31, 23, 59, 59, 999))
-          expect(converter.atomicToUnix(Date.UTC(1979, DEC, 31, 23, 59, 59, 999)))
+          expect(converter.atomicMillisToUnixMillis(Date.UTC(1979, DEC, 31, 23, 59, 59, 999)))
             .toBe(Date.UTC(1979, DEC, 31, 23, 59, 59, 999))
         })
 
         it('first instant of the Unix time discontinuity: one Unix time is two TAI times', () => {
-          expect(converter.unixToAtomic(Date.UTC(1980, JAN, 1, 0, 0, 0), { range: true }))
+          expect(converter.unixMillisToAtomicMillis(Date.UTC(1980, JAN, 1, 0, 0, 0), { range: true }))
             .toEqual([
               Date.UTC(1980, JAN, 1, 0, 0, 0, 0),
               Date.UTC(1980, JAN, 1, 0, 0, 1, 0) // stalled
             ])
-          expect(converter.unixToAtomic(Date.UTC(1980, JAN, 1, 0, 0, 0)))
+          expect(converter.unixMillisToAtomicMillis(Date.UTC(1980, JAN, 1, 0, 0, 0)))
             .toBe(Date.UTC(1980, JAN, 1, 0, 0, 1))
-          expect(converter.atomicToUnix(Date.UTC(1980, JAN, 1, 0, 0, 0)))
+          expect(converter.atomicMillisToUnixMillis(Date.UTC(1980, JAN, 1, 0, 0, 0)))
             .toBe(Date.UTC(1980, JAN, 1, 0, 0, 0))
-          expect(converter.atomicToUnix(Date.UTC(1980, JAN, 1, 0, 0, 1)))
+          expect(converter.atomicMillisToUnixMillis(Date.UTC(1980, JAN, 1, 0, 0, 1)))
             .toBe(Date.UTC(1980, JAN, 1, 0, 0, 0))
         })
 
         it('final instant of the Unix time discontinuity: one Unix time is two TAI times', () => {
-          expect(converter.unixToAtomic(Date.UTC(1980, JAN, 1, 0, 0, 0, 999), { range: true }))
+          expect(converter.unixMillisToAtomicMillis(Date.UTC(1980, JAN, 1, 0, 0, 0, 999), { range: true }))
             .toEqual([
               Date.UTC(1980, JAN, 1, 0, 0, 1, 999),
               Date.UTC(1980, JAN, 1, 0, 0, 1, 999)
             ])
-          expect(converter.unixToAtomic(Date.UTC(1980, JAN, 1, 0, 0, 0, 999)))
+          expect(converter.unixMillisToAtomicMillis(Date.UTC(1980, JAN, 1, 0, 0, 0, 999)))
             .toBe(Date.UTC(1980, JAN, 1, 0, 0, 1, 999))
-          expect(converter.atomicToUnix(Date.UTC(1980, JAN, 1, 0, 0, 0, 999)))
+          expect(converter.atomicMillisToUnixMillis(Date.UTC(1980, JAN, 1, 0, 0, 0, 999)))
             .toBe(Date.UTC(1980, JAN, 1, 0, 0, 0)) // stalled
-          expect(converter.atomicToUnix(Date.UTC(1980, JAN, 1, 0, 0, 1, 999)))
+          expect(converter.atomicMillisToUnixMillis(Date.UTC(1980, JAN, 1, 0, 0, 1, 999)))
             .toBe(Date.UTC(1980, JAN, 1, 0, 0, 0, 999))
         })
 
         it('millisecond after discontinuity ends', () => {
-          expect(converter.unixToAtomic(Date.UTC(1980, JAN, 1, 0, 0, 1, 0), { range: true }))
+          expect(converter.unixMillisToAtomicMillis(Date.UTC(1980, JAN, 1, 0, 0, 1, 0), { range: true }))
             .toEqual([
               Date.UTC(1980, JAN, 1, 0, 0, 2, 0),
               Date.UTC(1980, JAN, 1, 0, 0, 2, 0)
             ])
-          expect(converter.unixToAtomic(Date.UTC(1980, JAN, 1, 0, 0, 1)))
+          expect(converter.unixMillisToAtomicMillis(Date.UTC(1980, JAN, 1, 0, 0, 1)))
             .toBe(Date.UTC(1980, JAN, 1, 0, 0, 2, 0))
-          expect(converter.atomicToUnix(Date.UTC(1980, JAN, 1, 0, 0, 2, 0)))
+          expect(converter.atomicMillisToUnixMillis(Date.UTC(1980, JAN, 1, 0, 0, 2, 0)))
             .toBe(Date.UTC(1980, JAN, 1, 0, 0, 1, 0))
         })
       })
 
       describe('conversions grouped by method', () => {
-        it('unixToAtomic (range mode)', () => {
-          expect(converter.unixToAtomic(0, { range: true })).toEqual([0, 0])
-          expect(converter.unixToAtomic(Date.UTC(1979, DEC, 31, 23, 59, 59, 999), { range: true }))
+        it('unixMillisToAtomicMillis (range mode)', () => {
+          expect(converter.unixMillisToAtomicMillis(0, { range: true })).toEqual([0, 0])
+          expect(converter.unixMillisToAtomicMillis(Date.UTC(1979, DEC, 31, 23, 59, 59, 999), { range: true }))
             .toEqual([
               Date.UTC(1979, DEC, 31, 23, 59, 59, 999),
               Date.UTC(1979, DEC, 31, 23, 59, 59, 999)
             ])
-          expect(converter.unixToAtomic(Date.UTC(1980, JAN, 1, 0, 0, 0, 0), { range: true }))
+          expect(converter.unixMillisToAtomicMillis(Date.UTC(1980, JAN, 1, 0, 0, 0, 0), { range: true }))
             .toEqual([
               Date.UTC(1980, JAN, 1, 0, 0, 0, 0),
               Date.UTC(1980, JAN, 1, 0, 0, 1, 0)
             ])
-          expect(converter.unixToAtomic(Date.UTC(1980, JAN, 1, 0, 0, 0, 1), { range: true }))
+          expect(converter.unixMillisToAtomicMillis(Date.UTC(1980, JAN, 1, 0, 0, 0, 1), { range: true }))
             .toEqual([
               Date.UTC(1980, JAN, 1, 0, 0, 1, 1),
               Date.UTC(1980, JAN, 1, 0, 0, 1, 1)
             ])
-          expect(converter.unixToAtomic(Date.UTC(1980, JAN, 1, 0, 0, 0, 999), { range: true }))
+          expect(converter.unixMillisToAtomicMillis(Date.UTC(1980, JAN, 1, 0, 0, 0, 999), { range: true }))
             .toEqual([
               Date.UTC(1980, JAN, 1, 0, 0, 1, 999),
               Date.UTC(1980, JAN, 1, 0, 0, 1, 999)
             ])
-          expect(converter.unixToAtomic(Date.UTC(1980, JAN, 1, 0, 0, 1, 0), { range: true }))
+          expect(converter.unixMillisToAtomicMillis(Date.UTC(1980, JAN, 1, 0, 0, 1, 0), { range: true }))
             .toEqual([
               Date.UTC(1980, JAN, 1, 0, 0, 2, 0),
               Date.UTC(1980, JAN, 1, 0, 0, 2, 0)
             ])
         })
 
-        it('unixToAtomic', () => {
-          expect(converter.unixToAtomic(0)).toBe(0)
-          expect(converter.unixToAtomic(Date.UTC(1979, DEC, 31, 23, 59, 59, 999)))
+        it('unixMillisToAtomicMillis', () => {
+          expect(converter.unixMillisToAtomicMillis(0)).toBe(0)
+          expect(converter.unixMillisToAtomicMillis(Date.UTC(1979, DEC, 31, 23, 59, 59, 999)))
             .toBe(Date.UTC(1979, DEC, 31, 23, 59, 59, 999))
-          expect(converter.unixToAtomic(Date.UTC(1980, JAN, 1, 0, 0, 0)))
+          expect(converter.unixMillisToAtomicMillis(Date.UTC(1980, JAN, 1, 0, 0, 0)))
             .toBe(Date.UTC(1980, JAN, 1, 0, 0, 1))
-          expect(converter.unixToAtomic(Date.UTC(1980, JAN, 1, 0, 0, 0, 999)))
+          expect(converter.unixMillisToAtomicMillis(Date.UTC(1980, JAN, 1, 0, 0, 0, 999)))
             .toBe(Date.UTC(1980, JAN, 1, 0, 0, 1, 999))
-          expect(converter.unixToAtomic(Date.UTC(1980, JAN, 1, 0, 0, 1)))
+          expect(converter.unixMillisToAtomicMillis(Date.UTC(1980, JAN, 1, 0, 0, 1)))
             .toBe(Date.UTC(1980, JAN, 1, 0, 0, 2))
         })
 
-        it('atomicToUnix', () => {
-          expect(converter.atomicToUnix(0)).toBe(0)
-          expect(converter.atomicToUnix(Date.UTC(1979, DEC, 31, 23, 59, 59, 999)))
+        it('atomicMillisToUnixMillis', () => {
+          expect(converter.atomicMillisToUnixMillis(0)).toBe(0)
+          expect(converter.atomicMillisToUnixMillis(Date.UTC(1979, DEC, 31, 23, 59, 59, 999)))
             .toBe(Date.UTC(1979, DEC, 31, 23, 59, 59, 999))
-          expect(converter.atomicToUnix(Date.UTC(1980, JAN, 1, 0, 0, 0)))
+          expect(converter.atomicMillisToUnixMillis(Date.UTC(1980, JAN, 1, 0, 0, 0)))
             .toBe(Date.UTC(1980, JAN, 1, 0, 0, 0)) // stalled
-          expect(converter.atomicToUnix(Date.UTC(1980, JAN, 1, 0, 0, 0, 999)))
+          expect(converter.atomicMillisToUnixMillis(Date.UTC(1980, JAN, 1, 0, 0, 0, 999)))
             .toBe(Date.UTC(1980, JAN, 1, 0, 0, 0)) // stalled
-          expect(converter.atomicToUnix(Date.UTC(1980, JAN, 1, 0, 0, 1)))
+          expect(converter.atomicMillisToUnixMillis(Date.UTC(1980, JAN, 1, 0, 0, 1)))
             .toBe(Date.UTC(1980, JAN, 1, 0, 0, 0))
-          expect(converter.atomicToUnix(Date.UTC(1980, JAN, 1, 0, 0, 1, 999)))
+          expect(converter.atomicMillisToUnixMillis(Date.UTC(1980, JAN, 1, 0, 0, 1, 999)))
             .toBe(Date.UTC(1980, JAN, 1, 0, 0, 0, 999))
-          expect(converter.atomicToUnix(Date.UTC(1980, JAN, 1, 0, 0, 2)))
+          expect(converter.atomicMillisToUnixMillis(Date.UTC(1980, JAN, 1, 0, 0, 2)))
             .toBe(Date.UTC(1980, JAN, 1, 0, 0, 1))
         })
       })
@@ -392,35 +407,35 @@ describe('Converter', () => {
     describe('SMEAR', () => {
       const converter = Converter(data, MODELS.SMEAR)
 
-      it('unixToAtomic', () => {
-        expect(converter.unixToAtomic(0)).toBe(0)
-        expect(converter.unixToAtomic(Date.UTC(1979, DEC, 31, 11, 59, 59, 999)))
+      it('unixMillisToAtomicMillis', () => {
+        expect(converter.unixMillisToAtomicMillis(0)).toBe(0)
+        expect(converter.unixMillisToAtomicMillis(Date.UTC(1979, DEC, 31, 11, 59, 59, 999)))
           .toBe(Date.UTC(1979, DEC, 31, 11, 59, 59, 999))
-        expect(converter.unixToAtomic(Date.UTC(1979, DEC, 31, 12, 0, 0, 0)))
+        expect(converter.unixMillisToAtomicMillis(Date.UTC(1979, DEC, 31, 12, 0, 0, 0)))
           .toBe(Date.UTC(1979, DEC, 31, 12, 0, 0, 0))
-        expect(converter.unixToAtomic(Date.UTC(1980, JAN, 1, 0, 0, 0, 0)))
+        expect(converter.unixMillisToAtomicMillis(Date.UTC(1980, JAN, 1, 0, 0, 0, 0)))
           .toBe(Date.UTC(1980, JAN, 1, 0, 0, 0, 500))
-        expect(converter.unixToAtomic(Date.UTC(1980, JAN, 1, 12, 0, 0, 0)))
+        expect(converter.unixMillisToAtomicMillis(Date.UTC(1980, JAN, 1, 12, 0, 0, 0)))
           .toBe(Date.UTC(1980, JAN, 1, 12, 0, 1, 0))
-        expect(converter.unixToAtomic(Date.UTC(1980, JAN, 1, 12, 0, 0, 1)))
+        expect(converter.unixMillisToAtomicMillis(Date.UTC(1980, JAN, 1, 12, 0, 0, 1)))
           .toBe(Date.UTC(1980, JAN, 1, 12, 0, 1, 1))
-        expect(converter.unixToAtomic(Date.UTC(1980, JAN, 1, 12, 0, 1, 0)))
+        expect(converter.unixMillisToAtomicMillis(Date.UTC(1980, JAN, 1, 12, 0, 1, 0)))
           .toBe(Date.UTC(1980, JAN, 1, 12, 0, 2, 0))
       })
 
-      it('atomicToUnix', () => {
-        expect(converter.atomicToUnix(0)).toBe(0)
-        expect(converter.atomicToUnix(Date.UTC(1979, DEC, 31, 11, 59, 59, 999)))
+      it('atomicMillisToUnixMillis', () => {
+        expect(converter.atomicMillisToUnixMillis(0)).toBe(0)
+        expect(converter.atomicMillisToUnixMillis(Date.UTC(1979, DEC, 31, 11, 59, 59, 999)))
           .toBe(Date.UTC(1979, DEC, 31, 11, 59, 59, 999))
-        expect(converter.atomicToUnix(Date.UTC(1979, DEC, 31, 12, 0, 0, 0)))
+        expect(converter.atomicMillisToUnixMillis(Date.UTC(1979, DEC, 31, 12, 0, 0, 0)))
           .toBe(Date.UTC(1979, DEC, 31, 12, 0, 0, 0))
-        expect(converter.atomicToUnix(Date.UTC(1980, JAN, 1, 0, 0, 0, 500)))
+        expect(converter.atomicMillisToUnixMillis(Date.UTC(1980, JAN, 1, 0, 0, 0, 500)))
           .toBe(Date.UTC(1980, JAN, 1, 0, 0, 0, 0))
-        expect(converter.atomicToUnix(Date.UTC(1980, JAN, 1, 12, 0, 1, 0)))
+        expect(converter.atomicMillisToUnixMillis(Date.UTC(1980, JAN, 1, 12, 0, 1, 0)))
           .toBe(Date.UTC(1980, JAN, 1, 12, 0, 0, 0))
-        expect(converter.atomicToUnix(Date.UTC(1980, JAN, 1, 12, 0, 1, 1)))
+        expect(converter.atomicMillisToUnixMillis(Date.UTC(1980, JAN, 1, 12, 0, 1, 1)))
           .toBe(Date.UTC(1980, JAN, 1, 12, 0, 0, 1))
-        expect(converter.atomicToUnix(Date.UTC(1980, JAN, 1, 12, 0, 2, 0)))
+        expect(converter.atomicMillisToUnixMillis(Date.UTC(1980, JAN, 1, 12, 0, 2, 0)))
           .toBe(Date.UTC(1980, JAN, 1, 12, 0, 1, 0))
       })
     })
@@ -437,87 +452,87 @@ describe('Converter', () => {
 
       describe('conversions grouped by instant', () => {
         it('start of time', () => {
-          expect(converter.unixToAtomic(0, { array: true })).toEqual([0])
-          expect(converter.unixToAtomic(0)).toEqual(0)
-          expect(converter.atomicToUnix(0)).toBe(0)
+          expect(converter.unixMillisToAtomicMillis(0, { array: true })).toEqual([0])
+          expect(converter.unixMillisToAtomicMillis(0)).toEqual(0)
+          expect(converter.atomicMillisToUnixMillis(0)).toBe(0)
         })
 
         it('millisecond before removed leap second discontinuity begins', () => {
-          expect(converter.unixToAtomic(Date.UTC(1979, DEC, 31, 23, 59, 58, 999), { array: true }))
+          expect(converter.unixMillisToAtomicMillis(Date.UTC(1979, DEC, 31, 23, 59, 58, 999), { array: true }))
             .toEqual([
               Date.UTC(1979, DEC, 31, 23, 59, 58, 999)
             ])
-          expect(converter.unixToAtomic(Date.UTC(1979, DEC, 31, 23, 59, 58, 999)))
+          expect(converter.unixMillisToAtomicMillis(Date.UTC(1979, DEC, 31, 23, 59, 58, 999)))
             .toBe(Date.UTC(1979, DEC, 31, 23, 59, 58, 999))
-          expect(converter.atomicToUnix(Date.UTC(1979, DEC, 31, 23, 59, 58, 999)))
+          expect(converter.atomicMillisToUnixMillis(Date.UTC(1979, DEC, 31, 23, 59, 58, 999)))
             .toBe(Date.UTC(1979, DEC, 31, 23, 59, 58, 999))
         })
 
         it('first instant of the Unix time discontinuity: one Unix time is zero TAI times', () => {
-          expect(converter.unixToAtomic(Date.UTC(1979, DEC, 31, 23, 59, 59, 0), { array: true }))
+          expect(converter.unixMillisToAtomicMillis(Date.UTC(1979, DEC, 31, 23, 59, 59, 0), { array: true }))
             .toEqual([])
-          expect(converter.unixToAtomic(Date.UTC(1979, DEC, 31, 23, 59, 59, 0)))
+          expect(converter.unixMillisToAtomicMillis(Date.UTC(1979, DEC, 31, 23, 59, 59, 0)))
             .toBe(NaN)
-          // no atomicToUnix can return the value above
+          // no atomicMillisToUnixMillis can return the value above
         })
 
         it('final instant of the Unix time discontinuity: one Unix time is zero TAI times', () => {
-          expect(converter.unixToAtomic(Date.UTC(1979, DEC, 31, 23, 59, 59, 999), { array: true }))
+          expect(converter.unixMillisToAtomicMillis(Date.UTC(1979, DEC, 31, 23, 59, 59, 999), { array: true }))
             .toEqual([])
-          expect(converter.unixToAtomic(Date.UTC(1979, DEC, 31, 23, 59, 59, 999)))
+          expect(converter.unixMillisToAtomicMillis(Date.UTC(1979, DEC, 31, 23, 59, 59, 999)))
             .toBe(NaN)
-          // no atomicToUnix can return the value above
+          // no atomicMillisToUnixMillis can return the value above
         })
 
         it('millisecond after discontinuity ends', () => {
-          expect(converter.unixToAtomic(Date.UTC(1980, JAN, 1, 0, 0, 0), { array: true }))
+          expect(converter.unixMillisToAtomicMillis(Date.UTC(1980, JAN, 1, 0, 0, 0), { array: true }))
             .toEqual([
               Date.UTC(1979, DEC, 31, 23, 59, 59, 0)
             ])
-          expect(converter.unixToAtomic(Date.UTC(1980, JAN, 1, 0, 0, 0)))
+          expect(converter.unixMillisToAtomicMillis(Date.UTC(1980, JAN, 1, 0, 0, 0)))
             .toBe(Date.UTC(1979, DEC, 31, 23, 59, 59, 0))
-          expect(converter.atomicToUnix(Date.UTC(1979, DEC, 31, 23, 59, 59, 0), { array: true }))
+          expect(converter.atomicMillisToUnixMillis(Date.UTC(1979, DEC, 31, 23, 59, 59, 0), { array: true }))
             .toBe(Date.UTC(1980, JAN, 1, 0, 0, 0))
         })
       })
 
       describe('conversions grouped by method', () => {
-        it('unixToAtomic (array mode)', () => {
-          expect(converter.unixToAtomic(0, { array: true }))
+        it('unixMillisToAtomicMillis (array mode)', () => {
+          expect(converter.unixMillisToAtomicMillis(0, { array: true }))
             .toEqual([0])
-          expect(converter.unixToAtomic(Date.UTC(1979, DEC, 31, 23, 59, 58, 999), { array: true }))
+          expect(converter.unixMillisToAtomicMillis(Date.UTC(1979, DEC, 31, 23, 59, 58, 999), { array: true }))
             .toEqual([
               Date.UTC(1979, DEC, 31, 23, 59, 58, 999)
             ])
-          expect(converter.unixToAtomic(Date.UTC(1979, DEC, 31, 23, 59, 59, 0), { array: true }))
+          expect(converter.unixMillisToAtomicMillis(Date.UTC(1979, DEC, 31, 23, 59, 59, 0), { array: true }))
             .toEqual([])
-          expect(converter.unixToAtomic(Date.UTC(1979, DEC, 31, 23, 59, 59, 999), { array: true }))
+          expect(converter.unixMillisToAtomicMillis(Date.UTC(1979, DEC, 31, 23, 59, 59, 999), { array: true }))
             .toEqual([])
-          expect(converter.unixToAtomic(Date.UTC(1980, JAN, 1, 0, 0, 0), { array: true }))
+          expect(converter.unixMillisToAtomicMillis(Date.UTC(1980, JAN, 1, 0, 0, 0), { array: true }))
             .toEqual([
               Date.UTC(1979, DEC, 31, 23, 59, 59, 0)
             ])
         })
 
-        it('unixToAtomic', () => {
-          expect(converter.unixToAtomic(0))
+        it('unixMillisToAtomicMillis', () => {
+          expect(converter.unixMillisToAtomicMillis(0))
             .toBe(0)
-          expect(converter.unixToAtomic(Date.UTC(1979, DEC, 31, 23, 59, 58, 999)))
+          expect(converter.unixMillisToAtomicMillis(Date.UTC(1979, DEC, 31, 23, 59, 58, 999)))
             .toBe(Date.UTC(1979, DEC, 31, 23, 59, 58, 999))
-          expect(converter.unixToAtomic(Date.UTC(1979, DEC, 31, 23, 59, 59, 0)))
+          expect(converter.unixMillisToAtomicMillis(Date.UTC(1979, DEC, 31, 23, 59, 59, 0)))
             .toBe(NaN)
-          expect(converter.unixToAtomic(Date.UTC(1979, DEC, 31, 23, 59, 59, 999)))
+          expect(converter.unixMillisToAtomicMillis(Date.UTC(1979, DEC, 31, 23, 59, 59, 999)))
             .toBe(NaN)
-          expect(converter.unixToAtomic(Date.UTC(1980, JAN, 1, 0, 0, 0)))
+          expect(converter.unixMillisToAtomicMillis(Date.UTC(1980, JAN, 1, 0, 0, 0)))
             .toBe(Date.UTC(1979, DEC, 31, 23, 59, 59, 0))
         })
 
-        it('atomicToUnix', () => {
-          expect(converter.atomicToUnix(0))
+        it('atomicMillisToUnixMillis', () => {
+          expect(converter.atomicMillisToUnixMillis(0))
             .toBe(0)
-          expect(converter.atomicToUnix(Date.UTC(1979, DEC, 31, 23, 59, 58, 999)))
+          expect(converter.atomicMillisToUnixMillis(Date.UTC(1979, DEC, 31, 23, 59, 58, 999)))
             .toBe(Date.UTC(1979, DEC, 31, 23, 59, 58, 999))
-          expect(converter.atomicToUnix(Date.UTC(1979, DEC, 31, 23, 59, 59, 0)))
+          expect(converter.atomicMillisToUnixMillis(Date.UTC(1979, DEC, 31, 23, 59, 59, 0)))
             .toBe(Date.UTC(1980, JAN, 1, 0, 0, 0))
         })
       })
@@ -528,57 +543,57 @@ describe('Converter', () => {
 
       describe('conversions grouped by instant', () => {
         it('start of time', () => {
-          expect(converter.unixToAtomic(0)).toEqual(0)
-          expect(converter.atomicToUnix(0)).toBe(0)
+          expect(converter.unixMillisToAtomicMillis(0)).toEqual(0)
+          expect(converter.atomicMillisToUnixMillis(0)).toBe(0)
         })
 
         it('millisecond before removed leap second discontinuity begins', () => {
-          expect(converter.unixToAtomic(Date.UTC(1979, DEC, 31, 23, 59, 58, 999)))
+          expect(converter.unixMillisToAtomicMillis(Date.UTC(1979, DEC, 31, 23, 59, 58, 999)))
             .toBe(Date.UTC(1979, DEC, 31, 23, 59, 58, 999))
-          expect(converter.atomicToUnix(Date.UTC(1979, DEC, 31, 23, 59, 58, 999)))
+          expect(converter.atomicMillisToUnixMillis(Date.UTC(1979, DEC, 31, 23, 59, 58, 999)))
             .toBe(Date.UTC(1979, DEC, 31, 23, 59, 58, 999))
         })
 
         it('first instant of the Unix time discontinuity: one Unix time is zero TAI times', () => {
-          expect(converter.unixToAtomic(Date.UTC(1979, DEC, 31, 23, 59, 59, 0)))
+          expect(converter.unixMillisToAtomicMillis(Date.UTC(1979, DEC, 31, 23, 59, 59, 0)))
             .toBe(NaN)
-          // no atomicToUnix can return the value above
+          // no atomicMillisToUnixMillis can return the value above
         })
 
         it('final instant of the Unix time discontinuity: one Unix time is zero TAI times', () => {
-          expect(converter.unixToAtomic(Date.UTC(1979, DEC, 31, 23, 59, 59, 999)))
+          expect(converter.unixMillisToAtomicMillis(Date.UTC(1979, DEC, 31, 23, 59, 59, 999)))
             .toBe(NaN)
-          // no atomicToUnix can return the value above
+          // no atomicMillisToUnixMillis can return the value above
         })
 
         it('millisecond after discontinuity ends', () => {
-          expect(converter.unixToAtomic(Date.UTC(1980, JAN, 1, 0, 0, 0)))
+          expect(converter.unixMillisToAtomicMillis(Date.UTC(1980, JAN, 1, 0, 0, 0)))
             .toBe(Date.UTC(1979, DEC, 31, 23, 59, 59, 0))
-          expect(converter.atomicToUnix(Date.UTC(1979, DEC, 31, 23, 59, 59, 0)))
+          expect(converter.atomicMillisToUnixMillis(Date.UTC(1979, DEC, 31, 23, 59, 59, 0)))
             .toBe(Date.UTC(1980, JAN, 1, 0, 0, 0))
         })
       })
 
       describe('conversions grouped by method', () => {
-        it('unixToAtomic', () => {
-          expect(converter.unixToAtomic(0))
+        it('unixMillisToAtomicMillis', () => {
+          expect(converter.unixMillisToAtomicMillis(0))
             .toBe(0)
-          expect(converter.unixToAtomic(Date.UTC(1979, DEC, 31, 23, 59, 58, 999)))
+          expect(converter.unixMillisToAtomicMillis(Date.UTC(1979, DEC, 31, 23, 59, 58, 999)))
             .toBe(Date.UTC(1979, DEC, 31, 23, 59, 58, 999))
-          expect(converter.unixToAtomic(Date.UTC(1979, DEC, 31, 23, 59, 59, 0)))
+          expect(converter.unixMillisToAtomicMillis(Date.UTC(1979, DEC, 31, 23, 59, 59, 0)))
             .toBe(NaN)
-          expect(converter.unixToAtomic(Date.UTC(1979, DEC, 31, 23, 59, 59, 999)))
+          expect(converter.unixMillisToAtomicMillis(Date.UTC(1979, DEC, 31, 23, 59, 59, 999)))
             .toBe(NaN)
-          expect(converter.unixToAtomic(Date.UTC(1980, JAN, 1, 0, 0, 0)))
+          expect(converter.unixMillisToAtomicMillis(Date.UTC(1980, JAN, 1, 0, 0, 0)))
             .toBe(Date.UTC(1979, DEC, 31, 23, 59, 59, 0))
         })
 
-        it('atomicToUnix', () => {
-          expect(converter.atomicToUnix(0))
+        it('atomicMillisToUnixMillis', () => {
+          expect(converter.atomicMillisToUnixMillis(0))
             .toBe(0)
-          expect(converter.atomicToUnix(Date.UTC(1979, DEC, 31, 23, 59, 58, 999)))
+          expect(converter.atomicMillisToUnixMillis(Date.UTC(1979, DEC, 31, 23, 59, 58, 999)))
             .toBe(Date.UTC(1979, DEC, 31, 23, 59, 58, 999))
-          expect(converter.atomicToUnix(Date.UTC(1979, DEC, 31, 23, 59, 59, 0)))
+          expect(converter.atomicMillisToUnixMillis(Date.UTC(1979, DEC, 31, 23, 59, 59, 0)))
             .toBe(Date.UTC(1980, JAN, 1, 0, 0, 0))
         })
       })
@@ -589,91 +604,91 @@ describe('Converter', () => {
 
       describe('conversions grouped by instant', () => {
         it('start of time', () => {
-          expect(converter.unixToAtomic(0, { range: true })).toEqual([0, 0])
-          expect(converter.unixToAtomic(0)).toBe(0)
-          expect(converter.atomicToUnix(0)).toBe(0)
+          expect(converter.unixMillisToAtomicMillis(0, { range: true })).toEqual([0, 0])
+          expect(converter.unixMillisToAtomicMillis(0)).toBe(0)
+          expect(converter.atomicMillisToUnixMillis(0)).toBe(0)
         })
 
         it('millisecond before removed leap second discontinuity begins', () => {
-          expect(converter.unixToAtomic(Date.UTC(1979, DEC, 31, 23, 59, 58, 999), { range: true }))
+          expect(converter.unixMillisToAtomicMillis(Date.UTC(1979, DEC, 31, 23, 59, 58, 999), { range: true }))
             .toEqual([
               Date.UTC(1979, DEC, 31, 23, 59, 58, 999),
               Date.UTC(1979, DEC, 31, 23, 59, 58, 999)
             ])
-          expect(converter.unixToAtomic(Date.UTC(1979, DEC, 31, 23, 59, 58, 999)))
+          expect(converter.unixMillisToAtomicMillis(Date.UTC(1979, DEC, 31, 23, 59, 58, 999)))
             .toBe(Date.UTC(1979, DEC, 31, 23, 59, 58, 999))
-          expect(converter.atomicToUnix(Date.UTC(1979, DEC, 31, 23, 59, 58, 999)))
+          expect(converter.atomicMillisToUnixMillis(Date.UTC(1979, DEC, 31, 23, 59, 58, 999)))
             .toBe(Date.UTC(1979, DEC, 31, 23, 59, 58, 999))
         })
 
         it('first instant of the Unix time discontinuity: one Unix time is zero TAI times', () => {
-          expect(converter.unixToAtomic(Date.UTC(1979, DEC, 31, 23, 59, 59, 0), { range: true }))
+          expect(converter.unixMillisToAtomicMillis(Date.UTC(1979, DEC, 31, 23, 59, 59, 0), { range: true }))
             .toEqual([NaN, NaN])
-          expect(converter.unixToAtomic(Date.UTC(1979, DEC, 31, 23, 59, 59, 0)))
+          expect(converter.unixMillisToAtomicMillis(Date.UTC(1979, DEC, 31, 23, 59, 59, 0)))
             .toBe(NaN)
-          // no atomicToUnix can return the value above
+          // no atomicMillisToUnixMillis can return the value above
         })
 
         it('final instant of the Unix time discontinuity: one Unix time is zero TAI times', () => {
-          expect(converter.unixToAtomic(Date.UTC(1979, DEC, 31, 23, 59, 59, 999), { range: true }))
+          expect(converter.unixMillisToAtomicMillis(Date.UTC(1979, DEC, 31, 23, 59, 59, 999), { range: true }))
             .toEqual([NaN, NaN])
-          expect(converter.unixToAtomic(Date.UTC(1979, DEC, 31, 23, 59, 59, 999)))
+          expect(converter.unixMillisToAtomicMillis(Date.UTC(1979, DEC, 31, 23, 59, 59, 999)))
             .toBe(NaN)
-          // no atomicToUnix can return the value above
+          // no atomicMillisToUnixMillis can return the value above
         })
 
         it('millisecond after discontinuity ends', () => {
-          expect(converter.unixToAtomic(Date.UTC(1980, JAN, 1, 0, 0, 0), { range: true }))
+          expect(converter.unixMillisToAtomicMillis(Date.UTC(1980, JAN, 1, 0, 0, 0), { range: true }))
             .toEqual([
               Date.UTC(1979, DEC, 31, 23, 59, 59, 0),
               Date.UTC(1979, DEC, 31, 23, 59, 59, 0)
             ])
-          expect(converter.unixToAtomic(Date.UTC(1980, JAN, 1, 0, 0, 0)))
+          expect(converter.unixMillisToAtomicMillis(Date.UTC(1980, JAN, 1, 0, 0, 0)))
             .toBe(Date.UTC(1979, DEC, 31, 23, 59, 59, 0))
-          expect(converter.atomicToUnix(Date.UTC(1979, DEC, 31, 23, 59, 59, 0)))
+          expect(converter.atomicMillisToUnixMillis(Date.UTC(1979, DEC, 31, 23, 59, 59, 0)))
             .toBe(Date.UTC(1980, JAN, 1, 0, 0, 0))
         })
       })
 
       describe('conversions grouped by method', () => {
-        it('unixToAtomic (range mode)', () => {
-          expect(converter.unixToAtomic(0, { range: true }))
+        it('unixMillisToAtomicMillis (range mode)', () => {
+          expect(converter.unixMillisToAtomicMillis(0, { range: true }))
             .toEqual([0, 0])
-          expect(converter.unixToAtomic(Date.UTC(1979, DEC, 31, 23, 59, 58, 999), { range: true }))
+          expect(converter.unixMillisToAtomicMillis(Date.UTC(1979, DEC, 31, 23, 59, 58, 999), { range: true }))
             .toEqual([
               Date.UTC(1979, DEC, 31, 23, 59, 58, 999),
               Date.UTC(1979, DEC, 31, 23, 59, 58, 999)
             ])
-          expect(converter.unixToAtomic(Date.UTC(1979, DEC, 31, 23, 59, 59, 0), { range: true }))
+          expect(converter.unixMillisToAtomicMillis(Date.UTC(1979, DEC, 31, 23, 59, 59, 0), { range: true }))
             .toEqual([NaN, NaN])
-          expect(converter.unixToAtomic(Date.UTC(1979, DEC, 31, 23, 59, 59, 999), { range: true }))
+          expect(converter.unixMillisToAtomicMillis(Date.UTC(1979, DEC, 31, 23, 59, 59, 999), { range: true }))
             .toEqual([NaN, NaN])
-          expect(converter.unixToAtomic(Date.UTC(1980, JAN, 1, 0, 0, 0), { range: true }))
+          expect(converter.unixMillisToAtomicMillis(Date.UTC(1980, JAN, 1, 0, 0, 0), { range: true }))
             .toEqual([
               Date.UTC(1979, DEC, 31, 23, 59, 59, 0),
               Date.UTC(1979, DEC, 31, 23, 59, 59, 0)
             ])
         })
 
-        it('unixToAtomic', () => {
-          expect(converter.unixToAtomic(0))
+        it('unixMillisToAtomicMillis', () => {
+          expect(converter.unixMillisToAtomicMillis(0))
             .toBe(0)
-          expect(converter.unixToAtomic(Date.UTC(1979, DEC, 31, 23, 59, 58, 999)))
+          expect(converter.unixMillisToAtomicMillis(Date.UTC(1979, DEC, 31, 23, 59, 58, 999)))
             .toBe(Date.UTC(1979, DEC, 31, 23, 59, 58, 999))
-          expect(converter.unixToAtomic(Date.UTC(1979, DEC, 31, 23, 59, 59, 0)))
+          expect(converter.unixMillisToAtomicMillis(Date.UTC(1979, DEC, 31, 23, 59, 59, 0)))
             .toBe(NaN)
-          expect(converter.unixToAtomic(Date.UTC(1979, DEC, 31, 23, 59, 59, 999)))
+          expect(converter.unixMillisToAtomicMillis(Date.UTC(1979, DEC, 31, 23, 59, 59, 999)))
             .toBe(NaN)
-          expect(converter.unixToAtomic(Date.UTC(1980, JAN, 1, 0, 0, 0)))
+          expect(converter.unixMillisToAtomicMillis(Date.UTC(1980, JAN, 1, 0, 0, 0)))
             .toBe(Date.UTC(1979, DEC, 31, 23, 59, 59, 0))
         })
 
-        it('atomicToUnix', () => {
-          expect(converter.atomicToUnix(0))
+        it('atomicMillisToUnixMillis', () => {
+          expect(converter.atomicMillisToUnixMillis(0))
             .toBe(0)
-          expect(converter.atomicToUnix(Date.UTC(1979, DEC, 31, 23, 59, 58, 999)))
+          expect(converter.atomicMillisToUnixMillis(Date.UTC(1979, DEC, 31, 23, 59, 58, 999)))
             .toBe(Date.UTC(1979, DEC, 31, 23, 59, 58, 999))
-          expect(converter.atomicToUnix(Date.UTC(1979, DEC, 31, 23, 59, 59, 0)))
+          expect(converter.atomicMillisToUnixMillis(Date.UTC(1979, DEC, 31, 23, 59, 59, 0)))
             .toBe(Date.UTC(1980, JAN, 1, 0, 0, 0))
         })
       })
@@ -682,35 +697,35 @@ describe('Converter', () => {
     describe('SMEAR', () => {
       const converter = Converter(data, MODELS.SMEAR)
 
-      it('unixToAtomic', () => {
-        expect(converter.unixToAtomic(0)).toBe(0)
-        expect(converter.unixToAtomic(Date.UTC(1979, DEC, 31, 11, 59, 59, 999)))
+      it('unixMillisToAtomicMillis', () => {
+        expect(converter.unixMillisToAtomicMillis(0)).toBe(0)
+        expect(converter.unixMillisToAtomicMillis(Date.UTC(1979, DEC, 31, 11, 59, 59, 999)))
           .toBe(Date.UTC(1979, DEC, 31, 11, 59, 59, 999))
-        expect(converter.unixToAtomic(Date.UTC(1979, DEC, 31, 12, 0, 0, 0)))
+        expect(converter.unixMillisToAtomicMillis(Date.UTC(1979, DEC, 31, 12, 0, 0, 0)))
           .toBe(Date.UTC(1979, DEC, 31, 12, 0, 0, 0))
-        expect(converter.unixToAtomic(Date.UTC(1980, JAN, 1, 0, 0, 0, 0)))
+        expect(converter.unixMillisToAtomicMillis(Date.UTC(1980, JAN, 1, 0, 0, 0, 0)))
           .toBe(Date.UTC(1979, DEC, 31, 23, 59, 59, 500))
-        expect(converter.unixToAtomic(Date.UTC(1980, JAN, 1, 12, 0, 0, 0)))
+        expect(converter.unixMillisToAtomicMillis(Date.UTC(1980, JAN, 1, 12, 0, 0, 0)))
           .toBe(Date.UTC(1980, JAN, 1, 11, 59, 59, 0))
-        expect(converter.unixToAtomic(Date.UTC(1980, JAN, 1, 12, 0, 0, 1)))
+        expect(converter.unixMillisToAtomicMillis(Date.UTC(1980, JAN, 1, 12, 0, 0, 1)))
           .toBe(Date.UTC(1980, JAN, 1, 11, 59, 59, 1))
-        expect(converter.unixToAtomic(Date.UTC(1980, JAN, 1, 12, 0, 1, 0)))
+        expect(converter.unixMillisToAtomicMillis(Date.UTC(1980, JAN, 1, 12, 0, 1, 0)))
           .toBe(Date.UTC(1980, JAN, 1, 12, 0, 0, 0))
       })
 
-      it('atomicToUnix', () => {
-        expect(converter.atomicToUnix(0)).toBe(0)
-        expect(converter.atomicToUnix(Date.UTC(1979, DEC, 31, 11, 59, 59, 999)))
+      it('atomicMillisToUnixMillis', () => {
+        expect(converter.atomicMillisToUnixMillis(0)).toBe(0)
+        expect(converter.atomicMillisToUnixMillis(Date.UTC(1979, DEC, 31, 11, 59, 59, 999)))
           .toBe(Date.UTC(1979, DEC, 31, 11, 59, 59, 999))
-        expect(converter.atomicToUnix(Date.UTC(1979, DEC, 31, 12, 0, 0, 0)))
+        expect(converter.atomicMillisToUnixMillis(Date.UTC(1979, DEC, 31, 12, 0, 0, 0)))
           .toBe(Date.UTC(1979, DEC, 31, 12, 0, 0, 0))
-        expect(converter.atomicToUnix(Date.UTC(1979, DEC, 31, 23, 59, 59, 500)))
+        expect(converter.atomicMillisToUnixMillis(Date.UTC(1979, DEC, 31, 23, 59, 59, 500)))
           .toBe(Date.UTC(1980, JAN, 1, 0, 0, 0, 0))
-        expect(converter.atomicToUnix(Date.UTC(1980, JAN, 1, 11, 59, 59, 0)))
+        expect(converter.atomicMillisToUnixMillis(Date.UTC(1980, JAN, 1, 11, 59, 59, 0)))
           .toBe(Date.UTC(1980, JAN, 1, 12, 0, 0, 0))
-        expect(converter.atomicToUnix(Date.UTC(1980, JAN, 1, 11, 59, 59, 1)))
+        expect(converter.atomicMillisToUnixMillis(Date.UTC(1980, JAN, 1, 11, 59, 59, 1)))
           .toBe(Date.UTC(1980, JAN, 1, 12, 0, 0, 1))
-        expect(converter.atomicToUnix(Date.UTC(1980, JAN, 1, 12, 0, 0, 0)))
+        expect(converter.atomicMillisToUnixMillis(Date.UTC(1980, JAN, 1, 12, 0, 0, 0)))
           .toBe(Date.UTC(1980, JAN, 1, 12, 0, 1, 0))
       })
     })
@@ -724,7 +739,7 @@ describe('Converter', () => {
         ]
         const converter = Converter(data, MODELS.OVERRUN)
         // 900_000_000n TAI picoseconds rounds down to 0 seconds, which is not in the ray
-        expect(converter.unixToAtomic(1, { array: true })).toEqual([0])
+        expect(converter.unixMillisToAtomicMillis(1, { array: true })).toEqual([0])
       })
 
       it('at the end of the ray', () => {
@@ -733,7 +748,7 @@ describe('Converter', () => {
           [Date.UTC(1970, JAN, 1, 0, 0, 0, 1), -0.001_1]
         ]
         const converter = Converter(data, MODELS.OVERRUN)
-        expect(converter.unixToAtomic(-1, { array: true })).toEqual([-1])
+        expect(converter.unixMillisToAtomicMillis(-1, { array: true })).toEqual([-1])
       })
     })
   })
@@ -749,52 +764,52 @@ describe('Converter', () => {
       describe('OVERRUN', () => {
         const converter = Converter(data, MODELS.OVERRUN)
 
-        it('unixToAtomic (array mode)', () => {
-          expect(converter.unixToAtomic(0, { array: true })).toEqual([0])
-          expect(converter.unixToAtomic(999, { array: true }))
+        it('unixMillisToAtomicMillis (array mode)', () => {
+          expect(converter.unixMillisToAtomicMillis(0, { array: true })).toEqual([0])
+          expect(converter.unixMillisToAtomicMillis(999, { array: true }))
             .toEqual([
               999
             ])
-          expect(converter.unixToAtomic(1_000, { array: true }))
+          expect(converter.unixMillisToAtomicMillis(1_000, { array: true }))
             .toEqual([
               1_000,
               2_000,
               3_000
             ])
-          expect(converter.unixToAtomic(1_999, { array: true }))
+          expect(converter.unixMillisToAtomicMillis(1_999, { array: true }))
             .toEqual([
               1_999,
               2_999,
               3_999
             ])
-          expect(converter.unixToAtomic(2_000, { array: true }))
+          expect(converter.unixMillisToAtomicMillis(2_000, { array: true }))
             .toEqual([
               4_000
             ])
         })
 
-        it('unixToAtomic', () => {
-          expect(converter.unixToAtomic(0)).toBe(0)
-          expect(converter.unixToAtomic(999))
+        it('unixMillisToAtomicMillis', () => {
+          expect(converter.unixMillisToAtomicMillis(0)).toBe(0)
+          expect(converter.unixMillisToAtomicMillis(999))
             .toBe(999)
-          expect(converter.unixToAtomic(1_000))
+          expect(converter.unixMillisToAtomicMillis(1_000))
             .toBe(3_000)
-          expect(converter.unixToAtomic(1_999))
+          expect(converter.unixMillisToAtomicMillis(1_999))
             .toBe(3_999)
-          expect(converter.unixToAtomic(2_000))
+          expect(converter.unixMillisToAtomicMillis(2_000))
             .toBe(4_000)
         })
 
-        it('atomicToUnix', () => {
-          expect(converter.atomicToUnix(0)).toBe(0)
-          expect(converter.atomicToUnix(1_000)).toBe(1_000)
-          expect(converter.atomicToUnix(1_001)).toBe(1_001)
-          expect(converter.atomicToUnix(1_999)).toBe(1_999)
-          expect(converter.atomicToUnix(2_000)).toBe(1_000)
-          expect(converter.atomicToUnix(2_001)).toBe(1_001)
-          expect(converter.atomicToUnix(2_999)).toBe(1_999)
-          expect(converter.atomicToUnix(3_000)).toBe(1_000)
-          expect(converter.atomicToUnix(3_001)).toBe(1_001)
+        it('atomicMillisToUnixMillis', () => {
+          expect(converter.atomicMillisToUnixMillis(0)).toBe(0)
+          expect(converter.atomicMillisToUnixMillis(1_000)).toBe(1_000)
+          expect(converter.atomicMillisToUnixMillis(1_001)).toBe(1_001)
+          expect(converter.atomicMillisToUnixMillis(1_999)).toBe(1_999)
+          expect(converter.atomicMillisToUnixMillis(2_000)).toBe(1_000)
+          expect(converter.atomicMillisToUnixMillis(2_001)).toBe(1_001)
+          expect(converter.atomicMillisToUnixMillis(2_999)).toBe(1_999)
+          expect(converter.atomicMillisToUnixMillis(3_000)).toBe(1_000)
+          expect(converter.atomicMillisToUnixMillis(3_001)).toBe(1_001)
         })
       })
 
@@ -825,101 +840,101 @@ describe('Converter', () => {
       describe('OVERRUN', () => {
         const converter = Converter(data, MODELS.OVERRUN)
 
-        it('unixToAtomic (array mode)', () => {
-          expect(converter.unixToAtomic(0, { array: true })).toEqual([0])
-          expect(converter.unixToAtomic(999, { array: true })).toEqual([999])
-          expect(converter.unixToAtomic(1_000, { array: true })).toEqual([1_000, 2_000])
-          expect(converter.unixToAtomic(1_499, { array: true })).toEqual([1_499, 2_499])
-          expect(converter.unixToAtomic(1_500, { array: true })).toEqual([1_500, 2_500, 3_000])
+        it('unixMillisToAtomicMillis (array mode)', () => {
+          expect(converter.unixMillisToAtomicMillis(0, { array: true })).toEqual([0])
+          expect(converter.unixMillisToAtomicMillis(999, { array: true })).toEqual([999])
+          expect(converter.unixMillisToAtomicMillis(1_000, { array: true })).toEqual([1_000, 2_000])
+          expect(converter.unixMillisToAtomicMillis(1_499, { array: true })).toEqual([1_499, 2_499])
+          expect(converter.unixMillisToAtomicMillis(1_500, { array: true })).toEqual([1_500, 2_500, 3_000])
         })
 
-        it('unixToAtomic', () => {
-          expect(converter.unixToAtomic(0)).toBe(0)
-          expect(converter.unixToAtomic(999)).toBe(999)
-          expect(converter.unixToAtomic(1_000)).toBe(2_000)
-          expect(converter.unixToAtomic(1_499)).toBe(2_499)
-          expect(converter.unixToAtomic(1_500)).toBe(3_000)
+        it('unixMillisToAtomicMillis', () => {
+          expect(converter.unixMillisToAtomicMillis(0)).toBe(0)
+          expect(converter.unixMillisToAtomicMillis(999)).toBe(999)
+          expect(converter.unixMillisToAtomicMillis(1_000)).toBe(2_000)
+          expect(converter.unixMillisToAtomicMillis(1_499)).toBe(2_499)
+          expect(converter.unixMillisToAtomicMillis(1_500)).toBe(3_000)
         })
 
-        it('atomicToUnix', () => {
-          expect(converter.atomicToUnix(0)).toBe(0)
-          expect(converter.atomicToUnix(999)).toBe(999)
-          expect(converter.atomicToUnix(1_000)).toBe(1_000)
-          expect(converter.atomicToUnix(1_001)).toBe(1_001)
-          expect(converter.atomicToUnix(1_999)).toBe(1_999)
-          expect(converter.atomicToUnix(2_000)).toBe(1_000)
-          expect(converter.atomicToUnix(2_001)).toBe(1_001)
-          expect(converter.atomicToUnix(2_499)).toBe(1_499)
-          expect(converter.atomicToUnix(2_500)).toBe(1_500)
-          expect(converter.atomicToUnix(2_999)).toBe(1_999)
-          expect(converter.atomicToUnix(3_000)).toBe(1_500)
+        it('atomicMillisToUnixMillis', () => {
+          expect(converter.atomicMillisToUnixMillis(0)).toBe(0)
+          expect(converter.atomicMillisToUnixMillis(999)).toBe(999)
+          expect(converter.atomicMillisToUnixMillis(1_000)).toBe(1_000)
+          expect(converter.atomicMillisToUnixMillis(1_001)).toBe(1_001)
+          expect(converter.atomicMillisToUnixMillis(1_999)).toBe(1_999)
+          expect(converter.atomicMillisToUnixMillis(2_000)).toBe(1_000)
+          expect(converter.atomicMillisToUnixMillis(2_001)).toBe(1_001)
+          expect(converter.atomicMillisToUnixMillis(2_499)).toBe(1_499)
+          expect(converter.atomicMillisToUnixMillis(2_500)).toBe(1_500)
+          expect(converter.atomicMillisToUnixMillis(2_999)).toBe(1_999)
+          expect(converter.atomicMillisToUnixMillis(3_000)).toBe(1_500)
         })
       })
 
       describe('BREAK', () => {
         const converter = Converter(data, MODELS.BREAK)
 
-        it('unixToAtomic', () => {
-          expect(converter.unixToAtomic(0)).toBe(0)
-          expect(converter.unixToAtomic(999)).toBe(999)
-          expect(converter.unixToAtomic(1_000)).toBe(2_000)
-          expect(converter.unixToAtomic(1_499)).toBe(2_499)
-          expect(converter.unixToAtomic(1_500)).toBe(3_000)
+        it('unixMillisToAtomicMillis', () => {
+          expect(converter.unixMillisToAtomicMillis(0)).toBe(0)
+          expect(converter.unixMillisToAtomicMillis(999)).toBe(999)
+          expect(converter.unixMillisToAtomicMillis(1_000)).toBe(2_000)
+          expect(converter.unixMillisToAtomicMillis(1_499)).toBe(2_499)
+          expect(converter.unixMillisToAtomicMillis(1_500)).toBe(3_000)
         })
 
-        it('atomicToUnix', () => {
-          expect(converter.atomicToUnix(0)).toBe(0)
-          expect(converter.atomicToUnix(999)).toBe(999)
-          expect(converter.atomicToUnix(1_000)).toBe(NaN)
-          expect(converter.atomicToUnix(1_001)).toBe(NaN)
-          expect(converter.atomicToUnix(1_999)).toBe(NaN)
-          expect(converter.atomicToUnix(2_000)).toBe(1_000)
-          expect(converter.atomicToUnix(2_001)).toBe(1_001)
-          expect(converter.atomicToUnix(2_499)).toBe(1_499)
-          expect(converter.atomicToUnix(2_500)).toBe(NaN)
-          expect(converter.atomicToUnix(2_501)).toBe(NaN)
-          expect(converter.atomicToUnix(2_999)).toBe(NaN)
-          expect(converter.atomicToUnix(3_000)).toBe(1_500)
+        it('atomicMillisToUnixMillis', () => {
+          expect(converter.atomicMillisToUnixMillis(0)).toBe(0)
+          expect(converter.atomicMillisToUnixMillis(999)).toBe(999)
+          expect(converter.atomicMillisToUnixMillis(1_000)).toBe(NaN)
+          expect(converter.atomicMillisToUnixMillis(1_001)).toBe(NaN)
+          expect(converter.atomicMillisToUnixMillis(1_999)).toBe(NaN)
+          expect(converter.atomicMillisToUnixMillis(2_000)).toBe(1_000)
+          expect(converter.atomicMillisToUnixMillis(2_001)).toBe(1_001)
+          expect(converter.atomicMillisToUnixMillis(2_499)).toBe(1_499)
+          expect(converter.atomicMillisToUnixMillis(2_500)).toBe(NaN)
+          expect(converter.atomicMillisToUnixMillis(2_501)).toBe(NaN)
+          expect(converter.atomicMillisToUnixMillis(2_999)).toBe(NaN)
+          expect(converter.atomicMillisToUnixMillis(3_000)).toBe(1_500)
         })
       })
 
       describe('STALL', () => {
         const converter = Converter(data, MODELS.STALL)
 
-        it('unixToAtomic (range mode)', () => {
-          expect(converter.unixToAtomic(0, { range: true })).toEqual([0, 0])
-          expect(converter.unixToAtomic(999, { range: true })).toEqual([999, 999])
-          expect(converter.unixToAtomic(1_000, { range: true })).toEqual([1_000, 2_000])
-          expect(converter.unixToAtomic(1_001, { range: true })).toEqual([2_001, 2_001])
-          expect(converter.unixToAtomic(1_499, { range: true })).toEqual([2_499, 2_499])
-          expect(converter.unixToAtomic(1_500, { range: true })).toEqual([2_500, 3_000])
-          expect(converter.unixToAtomic(1_501, { range: true })).toEqual([3_001, 3_001])
+        it('unixMillisToAtomicMillis (range mode)', () => {
+          expect(converter.unixMillisToAtomicMillis(0, { range: true })).toEqual([0, 0])
+          expect(converter.unixMillisToAtomicMillis(999, { range: true })).toEqual([999, 999])
+          expect(converter.unixMillisToAtomicMillis(1_000, { range: true })).toEqual([1_000, 2_000])
+          expect(converter.unixMillisToAtomicMillis(1_001, { range: true })).toEqual([2_001, 2_001])
+          expect(converter.unixMillisToAtomicMillis(1_499, { range: true })).toEqual([2_499, 2_499])
+          expect(converter.unixMillisToAtomicMillis(1_500, { range: true })).toEqual([2_500, 3_000])
+          expect(converter.unixMillisToAtomicMillis(1_501, { range: true })).toEqual([3_001, 3_001])
         })
 
-        it('unixToAtomic', () => {
-          expect(converter.unixToAtomic(0)).toBe(0)
-          expect(converter.unixToAtomic(999)).toBe(999)
-          expect(converter.unixToAtomic(1_000)).toBe(2_000)
-          expect(converter.unixToAtomic(1_001)).toBe(2_001)
-          expect(converter.unixToAtomic(1_499)).toBe(2_499)
-          expect(converter.unixToAtomic(1_500)).toBe(3_000)
-          expect(converter.unixToAtomic(1_501)).toBe(3_001)
+        it('unixMillisToAtomicMillis', () => {
+          expect(converter.unixMillisToAtomicMillis(0)).toBe(0)
+          expect(converter.unixMillisToAtomicMillis(999)).toBe(999)
+          expect(converter.unixMillisToAtomicMillis(1_000)).toBe(2_000)
+          expect(converter.unixMillisToAtomicMillis(1_001)).toBe(2_001)
+          expect(converter.unixMillisToAtomicMillis(1_499)).toBe(2_499)
+          expect(converter.unixMillisToAtomicMillis(1_500)).toBe(3_000)
+          expect(converter.unixMillisToAtomicMillis(1_501)).toBe(3_001)
         })
 
-        it('atomicToUnix', () => {
-          expect(converter.atomicToUnix(0)).toBe(0)
-          expect(converter.atomicToUnix(999)).toBe(999)
-          expect(converter.atomicToUnix(1_000)).toBe(1_000)
-          expect(converter.atomicToUnix(1_001)).toBe(1_000)
-          expect(converter.atomicToUnix(1_999)).toBe(1_000)
-          expect(converter.atomicToUnix(2_000)).toBe(1_000)
-          expect(converter.atomicToUnix(2_001)).toBe(1_001)
-          expect(converter.atomicToUnix(2_499)).toBe(1_499)
-          expect(converter.atomicToUnix(2_500)).toBe(1_500)
-          expect(converter.atomicToUnix(2_501)).toBe(1_500)
-          expect(converter.atomicToUnix(2_999)).toBe(1_500)
-          expect(converter.atomicToUnix(3_000)).toBe(1_500)
-          expect(converter.atomicToUnix(3_001)).toBe(1_501)
+        it('atomicMillisToUnixMillis', () => {
+          expect(converter.atomicMillisToUnixMillis(0)).toBe(0)
+          expect(converter.atomicMillisToUnixMillis(999)).toBe(999)
+          expect(converter.atomicMillisToUnixMillis(1_000)).toBe(1_000)
+          expect(converter.atomicMillisToUnixMillis(1_001)).toBe(1_000)
+          expect(converter.atomicMillisToUnixMillis(1_999)).toBe(1_000)
+          expect(converter.atomicMillisToUnixMillis(2_000)).toBe(1_000)
+          expect(converter.atomicMillisToUnixMillis(2_001)).toBe(1_001)
+          expect(converter.atomicMillisToUnixMillis(2_499)).toBe(1_499)
+          expect(converter.atomicMillisToUnixMillis(2_500)).toBe(1_500)
+          expect(converter.atomicMillisToUnixMillis(2_501)).toBe(1_500)
+          expect(converter.atomicMillisToUnixMillis(2_999)).toBe(1_500)
+          expect(converter.atomicMillisToUnixMillis(3_000)).toBe(1_500)
+          expect(converter.atomicMillisToUnixMillis(3_001)).toBe(1_501)
         })
       })
     })
@@ -935,41 +950,41 @@ describe('Converter', () => {
       describe('OVERRUN', () => {
         const converter = Converter(data, MODELS.OVERRUN)
 
-        it('unixToAtomic (array mode)', () => {
-          expect(converter.unixToAtomic(0, { array: true })).toEqual([0])
-          expect(converter.unixToAtomic(499, { array: true })).toEqual([499])
-          expect(converter.unixToAtomic(500, { array: true })).toEqual([500, 3_000])
-          expect(converter.unixToAtomic(999, { array: true })).toEqual([999, 3_499])
-          expect(converter.unixToAtomic(1_000, { array: true })).toEqual([1_000, 2_000, 3_500])
-          expect(converter.unixToAtomic(1_999, { array: true })).toEqual([1_999, 2_999, 4_499])
-          expect(converter.unixToAtomic(2_000, { array: true })).toEqual([4_500])
+        it('unixMillisToAtomicMillis (array mode)', () => {
+          expect(converter.unixMillisToAtomicMillis(0, { array: true })).toEqual([0])
+          expect(converter.unixMillisToAtomicMillis(499, { array: true })).toEqual([499])
+          expect(converter.unixMillisToAtomicMillis(500, { array: true })).toEqual([500, 3_000])
+          expect(converter.unixMillisToAtomicMillis(999, { array: true })).toEqual([999, 3_499])
+          expect(converter.unixMillisToAtomicMillis(1_000, { array: true })).toEqual([1_000, 2_000, 3_500])
+          expect(converter.unixMillisToAtomicMillis(1_999, { array: true })).toEqual([1_999, 2_999, 4_499])
+          expect(converter.unixMillisToAtomicMillis(2_000, { array: true })).toEqual([4_500])
         })
 
-        it('unixToAtomic', () => {
-          expect(converter.unixToAtomic(0)).toBe(0)
-          expect(converter.unixToAtomic(499)).toBe(499)
-          expect(converter.unixToAtomic(500)).toBe(3_000)
-          expect(converter.unixToAtomic(999)).toBe(3_499)
-          expect(converter.unixToAtomic(1_000)).toBe(3_500)
-          expect(converter.unixToAtomic(1_999)).toBe(4_499)
-          expect(converter.unixToAtomic(2_000)).toBe(4_500)
+        it('unixMillisToAtomicMillis', () => {
+          expect(converter.unixMillisToAtomicMillis(0)).toBe(0)
+          expect(converter.unixMillisToAtomicMillis(499)).toBe(499)
+          expect(converter.unixMillisToAtomicMillis(500)).toBe(3_000)
+          expect(converter.unixMillisToAtomicMillis(999)).toBe(3_499)
+          expect(converter.unixMillisToAtomicMillis(1_000)).toBe(3_500)
+          expect(converter.unixMillisToAtomicMillis(1_999)).toBe(4_499)
+          expect(converter.unixMillisToAtomicMillis(2_000)).toBe(4_500)
         })
 
-        it('atomicToUnix', () => {
-          expect(converter.atomicToUnix(0)).toBe(0)
-          expect(converter.atomicToUnix(499)).toBe(499)
-          expect(converter.atomicToUnix(500)).toBe(500)
-          expect(converter.atomicToUnix(999)).toBe(999)
-          expect(converter.atomicToUnix(1_000)).toBe(1_000)
-          expect(converter.atomicToUnix(1_001)).toBe(1_001)
-          expect(converter.atomicToUnix(1_999)).toBe(1_999)
-          expect(converter.atomicToUnix(2_000)).toBe(1_000)
-          expect(converter.atomicToUnix(2_001)).toBe(1_001)
-          expect(converter.atomicToUnix(2_999)).toBe(1_999)
-          expect(converter.atomicToUnix(3_000)).toBe(500)
-          expect(converter.atomicToUnix(3_001)).toBe(501)
-          expect(converter.atomicToUnix(4_499)).toBe(1_999)
-          expect(converter.atomicToUnix(4_500)).toBe(2_000)
+        it('atomicMillisToUnixMillis', () => {
+          expect(converter.atomicMillisToUnixMillis(0)).toBe(0)
+          expect(converter.atomicMillisToUnixMillis(499)).toBe(499)
+          expect(converter.atomicMillisToUnixMillis(500)).toBe(500)
+          expect(converter.atomicMillisToUnixMillis(999)).toBe(999)
+          expect(converter.atomicMillisToUnixMillis(1_000)).toBe(1_000)
+          expect(converter.atomicMillisToUnixMillis(1_001)).toBe(1_001)
+          expect(converter.atomicMillisToUnixMillis(1_999)).toBe(1_999)
+          expect(converter.atomicMillisToUnixMillis(2_000)).toBe(1_000)
+          expect(converter.atomicMillisToUnixMillis(2_001)).toBe(1_001)
+          expect(converter.atomicMillisToUnixMillis(2_999)).toBe(1_999)
+          expect(converter.atomicMillisToUnixMillis(3_000)).toBe(500)
+          expect(converter.atomicMillisToUnixMillis(3_001)).toBe(501)
+          expect(converter.atomicMillisToUnixMillis(4_499)).toBe(1_999)
+          expect(converter.atomicMillisToUnixMillis(4_500)).toBe(2_000)
         })
       })
 
@@ -997,7 +1012,7 @@ describe('Converter', () => {
     const converter = Converter(data, MODELS.OVERRUN)
 
     it('before anything clever occurs', () => {
-      expect(converter.unixToAtomic(Date.UTC(1963, OCT, 31, 23, 59, 59, 999), { array: true }))
+      expect(converter.unixMillisToAtomicMillis(Date.UTC(1963, OCT, 31, 23, 59, 59, 999), { array: true }))
         .toEqual([
           Date.UTC(1963, NOV, 1, 0, 0, 2, 596)
         ])
@@ -1005,33 +1020,33 @@ describe('Converter', () => {
     })
 
     it('exactly at the time', () => {
-      expect(converter.unixToAtomic(Date.UTC(1963, NOV, 1, 0, 0, 0, 0), { array: true }))
+      expect(converter.unixMillisToAtomicMillis(Date.UTC(1963, NOV, 1, 0, 0, 0, 0), { array: true }))
         .toEqual([
           Date.UTC(1963, NOV, 1, 0, 0, 2, 597),
           Date.UTC(1963, NOV, 1, 0, 0, 2, 697)
         ])
-      // expect(converter.unixToAtomicPicos(Date.UTC(1963, NOV, 1, 0, 0, 0, 0)))
+      // expect(converter.unixMillisToAtomicMillisPicos(Date.UTC(1963, NOV, 1, 0, 0, 0, 0)))
     })
 
     it('then', () => {
-      expect(converter.unixToAtomic(Date.UTC(1963, NOV, 1, 0, 0, 0, 1), { array: true }))
+      expect(converter.unixMillisToAtomicMillis(Date.UTC(1963, NOV, 1, 0, 0, 0, 1), { array: true }))
         .toEqual([
           Date.UTC(1963, NOV, 1, 0, 0, 2, 598),
           Date.UTC(1963, NOV, 1, 0, 0, 2, 698)
         ])
 
-      expect(converter.unixToAtomic(Date.UTC(1963, NOV, 1, 0, 0, 0, 99), { array: true }))
+      expect(converter.unixMillisToAtomicMillis(Date.UTC(1963, NOV, 1, 0, 0, 0, 99), { array: true }))
         .toEqual([
           Date.UTC(1963, NOV, 1, 0, 0, 2, 696),
           Date.UTC(1963, NOV, 1, 0, 0, 2, 796) // -194_659_197_203_721_198_713n TAI
         ])
 
-      expect(converter.unixToAtomic(Date.UTC(1963, NOV, 1, 0, 0, 0, 100), { array: true }))
+      expect(converter.unixMillisToAtomicMillis(Date.UTC(1963, NOV, 1, 0, 0, 0, 100), { array: true }))
         .toEqual([
           Date.UTC(1963, NOV, 1, 0, 0, 2, 797)
         ])
 
-      expect(converter.unixToAtomic(Date.UTC(1963, NOV, 1, 0, 0, 0, 101), { array: true }))
+      expect(converter.unixMillisToAtomicMillis(Date.UTC(1963, NOV, 1, 0, 0, 0, 101), { array: true }))
         .toEqual([
           Date.UTC(1963, NOV, 1, 0, 0, 2, 798)
         ])

--- a/src/converter.spec.js
+++ b/src/converter.spec.js
@@ -297,51 +297,115 @@ describe('Converter', () => {
       })
     })
 
-    // /////////////
-
     describe('BREAK', () => {
       const converter = Converter(data, MODELS.BREAK)
 
       describe('conversions grouped by instant', () => {
         it('start of time', () => {
+          expect(converter.unixToAtomic(new Rat(0n))).toEqual([{ start: new Rat(0n), end: new Rat(0n), closed: true }])
           expect(converter.unixMillisToAtomicMillis(0)).toBe(0)
+          expect(converter.atomicToUnix(new Rat(0n))).toEqual(new Rat(0n))
           expect(converter.atomicMillisToUnixMillis(0)).toBe(0)
         })
 
         it('millisecond before inserted leap second discontinuity begins', () => {
+          expect(converter.unixToAtomic(millisToExact(Date.UTC(1979, DEC, 31, 23, 59, 59, 999))))
+            .toEqual([{
+              start: millisToExact(Date.UTC(1979, DEC, 31, 23, 59, 59, 999)),
+              end: millisToExact(Date.UTC(1979, DEC, 31, 23, 59, 59, 999)),
+              closed: true
+            }])
           expect(converter.unixMillisToAtomicMillis(Date.UTC(1979, DEC, 31, 23, 59, 59, 999)))
             .toBe(Date.UTC(1979, DEC, 31, 23, 59, 59, 999))
+          expect(converter.atomicToUnix(millisToExact(Date.UTC(1979, DEC, 31, 23, 59, 59, 999))))
+            .toEqual(millisToExact(Date.UTC(1979, DEC, 31, 23, 59, 59, 999)))
           expect(converter.atomicMillisToUnixMillis(Date.UTC(1979, DEC, 31, 23, 59, 59, 999)))
             .toBe(Date.UTC(1979, DEC, 31, 23, 59, 59, 999))
         })
 
         it('first instant of the Unix time discontinuity: one Unix time is two TAI times', () => {
+          expect(converter.unixToAtomic(millisToExact(Date.UTC(1980, JAN, 1, 0, 0, 0))))
+            .toEqual([{
+              start: millisToExact(Date.UTC(1980, JAN, 1, 0, 0, 1)),
+              end: millisToExact(Date.UTC(1980, JAN, 1, 0, 0, 1)),
+              closed: true
+            }])
           expect(converter.unixMillisToAtomicMillis(Date.UTC(1980, JAN, 1, 0, 0, 0)))
             .toBe(Date.UTC(1980, JAN, 1, 0, 0, 1))
+          expect(converter.atomicToUnix(millisToExact(Date.UTC(1980, JAN, 1, 0, 0, 0))))
+            .toBe(NaN)
           expect(converter.atomicMillisToUnixMillis(Date.UTC(1980, JAN, 1, 0, 0, 0)))
             .toBe(NaN)
+          expect(converter.atomicToUnix(millisToExact(Date.UTC(1980, JAN, 1, 0, 0, 1))))
+            .toEqual(millisToExact(Date.UTC(1980, JAN, 1, 0, 0, 0)))
           expect(converter.atomicMillisToUnixMillis(Date.UTC(1980, JAN, 1, 0, 0, 1)))
             .toBe(Date.UTC(1980, JAN, 1, 0, 0, 0))
         })
 
         it('final instant of the Unix time discontinuity: one Unix time is two TAI times', () => {
+          expect(converter.unixToAtomic(millisToExact(Date.UTC(1980, JAN, 1, 0, 0, 0, 999))))
+            .toEqual([{
+              start: millisToExact(Date.UTC(1980, JAN, 1, 0, 0, 1, 999)),
+              end: millisToExact(Date.UTC(1980, JAN, 1, 0, 0, 1, 999)),
+              closed: true
+            }])
           expect(converter.unixMillisToAtomicMillis(Date.UTC(1980, JAN, 1, 0, 0, 0, 999)))
             .toBe(Date.UTC(1980, JAN, 1, 0, 0, 1, 999))
+          expect(converter.atomicToUnix(millisToExact(Date.UTC(1980, JAN, 1, 0, 0, 0, 999))))
+            .toBe(NaN)
           expect(converter.atomicMillisToUnixMillis(Date.UTC(1980, JAN, 1, 0, 0, 0, 999)))
             .toBe(NaN)
+          expect(converter.atomicToUnix(millisToExact(Date.UTC(1980, JAN, 1, 0, 0, 1, 999))))
+            .toEqual(millisToExact(Date.UTC(1980, JAN, 1, 0, 0, 0, 999)))
           expect(converter.atomicMillisToUnixMillis(Date.UTC(1980, JAN, 1, 0, 0, 1, 999)))
             .toBe(Date.UTC(1980, JAN, 1, 0, 0, 0, 999))
         })
 
         it('millisecond after discontinuity ends', () => {
+          expect(converter.unixToAtomic(millisToExact(Date.UTC(1980, JAN, 1, 0, 0, 1))))
+            .toEqual([{
+              start: millisToExact(Date.UTC(1980, JAN, 1, 0, 0, 2)),
+              end: millisToExact(Date.UTC(1980, JAN, 1, 0, 0, 2)),
+              closed: true
+            }])
           expect(converter.unixMillisToAtomicMillis(Date.UTC(1980, JAN, 1, 0, 0, 1)))
             .toBe(Date.UTC(1980, JAN, 1, 0, 0, 2))
+          expect(converter.atomicToUnix(millisToExact(Date.UTC(1980, JAN, 1, 0, 0, 2))))
+            .toEqual(millisToExact(Date.UTC(1980, JAN, 1, 0, 0, 1)))
           expect(converter.atomicMillisToUnixMillis(Date.UTC(1980, JAN, 1, 0, 0, 2)))
             .toBe(Date.UTC(1980, JAN, 1, 0, 0, 1))
         })
       })
 
       describe('conversions grouped by method', () => {
+        it('unixToAtomic', () => {
+          expect(converter.unixToAtomic(new Rat(0n))).toEqual([{ start: new Rat(0n), end: new Rat(0n), closed: true }])
+          expect(converter.unixToAtomic(millisToExact(Date.UTC(1979, DEC, 31, 23, 59, 59, 999))))
+            .toEqual([{
+              start: millisToExact(Date.UTC(1979, DEC, 31, 23, 59, 59, 999)),
+              end: millisToExact(Date.UTC(1979, DEC, 31, 23, 59, 59, 999)),
+              closed: true
+            }])
+          expect(converter.unixToAtomic(millisToExact(Date.UTC(1980, JAN, 1, 0, 0, 0))))
+            .toEqual([{
+              start: millisToExact(Date.UTC(1980, JAN, 1, 0, 0, 1)),
+              end: millisToExact(Date.UTC(1980, JAN, 1, 0, 0, 1)),
+              closed: true
+            }])
+          expect(converter.unixToAtomic(millisToExact(Date.UTC(1980, JAN, 1, 0, 0, 0, 999))))
+            .toEqual([{
+              start: millisToExact(Date.UTC(1980, JAN, 1, 0, 0, 1, 999)),
+              end: millisToExact(Date.UTC(1980, JAN, 1, 0, 0, 1, 999)),
+              closed: true
+            }])
+          expect(converter.unixToAtomic(millisToExact(Date.UTC(1980, JAN, 1, 0, 0, 1))))
+            .toEqual([{
+              start: millisToExact(Date.UTC(1980, JAN, 1, 0, 0, 2)),
+              end: millisToExact(Date.UTC(1980, JAN, 1, 0, 0, 2)),
+              closed: true
+            }])
+        })
+
         it('unixMillisToAtomicMillis', () => {
           expect(converter.unixMillisToAtomicMillis(0)).toBe(0)
           expect(converter.unixMillisToAtomicMillis(Date.UTC(1979, DEC, 31, 23, 59, 59, 999)))
@@ -352,6 +416,20 @@ describe('Converter', () => {
             .toBe(Date.UTC(1980, JAN, 1, 0, 0, 1, 999))
           expect(converter.unixMillisToAtomicMillis(Date.UTC(1980, JAN, 1, 0, 0, 1)))
             .toBe(Date.UTC(1980, JAN, 1, 0, 0, 2))
+        })
+
+        it('atomicToUnix', () => {
+          expect(converter.atomicToUnix(new Rat(0n))).toEqual(new Rat(0n))
+          expect(converter.atomicToUnix(millisToExact(Date.UTC(1979, DEC, 31, 23, 59, 59, 999))))
+            .toEqual(millisToExact(Date.UTC(1979, DEC, 31, 23, 59, 59, 999)))
+          expect(converter.atomicToUnix(millisToExact(Date.UTC(1980, JAN, 1, 0, 0, 0, 999))))
+            .toBe(NaN)
+          expect(converter.atomicToUnix(millisToExact(Date.UTC(1980, JAN, 1, 0, 0, 1))))
+            .toEqual(millisToExact(Date.UTC(1980, JAN, 1, 0, 0, 0)))
+          expect(converter.atomicToUnix(millisToExact(Date.UTC(1980, JAN, 1, 0, 0, 1, 999))))
+            .toEqual(millisToExact(Date.UTC(1980, JAN, 1, 0, 0, 0, 999)))
+          expect(converter.atomicToUnix(millisToExact(Date.UTC(1980, JAN, 1, 0, 0, 2))))
+            .toEqual(millisToExact(Date.UTC(1980, JAN, 1, 0, 0, 1)))
         })
 
         it('atomicMillisToUnixMillis', () => {
@@ -377,12 +455,24 @@ describe('Converter', () => {
 
       describe('conversions grouped by instant', () => {
         it('start of time', () => {
+          expect(converter.unixToAtomic(new Rat(0n))).toEqual([{
+            start: new Rat(0n),
+            end: new Rat(0n),
+            closed: true
+          }])
           expect(converter.unixMillisToAtomicMillis(0, { range: true })).toEqual([0, 0])
           expect(converter.unixMillisToAtomicMillis(0)).toBe(0)
+          expect(converter.atomicToUnix(new Rat(0n))).toEqual(new Rat(0n))
           expect(converter.atomicMillisToUnixMillis(0)).toBe(0)
         })
 
         it('millisecond before inserted leap second discontinuity begins', () => {
+          expect(converter.unixToAtomic(millisToExact(Date.UTC(1979, DEC, 31, 23, 59, 59, 999))))
+            .toEqual([{
+              start: millisToExact(Date.UTC(1979, DEC, 31, 23, 59, 59, 999)),
+              end: millisToExact(Date.UTC(1979, DEC, 31, 23, 59, 59, 999)),
+              closed: true
+            }])
           expect(converter.unixMillisToAtomicMillis(Date.UTC(1979, DEC, 31, 23, 59, 59, 999), { range: true }))
             .toEqual([
               Date.UTC(1979, DEC, 31, 23, 59, 59, 999),
@@ -390,11 +480,19 @@ describe('Converter', () => {
             ])
           expect(converter.unixMillisToAtomicMillis(Date.UTC(1979, DEC, 31, 23, 59, 59, 999)))
             .toBe(Date.UTC(1979, DEC, 31, 23, 59, 59, 999))
+          expect(converter.atomicToUnix(millisToExact(Date.UTC(1979, DEC, 31, 23, 59, 59, 999))))
+            .toEqual(millisToExact(Date.UTC(1979, DEC, 31, 23, 59, 59, 999)))
           expect(converter.atomicMillisToUnixMillis(Date.UTC(1979, DEC, 31, 23, 59, 59, 999)))
             .toBe(Date.UTC(1979, DEC, 31, 23, 59, 59, 999))
         })
 
         it('first instant of the Unix time discontinuity: one Unix time is two TAI times', () => {
+          expect(converter.unixToAtomic(millisToExact(Date.UTC(1980, JAN, 1, 0, 0, 0))))
+            .toEqual([{
+              start: millisToExact(Date.UTC(1980, JAN, 1, 0, 0, 0, 0)),
+              end: millisToExact(Date.UTC(1980, JAN, 1, 0, 0, 1, 0)),
+              closed: true
+            }])
           expect(converter.unixMillisToAtomicMillis(Date.UTC(1980, JAN, 1, 0, 0, 0), { range: true }))
             .toEqual([
               Date.UTC(1980, JAN, 1, 0, 0, 0, 0),
@@ -402,13 +500,23 @@ describe('Converter', () => {
             ])
           expect(converter.unixMillisToAtomicMillis(Date.UTC(1980, JAN, 1, 0, 0, 0)))
             .toBe(Date.UTC(1980, JAN, 1, 0, 0, 1))
+          expect(converter.atomicToUnix(millisToExact(Date.UTC(1980, JAN, 1, 0, 0, 0))))
+            .toEqual(millisToExact(Date.UTC(1980, JAN, 1, 0, 0, 0)))
           expect(converter.atomicMillisToUnixMillis(Date.UTC(1980, JAN, 1, 0, 0, 0)))
             .toBe(Date.UTC(1980, JAN, 1, 0, 0, 0))
+          expect(converter.atomicToUnix(millisToExact(Date.UTC(1980, JAN, 1, 0, 0, 1))))
+            .toEqual(millisToExact(Date.UTC(1980, JAN, 1, 0, 0, 0)))
           expect(converter.atomicMillisToUnixMillis(Date.UTC(1980, JAN, 1, 0, 0, 1)))
             .toBe(Date.UTC(1980, JAN, 1, 0, 0, 0))
         })
 
         it('final instant of the Unix time discontinuity: one Unix time is two TAI times', () => {
+          expect(converter.unixToAtomic(millisToExact(Date.UTC(1980, JAN, 1, 0, 0, 0, 999))))
+            .toEqual([{
+              start: millisToExact(Date.UTC(1980, JAN, 1, 0, 0, 1, 999)),
+              end: millisToExact(Date.UTC(1980, JAN, 1, 0, 0, 1, 999)),
+              closed: true
+            }])
           expect(converter.unixMillisToAtomicMillis(Date.UTC(1980, JAN, 1, 0, 0, 0, 999), { range: true }))
             .toEqual([
               Date.UTC(1980, JAN, 1, 0, 0, 1, 999),
@@ -416,13 +524,23 @@ describe('Converter', () => {
             ])
           expect(converter.unixMillisToAtomicMillis(Date.UTC(1980, JAN, 1, 0, 0, 0, 999)))
             .toBe(Date.UTC(1980, JAN, 1, 0, 0, 1, 999))
+          expect(converter.atomicToUnix(millisToExact(Date.UTC(1980, JAN, 1, 0, 0, 0, 999))))
+            .toEqual(millisToExact(Date.UTC(1980, JAN, 1, 0, 0, 0))) // stalled
           expect(converter.atomicMillisToUnixMillis(Date.UTC(1980, JAN, 1, 0, 0, 0, 999)))
             .toBe(Date.UTC(1980, JAN, 1, 0, 0, 0)) // stalled
+          expect(converter.atomicToUnix(millisToExact(Date.UTC(1980, JAN, 1, 0, 0, 1, 999))))
+            .toEqual(millisToExact(Date.UTC(1980, JAN, 1, 0, 0, 0, 999)))
           expect(converter.atomicMillisToUnixMillis(Date.UTC(1980, JAN, 1, 0, 0, 1, 999)))
             .toBe(Date.UTC(1980, JAN, 1, 0, 0, 0, 999))
         })
 
         it('millisecond after discontinuity ends', () => {
+          expect(converter.unixToAtomic(millisToExact(Date.UTC(1980, JAN, 1, 0, 0, 1, 0))))
+            .toEqual([{
+              start: millisToExact(Date.UTC(1980, JAN, 1, 0, 0, 2, 0)),
+              end: millisToExact(Date.UTC(1980, JAN, 1, 0, 0, 2, 0)),
+              closed: true
+            }])
           expect(converter.unixMillisToAtomicMillis(Date.UTC(1980, JAN, 1, 0, 0, 1, 0), { range: true }))
             .toEqual([
               Date.UTC(1980, JAN, 1, 0, 0, 2, 0),
@@ -430,12 +548,46 @@ describe('Converter', () => {
             ])
           expect(converter.unixMillisToAtomicMillis(Date.UTC(1980, JAN, 1, 0, 0, 1)))
             .toBe(Date.UTC(1980, JAN, 1, 0, 0, 2, 0))
+          expect(converter.atomicToUnix(millisToExact(Date.UTC(1980, JAN, 1, 0, 0, 2, 0))))
+            .toEqual(millisToExact(Date.UTC(1980, JAN, 1, 0, 0, 1, 0)))
           expect(converter.atomicMillisToUnixMillis(Date.UTC(1980, JAN, 1, 0, 0, 2, 0)))
             .toBe(Date.UTC(1980, JAN, 1, 0, 0, 1, 0))
         })
       })
 
       describe('conversions grouped by method', () => {
+        it('unixToAtomic', () => {
+          expect(converter.unixToAtomic(new Rat(0n))).toEqual([{
+            start: new Rat(0n),
+            end: new Rat(0n),
+            closed: true
+          }])
+          expect(converter.unixToAtomic(millisToExact(Date.UTC(1979, DEC, 31, 23, 59, 59, 999))))
+            .toEqual([{
+              start: millisToExact(Date.UTC(1979, DEC, 31, 23, 59, 59, 999)),
+              end: millisToExact(Date.UTC(1979, DEC, 31, 23, 59, 59, 999)),
+              closed: true
+            }])
+          expect(converter.unixToAtomic(millisToExact(Date.UTC(1980, JAN, 1, 0, 0, 0))))
+            .toEqual([{
+              start: millisToExact(Date.UTC(1980, JAN, 1, 0, 0, 0, 0)),
+              end: millisToExact(Date.UTC(1980, JAN, 1, 0, 0, 1, 0)),
+              closed: true
+            }])
+          expect(converter.unixToAtomic(millisToExact(Date.UTC(1980, JAN, 1, 0, 0, 0, 999))))
+            .toEqual([{
+              start: millisToExact(Date.UTC(1980, JAN, 1, 0, 0, 1, 999)),
+              end: millisToExact(Date.UTC(1980, JAN, 1, 0, 0, 1, 999)),
+              closed: true
+            }])
+          expect(converter.unixToAtomic(millisToExact(Date.UTC(1980, JAN, 1, 0, 0, 1, 0))))
+            .toEqual([{
+              start: millisToExact(Date.UTC(1980, JAN, 1, 0, 0, 2, 0)),
+              end: millisToExact(Date.UTC(1980, JAN, 1, 0, 0, 2, 0)),
+              closed: true
+            }])
+        })
+
         it('unixMillisToAtomicMillis (range mode)', () => {
           expect(converter.unixMillisToAtomicMillis(0, { range: true })).toEqual([0, 0])
           expect(converter.unixMillisToAtomicMillis(Date.UTC(1979, DEC, 31, 23, 59, 59, 999), { range: true }))
@@ -475,6 +627,22 @@ describe('Converter', () => {
             .toBe(Date.UTC(1980, JAN, 1, 0, 0, 1, 999))
           expect(converter.unixMillisToAtomicMillis(Date.UTC(1980, JAN, 1, 0, 0, 1)))
             .toBe(Date.UTC(1980, JAN, 1, 0, 0, 2))
+        })
+
+        it('atomicToUnix', () => {
+          expect(converter.atomicToUnix(new Rat(0n))).toEqual(new Rat(0n))
+          expect(converter.atomicToUnix(millisToExact(Date.UTC(1979, DEC, 31, 23, 59, 59, 999))))
+            .toEqual(millisToExact(Date.UTC(1979, DEC, 31, 23, 59, 59, 999)))
+          expect(converter.atomicToUnix(millisToExact(Date.UTC(1980, JAN, 1, 0, 0, 0))))
+            .toEqual(millisToExact(Date.UTC(1980, JAN, 1, 0, 0, 0)))
+          expect(converter.atomicToUnix(millisToExact(Date.UTC(1980, JAN, 1, 0, 0, 0, 999))))
+            .toEqual(millisToExact(Date.UTC(1980, JAN, 1, 0, 0, 0))) // stalled
+          expect(converter.atomicToUnix(millisToExact(Date.UTC(1980, JAN, 1, 0, 0, 1))))
+            .toEqual(millisToExact(Date.UTC(1980, JAN, 1, 0, 0, 0)))
+          expect(converter.atomicToUnix(millisToExact(Date.UTC(1980, JAN, 1, 0, 0, 1, 999))))
+            .toEqual(millisToExact(Date.UTC(1980, JAN, 1, 0, 0, 0, 999)))
+          expect(converter.atomicToUnix(millisToExact(Date.UTC(1980, JAN, 1, 0, 0, 2, 0))))
+            .toEqual(millisToExact(Date.UTC(1980, JAN, 1, 0, 0, 1, 0)))
         })
 
         it('atomicMillisToUnixMillis', () => {

--- a/src/converter.spec.js
+++ b/src/converter.spec.js
@@ -2,7 +2,6 @@
 
 const { Converter, MODELS } = require('./converter.js')
 const { Rat } = require('./rat.js')
-const { millisToExact } = require('./munge.js')
 
 const JAN = 0
 const OCT = 9
@@ -104,46 +103,46 @@ describe('Converter', () => {
           }])
 
         // BIFURCATION
-        expect(converter.unixToAtomic(millisToExact(Date.UTC(1979, DEC, 31, 23, 59, 59, 999))))
+        expect(converter.unixToAtomic(Rat.fromMillis(Date.UTC(1979, DEC, 31, 23, 59, 59, 999))))
           .toEqual([{
-            start: millisToExact(Date.UTC(1979, DEC, 31, 23, 59, 59, 999)),
-            end: millisToExact(Date.UTC(1979, DEC, 31, 23, 59, 59, 999))
+            start: Rat.fromMillis(Date.UTC(1979, DEC, 31, 23, 59, 59, 999)),
+            end: Rat.fromMillis(Date.UTC(1979, DEC, 31, 23, 59, 59, 999))
           }])
-        expect(converter.unixToAtomic(millisToExact(Date.UTC(1980, JAN, 1, 0, 0, 0, 0))))
+        expect(converter.unixToAtomic(Rat.fromMillis(Date.UTC(1980, JAN, 1, 0, 0, 0, 0))))
           .toEqual([{
-            start: millisToExact(Date.UTC(1980, JAN, 1, 0, 0, 0, 0)),
-            end: millisToExact(Date.UTC(1980, JAN, 1, 0, 0, 0, 0))
+            start: Rat.fromMillis(Date.UTC(1980, JAN, 1, 0, 0, 0, 0)),
+            end: Rat.fromMillis(Date.UTC(1980, JAN, 1, 0, 0, 0, 0))
           }, {
-            start: millisToExact(Date.UTC(1980, JAN, 1, 0, 0, 1)),
-            end: millisToExact(Date.UTC(1980, JAN, 1, 0, 0, 1))
+            start: Rat.fromMillis(Date.UTC(1980, JAN, 1, 0, 0, 1)),
+            end: Rat.fromMillis(Date.UTC(1980, JAN, 1, 0, 0, 1))
           }])
-        expect(converter.unixToAtomic(millisToExact(Date.UTC(1980, JAN, 1, 0, 0, 0, 1))))
+        expect(converter.unixToAtomic(Rat.fromMillis(Date.UTC(1980, JAN, 1, 0, 0, 0, 1))))
           .toEqual([{
-            start: millisToExact(Date.UTC(1980, JAN, 1, 0, 0, 0, 1)),
-            end: millisToExact(Date.UTC(1980, JAN, 1, 0, 0, 0, 1))
+            start: Rat.fromMillis(Date.UTC(1980, JAN, 1, 0, 0, 0, 1)),
+            end: Rat.fromMillis(Date.UTC(1980, JAN, 1, 0, 0, 0, 1))
           }, {
-            start: millisToExact(Date.UTC(1980, JAN, 1, 0, 0, 1, 1)),
-            end: millisToExact(Date.UTC(1980, JAN, 1, 0, 0, 1, 1))
+            start: Rat.fromMillis(Date.UTC(1980, JAN, 1, 0, 0, 1, 1)),
+            end: Rat.fromMillis(Date.UTC(1980, JAN, 1, 0, 0, 1, 1))
           }])
 
         // COLLAPSE
-        expect(converter.unixToAtomic(millisToExact(Date.UTC(1980, JAN, 1, 0, 0, 0, 999))))
+        expect(converter.unixToAtomic(Rat.fromMillis(Date.UTC(1980, JAN, 1, 0, 0, 0, 999))))
           .toEqual([{
-            start: millisToExact(Date.UTC(1980, JAN, 1, 0, 0, 0, 999)),
-            end: millisToExact(Date.UTC(1980, JAN, 1, 0, 0, 0, 999))
+            start: Rat.fromMillis(Date.UTC(1980, JAN, 1, 0, 0, 0, 999)),
+            end: Rat.fromMillis(Date.UTC(1980, JAN, 1, 0, 0, 0, 999))
           }, {
-            start: millisToExact(Date.UTC(1980, JAN, 1, 0, 0, 1, 999)),
-            end: millisToExact(Date.UTC(1980, JAN, 1, 0, 0, 1, 999))
+            start: Rat.fromMillis(Date.UTC(1980, JAN, 1, 0, 0, 1, 999)),
+            end: Rat.fromMillis(Date.UTC(1980, JAN, 1, 0, 0, 1, 999))
           }])
-        expect(converter.unixToAtomic(millisToExact(Date.UTC(1980, JAN, 1, 0, 0, 1, 0))))
+        expect(converter.unixToAtomic(Rat.fromMillis(Date.UTC(1980, JAN, 1, 0, 0, 1, 0))))
           .toEqual([{
-            start: millisToExact(Date.UTC(1980, JAN, 1, 0, 0, 2, 0)),
-            end: millisToExact(Date.UTC(1980, JAN, 1, 0, 0, 2, 0))
+            start: Rat.fromMillis(Date.UTC(1980, JAN, 1, 0, 0, 2, 0)),
+            end: Rat.fromMillis(Date.UTC(1980, JAN, 1, 0, 0, 2, 0))
           }])
-        expect(converter.unixToAtomic(millisToExact(Date.UTC(1980, JAN, 1, 0, 0, 1, 1))))
+        expect(converter.unixToAtomic(Rat.fromMillis(Date.UTC(1980, JAN, 1, 0, 0, 1, 1))))
           .toEqual([{
-            start: millisToExact(Date.UTC(1980, JAN, 1, 0, 0, 2, 1)),
-            end: millisToExact(Date.UTC(1980, JAN, 1, 0, 0, 2, 1))
+            start: Rat.fromMillis(Date.UTC(1980, JAN, 1, 0, 0, 2, 1)),
+            end: Rat.fromMillis(Date.UTC(1980, JAN, 1, 0, 0, 2, 1))
           }])
       })
 
@@ -209,20 +208,20 @@ describe('Converter', () => {
         expect(converter.atomicToUnix(new Rat(0n)))
           .toEqual(new Rat(0n))
 
-        expect(converter.atomicToUnix(millisToExact(Date.UTC(1979, DEC, 31, 23, 59, 59, 999))))
-          .toEqual(millisToExact(Date.UTC(1979, DEC, 31, 23, 59, 59, 999)))
-        expect(converter.atomicToUnix(millisToExact(Date.UTC(1980, JAN, 1, 0, 0, 0, 0))))
-          .toEqual(millisToExact(Date.UTC(1980, JAN, 1, 0, 0, 0, 0)))
-        expect(converter.atomicToUnix(millisToExact(Date.UTC(1980, JAN, 1, 0, 0, 0, 1))))
-          .toEqual(millisToExact(Date.UTC(1980, JAN, 1, 0, 0, 0, 1)))
+        expect(converter.atomicToUnix(Rat.fromMillis(Date.UTC(1979, DEC, 31, 23, 59, 59, 999))))
+          .toEqual(Rat.fromMillis(Date.UTC(1979, DEC, 31, 23, 59, 59, 999)))
+        expect(converter.atomicToUnix(Rat.fromMillis(Date.UTC(1980, JAN, 1, 0, 0, 0, 0))))
+          .toEqual(Rat.fromMillis(Date.UTC(1980, JAN, 1, 0, 0, 0, 0)))
+        expect(converter.atomicToUnix(Rat.fromMillis(Date.UTC(1980, JAN, 1, 0, 0, 0, 1))))
+          .toEqual(Rat.fromMillis(Date.UTC(1980, JAN, 1, 0, 0, 0, 1)))
 
         // BACKTRACK
-        expect(converter.atomicToUnix(millisToExact(Date.UTC(1980, JAN, 1, 0, 0, 0, 999))))
-          .toEqual(millisToExact(Date.UTC(1980, JAN, 1, 0, 0, 0, 999)))
-        expect(converter.atomicToUnix(millisToExact(Date.UTC(1980, JAN, 1, 0, 0, 1, 0))))
-          .toEqual(millisToExact(Date.UTC(1980, JAN, 1, 0, 0, 0, 0)))
-        expect(converter.atomicToUnix(millisToExact(Date.UTC(1980, JAN, 1, 0, 0, 1, 1))))
-          .toEqual(millisToExact(Date.UTC(1980, JAN, 1, 0, 0, 0, 1)))
+        expect(converter.atomicToUnix(Rat.fromMillis(Date.UTC(1980, JAN, 1, 0, 0, 0, 999))))
+          .toEqual(Rat.fromMillis(Date.UTC(1980, JAN, 1, 0, 0, 0, 999)))
+        expect(converter.atomicToUnix(Rat.fromMillis(Date.UTC(1980, JAN, 1, 0, 0, 1, 0))))
+          .toEqual(Rat.fromMillis(Date.UTC(1980, JAN, 1, 0, 0, 0, 0)))
+        expect(converter.atomicToUnix(Rat.fromMillis(Date.UTC(1980, JAN, 1, 0, 0, 1, 1))))
+          .toEqual(Rat.fromMillis(Date.UTC(1980, JAN, 1, 0, 0, 0, 1)))
       })
 
       it('atomicMillisToUnixMillis', () => {
@@ -257,36 +256,36 @@ describe('Converter', () => {
           }])
 
         // FORWARD JUMP
-        expect(converter.unixToAtomic(millisToExact(Date.UTC(1979, DEC, 31, 23, 59, 59, 999))))
+        expect(converter.unixToAtomic(Rat.fromMillis(Date.UTC(1979, DEC, 31, 23, 59, 59, 999))))
           .toEqual([{
-            start: millisToExact(Date.UTC(1979, DEC, 31, 23, 59, 59, 999)),
-            end: millisToExact(Date.UTC(1979, DEC, 31, 23, 59, 59, 999))
+            start: Rat.fromMillis(Date.UTC(1979, DEC, 31, 23, 59, 59, 999)),
+            end: Rat.fromMillis(Date.UTC(1979, DEC, 31, 23, 59, 59, 999))
           }])
-        expect(converter.unixToAtomic(millisToExact(Date.UTC(1980, JAN, 1, 0, 0, 0, 0))))
+        expect(converter.unixToAtomic(Rat.fromMillis(Date.UTC(1980, JAN, 1, 0, 0, 0, 0))))
           .toEqual([{
-            start: millisToExact(Date.UTC(1980, JAN, 1, 0, 0, 1, 0)),
-            end: millisToExact(Date.UTC(1980, JAN, 1, 0, 0, 1, 0))
+            start: Rat.fromMillis(Date.UTC(1980, JAN, 1, 0, 0, 1, 0)),
+            end: Rat.fromMillis(Date.UTC(1980, JAN, 1, 0, 0, 1, 0))
           }])
-        expect(converter.unixToAtomic(millisToExact(Date.UTC(1980, JAN, 1, 0, 0, 0, 1))))
+        expect(converter.unixToAtomic(Rat.fromMillis(Date.UTC(1980, JAN, 1, 0, 0, 0, 1))))
           .toEqual([{
-            start: millisToExact(Date.UTC(1980, JAN, 1, 0, 0, 1, 1)),
-            end: millisToExact(Date.UTC(1980, JAN, 1, 0, 0, 1, 1))
+            start: Rat.fromMillis(Date.UTC(1980, JAN, 1, 0, 0, 1, 1)),
+            end: Rat.fromMillis(Date.UTC(1980, JAN, 1, 0, 0, 1, 1))
           }])
 
-        expect(converter.unixToAtomic(millisToExact(Date.UTC(1980, JAN, 1, 0, 0, 0, 999))))
+        expect(converter.unixToAtomic(Rat.fromMillis(Date.UTC(1980, JAN, 1, 0, 0, 0, 999))))
           .toEqual([{
-            start: millisToExact(Date.UTC(1980, JAN, 1, 0, 0, 1, 999)),
-            end: millisToExact(Date.UTC(1980, JAN, 1, 0, 0, 1, 999))
+            start: Rat.fromMillis(Date.UTC(1980, JAN, 1, 0, 0, 1, 999)),
+            end: Rat.fromMillis(Date.UTC(1980, JAN, 1, 0, 0, 1, 999))
           }])
-        expect(converter.unixToAtomic(millisToExact(Date.UTC(1980, JAN, 1, 0, 0, 1, 0))))
+        expect(converter.unixToAtomic(Rat.fromMillis(Date.UTC(1980, JAN, 1, 0, 0, 1, 0))))
           .toEqual([{
-            start: millisToExact(Date.UTC(1980, JAN, 1, 0, 0, 2, 0)),
-            end: millisToExact(Date.UTC(1980, JAN, 1, 0, 0, 2, 0))
+            start: Rat.fromMillis(Date.UTC(1980, JAN, 1, 0, 0, 2, 0)),
+            end: Rat.fromMillis(Date.UTC(1980, JAN, 1, 0, 0, 2, 0))
           }])
-        expect(converter.unixToAtomic(millisToExact(Date.UTC(1980, JAN, 1, 0, 0, 1, 1))))
+        expect(converter.unixToAtomic(Rat.fromMillis(Date.UTC(1980, JAN, 1, 0, 0, 1, 1))))
           .toEqual([{
-            start: millisToExact(Date.UTC(1980, JAN, 1, 0, 0, 2, 1)),
-            end: millisToExact(Date.UTC(1980, JAN, 1, 0, 0, 2, 1))
+            start: Rat.fromMillis(Date.UTC(1980, JAN, 1, 0, 0, 2, 1)),
+            end: Rat.fromMillis(Date.UTC(1980, JAN, 1, 0, 0, 2, 1))
           }])
       })
 
@@ -315,20 +314,20 @@ describe('Converter', () => {
           .toEqual(new Rat(0n))
 
         // UNDEFINED UNIX TIME STARTS
-        expect(converter.atomicToUnix(millisToExact(Date.UTC(1979, DEC, 31, 23, 59, 59, 999))))
-          .toEqual(millisToExact(Date.UTC(1979, DEC, 31, 23, 59, 59, 999)))
-        expect(converter.atomicToUnix(millisToExact(Date.UTC(1980, JAN, 1, 0, 0, 0, 0))))
+        expect(converter.atomicToUnix(Rat.fromMillis(Date.UTC(1979, DEC, 31, 23, 59, 59, 999))))
+          .toEqual(Rat.fromMillis(Date.UTC(1979, DEC, 31, 23, 59, 59, 999)))
+        expect(converter.atomicToUnix(Rat.fromMillis(Date.UTC(1980, JAN, 1, 0, 0, 0, 0))))
           .toBe(NaN)
-        expect(converter.atomicToUnix(millisToExact(Date.UTC(1980, JAN, 1, 0, 0, 0, 1))))
+        expect(converter.atomicToUnix(Rat.fromMillis(Date.UTC(1980, JAN, 1, 0, 0, 0, 1))))
           .toBe(NaN)
 
         // UNDEFINED UNIX TIME ENDS
-        expect(converter.atomicToUnix(millisToExact(Date.UTC(1980, JAN, 1, 0, 0, 0, 999))))
+        expect(converter.atomicToUnix(Rat.fromMillis(Date.UTC(1980, JAN, 1, 0, 0, 0, 999))))
           .toBe(NaN)
-        expect(converter.atomicToUnix(millisToExact(Date.UTC(1980, JAN, 1, 0, 0, 1, 0))))
-          .toEqual(millisToExact(Date.UTC(1980, JAN, 1, 0, 0, 0, 0)))
-        expect(converter.atomicToUnix(millisToExact(Date.UTC(1980, JAN, 1, 0, 0, 1, 1))))
-          .toEqual(millisToExact(Date.UTC(1980, JAN, 1, 0, 0, 0, 1)))
+        expect(converter.atomicToUnix(Rat.fromMillis(Date.UTC(1980, JAN, 1, 0, 0, 1, 0))))
+          .toEqual(Rat.fromMillis(Date.UTC(1980, JAN, 1, 0, 0, 0, 0)))
+        expect(converter.atomicToUnix(Rat.fromMillis(Date.UTC(1980, JAN, 1, 0, 0, 1, 1))))
+          .toEqual(Rat.fromMillis(Date.UTC(1980, JAN, 1, 0, 0, 0, 1)))
       })
 
       it('atomicMillisToUnixMillis', () => {
@@ -364,20 +363,20 @@ describe('Converter', () => {
           }])
 
         // STALL POINT
-        expect(converter.unixToAtomic(millisToExact(Date.UTC(1979, DEC, 31, 23, 59, 59, 999))))
+        expect(converter.unixToAtomic(Rat.fromMillis(Date.UTC(1979, DEC, 31, 23, 59, 59, 999))))
           .toEqual([{
-            start: millisToExact(Date.UTC(1979, DEC, 31, 23, 59, 59, 999)),
-            end: millisToExact(Date.UTC(1979, DEC, 31, 23, 59, 59, 999))
+            start: Rat.fromMillis(Date.UTC(1979, DEC, 31, 23, 59, 59, 999)),
+            end: Rat.fromMillis(Date.UTC(1979, DEC, 31, 23, 59, 59, 999))
           }])
-        expect(converter.unixToAtomic(millisToExact(Date.UTC(1980, JAN, 1, 0, 0, 0, 0))))
+        expect(converter.unixToAtomic(Rat.fromMillis(Date.UTC(1980, JAN, 1, 0, 0, 0, 0))))
           .toEqual([{
-            start: millisToExact(Date.UTC(1980, JAN, 1, 0, 0, 0, 0)),
-            end: millisToExact(Date.UTC(1980, JAN, 1, 0, 0, 1, 0))
+            start: Rat.fromMillis(Date.UTC(1980, JAN, 1, 0, 0, 0, 0)),
+            end: Rat.fromMillis(Date.UTC(1980, JAN, 1, 0, 0, 1, 0))
           }])
-        expect(converter.unixToAtomic(millisToExact(Date.UTC(1980, JAN, 1, 0, 0, 0, 1))))
+        expect(converter.unixToAtomic(Rat.fromMillis(Date.UTC(1980, JAN, 1, 0, 0, 0, 1))))
           .toEqual([{
-            start: millisToExact(Date.UTC(1980, JAN, 1, 0, 0, 1, 1)),
-            end: millisToExact(Date.UTC(1980, JAN, 1, 0, 0, 1, 1))
+            start: Rat.fromMillis(Date.UTC(1980, JAN, 1, 0, 0, 1, 1)),
+            end: Rat.fromMillis(Date.UTC(1980, JAN, 1, 0, 0, 1, 1))
           }])
       })
 
@@ -421,20 +420,20 @@ describe('Converter', () => {
           .toEqual(new Rat(0n))
 
         // STALL STARTS
-        expect(converter.atomicToUnix(millisToExact(Date.UTC(1979, DEC, 31, 23, 59, 59, 999))))
-          .toEqual(millisToExact(Date.UTC(1979, DEC, 31, 23, 59, 59, 999)))
-        expect(converter.atomicToUnix(millisToExact(Date.UTC(1980, JAN, 1, 0, 0, 0, 0))))
-          .toEqual(millisToExact(Date.UTC(1980, JAN, 1, 0, 0, 0, 0)))
-        expect(converter.atomicToUnix(millisToExact(Date.UTC(1980, JAN, 1, 0, 0, 0, 1))))
-          .toEqual(millisToExact(Date.UTC(1980, JAN, 1, 0, 0, 0, 0)))
+        expect(converter.atomicToUnix(Rat.fromMillis(Date.UTC(1979, DEC, 31, 23, 59, 59, 999))))
+          .toEqual(Rat.fromMillis(Date.UTC(1979, DEC, 31, 23, 59, 59, 999)))
+        expect(converter.atomicToUnix(Rat.fromMillis(Date.UTC(1980, JAN, 1, 0, 0, 0, 0))))
+          .toEqual(Rat.fromMillis(Date.UTC(1980, JAN, 1, 0, 0, 0, 0)))
+        expect(converter.atomicToUnix(Rat.fromMillis(Date.UTC(1980, JAN, 1, 0, 0, 0, 1))))
+          .toEqual(Rat.fromMillis(Date.UTC(1980, JAN, 1, 0, 0, 0, 0)))
 
         // STALL ENDS
-        expect(converter.atomicToUnix(millisToExact(Date.UTC(1980, JAN, 1, 0, 0, 0, 999))))
-          .toEqual(millisToExact(Date.UTC(1980, JAN, 1, 0, 0, 0, 0)))
-        expect(converter.atomicToUnix(millisToExact(Date.UTC(1980, JAN, 1, 0, 0, 1, 0))))
-          .toEqual(millisToExact(Date.UTC(1980, JAN, 1, 0, 0, 0, 0)))
-        expect(converter.atomicToUnix(millisToExact(Date.UTC(1980, JAN, 1, 0, 0, 1, 1))))
-          .toEqual(millisToExact(Date.UTC(1980, JAN, 1, 0, 0, 0, 1)))
+        expect(converter.atomicToUnix(Rat.fromMillis(Date.UTC(1980, JAN, 1, 0, 0, 0, 999))))
+          .toEqual(Rat.fromMillis(Date.UTC(1980, JAN, 1, 0, 0, 0, 0)))
+        expect(converter.atomicToUnix(Rat.fromMillis(Date.UTC(1980, JAN, 1, 0, 0, 1, 0))))
+          .toEqual(Rat.fromMillis(Date.UTC(1980, JAN, 1, 0, 0, 0, 0)))
+        expect(converter.atomicToUnix(Rat.fromMillis(Date.UTC(1980, JAN, 1, 0, 0, 1, 1))))
+          .toEqual(Rat.fromMillis(Date.UTC(1980, JAN, 1, 0, 0, 0, 1)))
       })
 
       it('atomicMillisToUnixMillis', () => {
@@ -470,44 +469,44 @@ describe('Converter', () => {
           }])
 
         // SMEAR STARTS, ATOMIC TIME "RUNS A LITTLE FASTER" THAN UNIX (actually Unix is slower)
-        expect(converter.unixToAtomic(millisToExact(Date.UTC(1979, DEC, 31, 11, 59, 59, 999))))
+        expect(converter.unixToAtomic(Rat.fromMillis(Date.UTC(1979, DEC, 31, 11, 59, 59, 999))))
           .toEqual([{
-            start: millisToExact(Date.UTC(1979, DEC, 31, 11, 59, 59, 999)),
-            end: millisToExact(Date.UTC(1979, DEC, 31, 11, 59, 59, 999))
+            start: Rat.fromMillis(Date.UTC(1979, DEC, 31, 11, 59, 59, 999)),
+            end: Rat.fromMillis(Date.UTC(1979, DEC, 31, 11, 59, 59, 999))
           }])
-        expect(converter.unixToAtomic(millisToExact(Date.UTC(1979, DEC, 31, 12, 0, 0, 0))))
+        expect(converter.unixToAtomic(Rat.fromMillis(Date.UTC(1979, DEC, 31, 12, 0, 0, 0))))
           .toEqual([{
-            start: millisToExact(Date.UTC(1979, DEC, 31, 12, 0, 0, 0)),
-            end: millisToExact(Date.UTC(1979, DEC, 31, 12, 0, 0, 0))
+            start: Rat.fromMillis(Date.UTC(1979, DEC, 31, 12, 0, 0, 0)),
+            end: Rat.fromMillis(Date.UTC(1979, DEC, 31, 12, 0, 0, 0))
           }])
-        expect(converter.unixToAtomic(millisToExact(Date.UTC(1979, DEC, 31, 12, 0, 0, 1))))
+        expect(converter.unixToAtomic(Rat.fromMillis(Date.UTC(1979, DEC, 31, 12, 0, 0, 1))))
           .toEqual([{
-            start: millisToExact(Date.UTC(1979, DEC, 31, 12, 0, 0, 1)).plus(new Rat(1n, 86_400_000n)),
-            end: millisToExact(Date.UTC(1979, DEC, 31, 12, 0, 0, 1)).plus(new Rat(1n, 86_400_000n))
+            start: Rat.fromMillis(Date.UTC(1979, DEC, 31, 12, 0, 0, 1)).plus(new Rat(1n, 86_400_000n)),
+            end: Rat.fromMillis(Date.UTC(1979, DEC, 31, 12, 0, 0, 1)).plus(new Rat(1n, 86_400_000n))
           }])
 
         // SMEAR MIDPOINT
-        expect(converter.unixToAtomic(millisToExact(Date.UTC(1980, JAN, 1, 0, 0, 0, 0))))
+        expect(converter.unixToAtomic(Rat.fromMillis(Date.UTC(1980, JAN, 1, 0, 0, 0, 0))))
           .toEqual([{
-            start: millisToExact(Date.UTC(1980, JAN, 1, 0, 0, 0, 500)),
-            end: millisToExact(Date.UTC(1980, JAN, 1, 0, 0, 0, 500))
+            start: Rat.fromMillis(Date.UTC(1980, JAN, 1, 0, 0, 0, 500)),
+            end: Rat.fromMillis(Date.UTC(1980, JAN, 1, 0, 0, 0, 500))
           }])
 
         // SMEAR ENDS, ATOMIC IS A FULL SECOND AHEAD (actually Unix is a full second behind)
-        expect(converter.unixToAtomic(millisToExact(Date.UTC(1980, JAN, 1, 11, 59, 59, 999))))
+        expect(converter.unixToAtomic(Rat.fromMillis(Date.UTC(1980, JAN, 1, 11, 59, 59, 999))))
           .toEqual([{
-            start: millisToExact(Date.UTC(1980, JAN, 1, 11, 59, 59, 999)).plus(new Rat(86_399_999n, 86_400_000n)),
-            end: millisToExact(Date.UTC(1980, JAN, 1, 11, 59, 59, 999)).plus(new Rat(86_399_999n, 86_400_000n))
+            start: Rat.fromMillis(Date.UTC(1980, JAN, 1, 11, 59, 59, 999)).plus(new Rat(86_399_999n, 86_400_000n)),
+            end: Rat.fromMillis(Date.UTC(1980, JAN, 1, 11, 59, 59, 999)).plus(new Rat(86_399_999n, 86_400_000n))
           }])
-        expect(converter.unixToAtomic(millisToExact(Date.UTC(1980, JAN, 1, 12, 0, 0, 0))))
+        expect(converter.unixToAtomic(Rat.fromMillis(Date.UTC(1980, JAN, 1, 12, 0, 0, 0))))
           .toEqual([{
-            start: millisToExact(Date.UTC(1980, JAN, 1, 12, 0, 1, 0)),
-            end: millisToExact(Date.UTC(1980, JAN, 1, 12, 0, 1, 0))
+            start: Rat.fromMillis(Date.UTC(1980, JAN, 1, 12, 0, 1, 0)),
+            end: Rat.fromMillis(Date.UTC(1980, JAN, 1, 12, 0, 1, 0))
           }])
-        expect(converter.unixToAtomic(millisToExact(Date.UTC(1980, JAN, 1, 12, 0, 0, 1))))
+        expect(converter.unixToAtomic(Rat.fromMillis(Date.UTC(1980, JAN, 1, 12, 0, 0, 1))))
           .toEqual([{
-            start: millisToExact(Date.UTC(1980, JAN, 1, 12, 0, 1, 1)),
-            end: millisToExact(Date.UTC(1980, JAN, 1, 12, 0, 1, 1))
+            start: Rat.fromMillis(Date.UTC(1980, JAN, 1, 12, 0, 1, 1)),
+            end: Rat.fromMillis(Date.UTC(1980, JAN, 1, 12, 0, 1, 1))
           }])
       })
 
@@ -541,24 +540,24 @@ describe('Converter', () => {
           .toEqual(new Rat(0n))
 
         // SMEAR STARTS, UNIX TIME RUNS A LITTLE SLOWER THAN ATOMIC
-        expect(converter.atomicToUnix(millisToExact(Date.UTC(1979, DEC, 31, 11, 59, 59, 999))))
-          .toEqual(millisToExact(Date.UTC(1979, DEC, 31, 11, 59, 59, 999)))
-        expect(converter.atomicToUnix(millisToExact(Date.UTC(1979, DEC, 31, 12, 0, 0, 0))))
-          .toEqual(millisToExact(Date.UTC(1979, DEC, 31, 12, 0, 0, 0)))
-        expect(converter.atomicToUnix(millisToExact(Date.UTC(1979, DEC, 31, 12, 0, 0, 1))))
-          .toEqual(millisToExact(Date.UTC(1979, DEC, 31, 12, 0, 0, 1)).minus(new Rat(1n, 86_401_000n)))
+        expect(converter.atomicToUnix(Rat.fromMillis(Date.UTC(1979, DEC, 31, 11, 59, 59, 999))))
+          .toEqual(Rat.fromMillis(Date.UTC(1979, DEC, 31, 11, 59, 59, 999)))
+        expect(converter.atomicToUnix(Rat.fromMillis(Date.UTC(1979, DEC, 31, 12, 0, 0, 0))))
+          .toEqual(Rat.fromMillis(Date.UTC(1979, DEC, 31, 12, 0, 0, 0)))
+        expect(converter.atomicToUnix(Rat.fromMillis(Date.UTC(1979, DEC, 31, 12, 0, 0, 1))))
+          .toEqual(Rat.fromMillis(Date.UTC(1979, DEC, 31, 12, 0, 0, 1)).minus(new Rat(1n, 86_401_000n)))
 
         // SMEAR MIDPOINT
-        expect(converter.atomicToUnix(millisToExact(Date.UTC(1980, JAN, 1, 0, 0, 0, 500))))
-          .toEqual(millisToExact(Date.UTC(1980, JAN, 1, 0, 0, 0, 0)))
+        expect(converter.atomicToUnix(Rat.fromMillis(Date.UTC(1980, JAN, 1, 0, 0, 0, 500))))
+          .toEqual(Rat.fromMillis(Date.UTC(1980, JAN, 1, 0, 0, 0, 0)))
 
         // SMEAR ENDS, UNIX HAS DROPPED A FULL SECOND BEHIND
-        expect(converter.atomicToUnix(millisToExact(Date.UTC(1980, JAN, 1, 12, 0, 0, 999))))
-          .toEqual(millisToExact(Date.UTC(1980, JAN, 1, 12, 0, 0, 999)).minus(new Rat(86_400_999n, 86_401_000n)))
-        expect(converter.atomicToUnix(millisToExact(Date.UTC(1980, JAN, 1, 12, 0, 1, 0))))
-          .toEqual(millisToExact(Date.UTC(1980, JAN, 1, 12, 0, 0, 0)))
-        expect(converter.atomicToUnix(millisToExact(Date.UTC(1980, JAN, 1, 12, 0, 1, 1))))
-          .toEqual(millisToExact(Date.UTC(1980, JAN, 1, 12, 0, 0, 1)))
+        expect(converter.atomicToUnix(Rat.fromMillis(Date.UTC(1980, JAN, 1, 12, 0, 0, 999))))
+          .toEqual(Rat.fromMillis(Date.UTC(1980, JAN, 1, 12, 0, 0, 999)).minus(new Rat(86_400_999n, 86_401_000n)))
+        expect(converter.atomicToUnix(Rat.fromMillis(Date.UTC(1980, JAN, 1, 12, 0, 1, 0))))
+          .toEqual(Rat.fromMillis(Date.UTC(1980, JAN, 1, 12, 0, 0, 0)))
+        expect(converter.atomicToUnix(Rat.fromMillis(Date.UTC(1980, JAN, 1, 12, 0, 1, 1))))
+          .toEqual(Rat.fromMillis(Date.UTC(1980, JAN, 1, 12, 0, 0, 1)))
       })
 
       it('atomicMillisToUnixMillis', () => {
@@ -605,31 +604,31 @@ describe('Converter', () => {
           }])
 
         // START OF MISSING TIME
-        expect(converter.unixToAtomic(millisToExact(Date.UTC(1979, DEC, 31, 23, 59, 58, 999))))
+        expect(converter.unixToAtomic(Rat.fromMillis(Date.UTC(1979, DEC, 31, 23, 59, 58, 999))))
           .toEqual([{
-            start: millisToExact(Date.UTC(1979, DEC, 31, 23, 59, 58, 999)),
-            end: millisToExact(Date.UTC(1979, DEC, 31, 23, 59, 58, 999))
+            start: Rat.fromMillis(Date.UTC(1979, DEC, 31, 23, 59, 58, 999)),
+            end: Rat.fromMillis(Date.UTC(1979, DEC, 31, 23, 59, 58, 999))
           }])
-        expect(converter.unixToAtomic(millisToExact(Date.UTC(1979, DEC, 31, 23, 59, 59, 0))))
+        expect(converter.unixToAtomic(Rat.fromMillis(Date.UTC(1979, DEC, 31, 23, 59, 59, 0))))
           .toEqual([
           ])
-        expect(converter.unixToAtomic(millisToExact(Date.UTC(1979, DEC, 31, 23, 59, 59, 1))))
+        expect(converter.unixToAtomic(Rat.fromMillis(Date.UTC(1979, DEC, 31, 23, 59, 59, 1))))
           .toEqual([
           ])
 
         // END OF MISSING TIME
-        expect(converter.unixToAtomic(millisToExact(Date.UTC(1979, DEC, 31, 23, 59, 59, 999))))
+        expect(converter.unixToAtomic(Rat.fromMillis(Date.UTC(1979, DEC, 31, 23, 59, 59, 999))))
           .toEqual([
           ])
-        expect(converter.unixToAtomic(millisToExact(Date.UTC(1980, JAN, 1, 0, 0, 0, 0))))
+        expect(converter.unixToAtomic(Rat.fromMillis(Date.UTC(1980, JAN, 1, 0, 0, 0, 0))))
           .toEqual([{
-            start: millisToExact(Date.UTC(1979, DEC, 31, 23, 59, 59, 0)),
-            end: millisToExact(Date.UTC(1979, DEC, 31, 23, 59, 59, 0))
+            start: Rat.fromMillis(Date.UTC(1979, DEC, 31, 23, 59, 59, 0)),
+            end: Rat.fromMillis(Date.UTC(1979, DEC, 31, 23, 59, 59, 0))
           }])
-        expect(converter.unixToAtomic(millisToExact(Date.UTC(1980, JAN, 1, 0, 0, 0, 1))))
+        expect(converter.unixToAtomic(Rat.fromMillis(Date.UTC(1980, JAN, 1, 0, 0, 0, 1))))
           .toEqual([{
-            start: millisToExact(Date.UTC(1979, DEC, 31, 23, 59, 59, 1)),
-            end: millisToExact(Date.UTC(1979, DEC, 31, 23, 59, 59, 1))
+            start: Rat.fromMillis(Date.UTC(1979, DEC, 31, 23, 59, 59, 1)),
+            end: Rat.fromMillis(Date.UTC(1979, DEC, 31, 23, 59, 59, 1))
           }])
       })
 
@@ -689,12 +688,12 @@ describe('Converter', () => {
           .toEqual(new Rat(0n))
 
         // JUMP AHEAD
-        expect(converter.atomicToUnix(millisToExact(Date.UTC(1979, DEC, 31, 23, 59, 58, 999))))
-          .toEqual(millisToExact(Date.UTC(1979, DEC, 31, 23, 59, 58, 999)))
-        expect(converter.atomicToUnix(millisToExact(Date.UTC(1979, DEC, 31, 23, 59, 59, 0))))
-          .toEqual(millisToExact(Date.UTC(1980, JAN, 1, 0, 0, 0, 0)))
-        expect(converter.atomicToUnix(millisToExact(Date.UTC(1979, DEC, 31, 23, 59, 59, 1))))
-          .toEqual(millisToExact(Date.UTC(1980, JAN, 1, 0, 0, 0, 1)))
+        expect(converter.atomicToUnix(Rat.fromMillis(Date.UTC(1979, DEC, 31, 23, 59, 58, 999))))
+          .toEqual(Rat.fromMillis(Date.UTC(1979, DEC, 31, 23, 59, 58, 999)))
+        expect(converter.atomicToUnix(Rat.fromMillis(Date.UTC(1979, DEC, 31, 23, 59, 59, 0))))
+          .toEqual(Rat.fromMillis(Date.UTC(1980, JAN, 1, 0, 0, 0, 0)))
+        expect(converter.atomicToUnix(Rat.fromMillis(Date.UTC(1979, DEC, 31, 23, 59, 59, 1))))
+          .toEqual(Rat.fromMillis(Date.UTC(1980, JAN, 1, 0, 0, 0, 1)))
       })
 
       it('atomicMillisToUnixMillis', () => {
@@ -722,31 +721,31 @@ describe('Converter', () => {
           }])
 
         // START OF MISSING TIME
-        expect(converter.unixToAtomic(millisToExact(Date.UTC(1979, DEC, 31, 23, 59, 58, 999))))
+        expect(converter.unixToAtomic(Rat.fromMillis(Date.UTC(1979, DEC, 31, 23, 59, 58, 999))))
           .toEqual([{
-            start: millisToExact(Date.UTC(1979, DEC, 31, 23, 59, 58, 999)),
-            end: millisToExact(Date.UTC(1979, DEC, 31, 23, 59, 58, 999))
+            start: Rat.fromMillis(Date.UTC(1979, DEC, 31, 23, 59, 58, 999)),
+            end: Rat.fromMillis(Date.UTC(1979, DEC, 31, 23, 59, 58, 999))
           }])
-        expect(converter.unixToAtomic(millisToExact(Date.UTC(1979, DEC, 31, 23, 59, 59, 0))))
+        expect(converter.unixToAtomic(Rat.fromMillis(Date.UTC(1979, DEC, 31, 23, 59, 59, 0))))
           .toEqual([
           ])
-        expect(converter.unixToAtomic(millisToExact(Date.UTC(1979, DEC, 31, 23, 59, 59, 1))))
+        expect(converter.unixToAtomic(Rat.fromMillis(Date.UTC(1979, DEC, 31, 23, 59, 59, 1))))
           .toEqual([
           ])
 
         // END OF MISSING TIME
-        expect(converter.unixToAtomic(millisToExact(Date.UTC(1979, DEC, 31, 23, 59, 59, 999))))
+        expect(converter.unixToAtomic(Rat.fromMillis(Date.UTC(1979, DEC, 31, 23, 59, 59, 999))))
           .toEqual([
           ])
-        expect(converter.unixToAtomic(millisToExact(Date.UTC(1980, JAN, 1, 0, 0, 0, 0))))
+        expect(converter.unixToAtomic(Rat.fromMillis(Date.UTC(1980, JAN, 1, 0, 0, 0, 0))))
           .toEqual([{
-            start: millisToExact(Date.UTC(1979, DEC, 31, 23, 59, 59, 0)),
-            end: millisToExact(Date.UTC(1979, DEC, 31, 23, 59, 59, 0))
+            start: Rat.fromMillis(Date.UTC(1979, DEC, 31, 23, 59, 59, 0)),
+            end: Rat.fromMillis(Date.UTC(1979, DEC, 31, 23, 59, 59, 0))
           }])
-        expect(converter.unixToAtomic(millisToExact(Date.UTC(1980, JAN, 1, 0, 0, 0, 1))))
+        expect(converter.unixToAtomic(Rat.fromMillis(Date.UTC(1980, JAN, 1, 0, 0, 0, 1))))
           .toEqual([{
-            start: millisToExact(Date.UTC(1979, DEC, 31, 23, 59, 59, 1)),
-            end: millisToExact(Date.UTC(1979, DEC, 31, 23, 59, 59, 1))
+            start: Rat.fromMillis(Date.UTC(1979, DEC, 31, 23, 59, 59, 1)),
+            end: Rat.fromMillis(Date.UTC(1979, DEC, 31, 23, 59, 59, 1))
           }])
       })
 
@@ -776,12 +775,12 @@ describe('Converter', () => {
           .toEqual(new Rat(0n))
 
         // JUMP AHEAD
-        expect(converter.atomicToUnix(millisToExact(Date.UTC(1979, DEC, 31, 23, 59, 58, 999))))
-          .toEqual(millisToExact(Date.UTC(1979, DEC, 31, 23, 59, 58, 999)))
-        expect(converter.atomicToUnix(millisToExact(Date.UTC(1979, DEC, 31, 23, 59, 59, 0))))
-          .toEqual(millisToExact(Date.UTC(1980, JAN, 1, 0, 0, 0, 0)))
-        expect(converter.atomicToUnix(millisToExact(Date.UTC(1979, DEC, 31, 23, 59, 59, 1))))
-          .toEqual(millisToExact(Date.UTC(1980, JAN, 1, 0, 0, 0, 1)))
+        expect(converter.atomicToUnix(Rat.fromMillis(Date.UTC(1979, DEC, 31, 23, 59, 58, 999))))
+          .toEqual(Rat.fromMillis(Date.UTC(1979, DEC, 31, 23, 59, 58, 999)))
+        expect(converter.atomicToUnix(Rat.fromMillis(Date.UTC(1979, DEC, 31, 23, 59, 59, 0))))
+          .toEqual(Rat.fromMillis(Date.UTC(1980, JAN, 1, 0, 0, 0, 0)))
+        expect(converter.atomicToUnix(Rat.fromMillis(Date.UTC(1979, DEC, 31, 23, 59, 59, 1))))
+          .toEqual(Rat.fromMillis(Date.UTC(1980, JAN, 1, 0, 0, 0, 1)))
       })
 
       it('atomicMillisToUnixMillis', () => {
@@ -809,31 +808,31 @@ describe('Converter', () => {
           }])
 
         // START OF MISSING TIME
-        expect(converter.unixToAtomic(millisToExact(Date.UTC(1979, DEC, 31, 23, 59, 58, 999))))
+        expect(converter.unixToAtomic(Rat.fromMillis(Date.UTC(1979, DEC, 31, 23, 59, 58, 999))))
           .toEqual([{
-            start: millisToExact(Date.UTC(1979, DEC, 31, 23, 59, 58, 999)),
-            end: millisToExact(Date.UTC(1979, DEC, 31, 23, 59, 58, 999))
+            start: Rat.fromMillis(Date.UTC(1979, DEC, 31, 23, 59, 58, 999)),
+            end: Rat.fromMillis(Date.UTC(1979, DEC, 31, 23, 59, 58, 999))
           }])
-        expect(converter.unixToAtomic(millisToExact(Date.UTC(1979, DEC, 31, 23, 59, 59, 0))))
+        expect(converter.unixToAtomic(Rat.fromMillis(Date.UTC(1979, DEC, 31, 23, 59, 59, 0))))
           .toEqual([
           ])
-        expect(converter.unixToAtomic(millisToExact(Date.UTC(1979, DEC, 31, 23, 59, 59, 1))))
+        expect(converter.unixToAtomic(Rat.fromMillis(Date.UTC(1979, DEC, 31, 23, 59, 59, 1))))
           .toEqual([
           ])
 
         // END OF MISSING TIME
-        expect(converter.unixToAtomic(millisToExact(Date.UTC(1979, DEC, 31, 23, 59, 59, 999))))
+        expect(converter.unixToAtomic(Rat.fromMillis(Date.UTC(1979, DEC, 31, 23, 59, 59, 999))))
           .toEqual([
           ])
-        expect(converter.unixToAtomic(millisToExact(Date.UTC(1980, JAN, 1, 0, 0, 0, 0))))
+        expect(converter.unixToAtomic(Rat.fromMillis(Date.UTC(1980, JAN, 1, 0, 0, 0, 0))))
           .toEqual([{
-            start: millisToExact(Date.UTC(1979, DEC, 31, 23, 59, 59, 0)),
-            end: millisToExact(Date.UTC(1979, DEC, 31, 23, 59, 59, 0))
+            start: Rat.fromMillis(Date.UTC(1979, DEC, 31, 23, 59, 59, 0)),
+            end: Rat.fromMillis(Date.UTC(1979, DEC, 31, 23, 59, 59, 0))
           }])
-        expect(converter.unixToAtomic(millisToExact(Date.UTC(1980, JAN, 1, 0, 0, 0, 1))))
+        expect(converter.unixToAtomic(Rat.fromMillis(Date.UTC(1980, JAN, 1, 0, 0, 0, 1))))
           .toEqual([{
-            start: millisToExact(Date.UTC(1979, DEC, 31, 23, 59, 59, 1)),
-            end: millisToExact(Date.UTC(1979, DEC, 31, 23, 59, 59, 1))
+            start: Rat.fromMillis(Date.UTC(1979, DEC, 31, 23, 59, 59, 1)),
+            end: Rat.fromMillis(Date.UTC(1979, DEC, 31, 23, 59, 59, 1))
           }])
       })
 
@@ -905,12 +904,12 @@ describe('Converter', () => {
           .toEqual(new Rat(0n))
 
         // JUMP AHEAD
-        expect(converter.atomicToUnix(millisToExact(Date.UTC(1979, DEC, 31, 23, 59, 58, 999))))
-          .toEqual(millisToExact(Date.UTC(1979, DEC, 31, 23, 59, 58, 999)))
-        expect(converter.atomicToUnix(millisToExact(Date.UTC(1979, DEC, 31, 23, 59, 59, 0))))
-          .toEqual(millisToExact(Date.UTC(1980, JAN, 1, 0, 0, 0, 0)))
-        expect(converter.atomicToUnix(millisToExact(Date.UTC(1979, DEC, 31, 23, 59, 59, 1))))
-          .toEqual(millisToExact(Date.UTC(1980, JAN, 1, 0, 0, 0, 1)))
+        expect(converter.atomicToUnix(Rat.fromMillis(Date.UTC(1979, DEC, 31, 23, 59, 58, 999))))
+          .toEqual(Rat.fromMillis(Date.UTC(1979, DEC, 31, 23, 59, 58, 999)))
+        expect(converter.atomicToUnix(Rat.fromMillis(Date.UTC(1979, DEC, 31, 23, 59, 59, 0))))
+          .toEqual(Rat.fromMillis(Date.UTC(1980, JAN, 1, 0, 0, 0, 0)))
+        expect(converter.atomicToUnix(Rat.fromMillis(Date.UTC(1979, DEC, 31, 23, 59, 59, 1))))
+          .toEqual(Rat.fromMillis(Date.UTC(1980, JAN, 1, 0, 0, 0, 1)))
       })
 
       it('atomicMillisToUnixMillis', () => {
@@ -938,44 +937,44 @@ describe('Converter', () => {
           }])
 
         // SMEAR STARTS, ATOMIC "RUNS A LITTLE SLOWER" THAN UNIX (actually Unix runs faster)
-        expect(converter.unixToAtomic(millisToExact(Date.UTC(1979, DEC, 31, 11, 59, 59, 999))))
+        expect(converter.unixToAtomic(Rat.fromMillis(Date.UTC(1979, DEC, 31, 11, 59, 59, 999))))
           .toEqual([{
-            start: millisToExact(Date.UTC(1979, DEC, 31, 11, 59, 59, 999)),
-            end: millisToExact(Date.UTC(1979, DEC, 31, 11, 59, 59, 999))
+            start: Rat.fromMillis(Date.UTC(1979, DEC, 31, 11, 59, 59, 999)),
+            end: Rat.fromMillis(Date.UTC(1979, DEC, 31, 11, 59, 59, 999))
           }])
-        expect(converter.unixToAtomic(millisToExact(Date.UTC(1979, DEC, 31, 12, 0, 0, 0))))
+        expect(converter.unixToAtomic(Rat.fromMillis(Date.UTC(1979, DEC, 31, 12, 0, 0, 0))))
           .toEqual([{
-            start: millisToExact(Date.UTC(1979, DEC, 31, 12, 0, 0, 0)),
-            end: millisToExact(Date.UTC(1979, DEC, 31, 12, 0, 0, 0))
+            start: Rat.fromMillis(Date.UTC(1979, DEC, 31, 12, 0, 0, 0)),
+            end: Rat.fromMillis(Date.UTC(1979, DEC, 31, 12, 0, 0, 0))
           }])
-        expect(converter.unixToAtomic(millisToExact(Date.UTC(1979, DEC, 31, 12, 0, 0, 1))))
+        expect(converter.unixToAtomic(Rat.fromMillis(Date.UTC(1979, DEC, 31, 12, 0, 0, 1))))
           .toEqual([{
-            start: millisToExact(Date.UTC(1979, DEC, 31, 12, 0, 0, 1)).minus(new Rat(1n, 86_400_000n)),
-            end: millisToExact(Date.UTC(1979, DEC, 31, 12, 0, 0, 1)).minus(new Rat(1n, 86_400_000n))
+            start: Rat.fromMillis(Date.UTC(1979, DEC, 31, 12, 0, 0, 1)).minus(new Rat(1n, 86_400_000n)),
+            end: Rat.fromMillis(Date.UTC(1979, DEC, 31, 12, 0, 0, 1)).minus(new Rat(1n, 86_400_000n))
           }])
 
         // SMEAR MIDPOINT
-        expect(converter.unixToAtomic(millisToExact(Date.UTC(1980, JAN, 1, 0, 0, 0, 0))))
+        expect(converter.unixToAtomic(Rat.fromMillis(Date.UTC(1980, JAN, 1, 0, 0, 0, 0))))
           .toEqual([{
-            start: millisToExact(Date.UTC(1979, DEC, 31, 23, 59, 59, 500)),
-            end: millisToExact(Date.UTC(1979, DEC, 31, 23, 59, 59, 500))
+            start: Rat.fromMillis(Date.UTC(1979, DEC, 31, 23, 59, 59, 500)),
+            end: Rat.fromMillis(Date.UTC(1979, DEC, 31, 23, 59, 59, 500))
           }])
 
         // SMEAR ENDS, ATOMIC IS A FULL SECOND BEHIND (actually Unix is a full second ahead)
-        expect(converter.unixToAtomic(millisToExact(Date.UTC(1980, JAN, 1, 11, 59, 59, 999))))
+        expect(converter.unixToAtomic(Rat.fromMillis(Date.UTC(1980, JAN, 1, 11, 59, 59, 999))))
           .toEqual([{
-            start: millisToExact(Date.UTC(1980, JAN, 1, 11, 59, 59, 999)).minus(new Rat(86_399_999n, 86_400_000n)),
-            end: millisToExact(Date.UTC(1980, JAN, 1, 11, 59, 59, 999)).minus(new Rat(86_399_999n, 86_400_000n))
+            start: Rat.fromMillis(Date.UTC(1980, JAN, 1, 11, 59, 59, 999)).minus(new Rat(86_399_999n, 86_400_000n)),
+            end: Rat.fromMillis(Date.UTC(1980, JAN, 1, 11, 59, 59, 999)).minus(new Rat(86_399_999n, 86_400_000n))
           }])
-        expect(converter.unixToAtomic(millisToExact(Date.UTC(1980, JAN, 1, 12, 0, 0, 0))))
+        expect(converter.unixToAtomic(Rat.fromMillis(Date.UTC(1980, JAN, 1, 12, 0, 0, 0))))
           .toEqual([{
-            start: millisToExact(Date.UTC(1980, JAN, 1, 11, 59, 59, 0)),
-            end: millisToExact(Date.UTC(1980, JAN, 1, 11, 59, 59, 0))
+            start: Rat.fromMillis(Date.UTC(1980, JAN, 1, 11, 59, 59, 0)),
+            end: Rat.fromMillis(Date.UTC(1980, JAN, 1, 11, 59, 59, 0))
           }])
-        expect(converter.unixToAtomic(millisToExact(Date.UTC(1980, JAN, 1, 12, 0, 0, 1))))
+        expect(converter.unixToAtomic(Rat.fromMillis(Date.UTC(1980, JAN, 1, 12, 0, 0, 1))))
           .toEqual([{
-            start: millisToExact(Date.UTC(1980, JAN, 1, 11, 59, 59, 1)),
-            end: millisToExact(Date.UTC(1980, JAN, 1, 11, 59, 59, 1))
+            start: Rat.fromMillis(Date.UTC(1980, JAN, 1, 11, 59, 59, 1)),
+            end: Rat.fromMillis(Date.UTC(1980, JAN, 1, 11, 59, 59, 1))
           }])
       })
 
@@ -1009,24 +1008,24 @@ describe('Converter', () => {
           .toEqual(new Rat(0n))
 
         // SMEAR STARTS, UNIX TIME RUNS A LITTLE FASTER THAN ATOMIC
-        expect(converter.atomicToUnix(millisToExact(Date.UTC(1979, DEC, 31, 11, 59, 59, 999))))
-          .toEqual(millisToExact(Date.UTC(1979, DEC, 31, 11, 59, 59, 999)))
-        expect(converter.atomicToUnix(millisToExact(Date.UTC(1979, DEC, 31, 12, 0, 0, 0))))
-          .toEqual(millisToExact(Date.UTC(1979, DEC, 31, 12, 0, 0, 0)))
-        expect(converter.atomicToUnix(millisToExact(Date.UTC(1979, DEC, 31, 12, 0, 0, 1))))
-          .toEqual(millisToExact(Date.UTC(1979, DEC, 31, 12, 0, 0, 1)).plus(new Rat(1n, 86_399_000n)))
+        expect(converter.atomicToUnix(Rat.fromMillis(Date.UTC(1979, DEC, 31, 11, 59, 59, 999))))
+          .toEqual(Rat.fromMillis(Date.UTC(1979, DEC, 31, 11, 59, 59, 999)))
+        expect(converter.atomicToUnix(Rat.fromMillis(Date.UTC(1979, DEC, 31, 12, 0, 0, 0))))
+          .toEqual(Rat.fromMillis(Date.UTC(1979, DEC, 31, 12, 0, 0, 0)))
+        expect(converter.atomicToUnix(Rat.fromMillis(Date.UTC(1979, DEC, 31, 12, 0, 0, 1))))
+          .toEqual(Rat.fromMillis(Date.UTC(1979, DEC, 31, 12, 0, 0, 1)).plus(new Rat(1n, 86_399_000n)))
 
         // SMEAR MIDPOINT
-        expect(converter.atomicToUnix(millisToExact(Date.UTC(1979, DEC, 31, 23, 59, 59, 500))))
-          .toEqual(millisToExact(Date.UTC(1980, JAN, 1, 0, 0, 0, 0)))
+        expect(converter.atomicToUnix(Rat.fromMillis(Date.UTC(1979, DEC, 31, 23, 59, 59, 500))))
+          .toEqual(Rat.fromMillis(Date.UTC(1980, JAN, 1, 0, 0, 0, 0)))
 
         // SMEAR ENDS, UNIX HAS RUN A FULL SECOND FASTER THAN ATOMIC
-        expect(converter.atomicToUnix(millisToExact(Date.UTC(1980, JAN, 1, 11, 59, 58, 999))))
-          .toEqual(millisToExact(Date.UTC(1980, JAN, 1, 11, 59, 58, 999)).plus(new Rat(86_398_999n, 86_399_000n)))
-        expect(converter.atomicToUnix(millisToExact(Date.UTC(1980, JAN, 1, 11, 59, 59, 0))))
-          .toEqual(millisToExact(Date.UTC(1980, JAN, 1, 12, 0, 0, 0)))
-        expect(converter.atomicToUnix(millisToExact(Date.UTC(1980, JAN, 1, 11, 59, 59, 1))))
-          .toEqual(millisToExact(Date.UTC(1980, JAN, 1, 12, 0, 0, 1)))
+        expect(converter.atomicToUnix(Rat.fromMillis(Date.UTC(1980, JAN, 1, 11, 59, 58, 999))))
+          .toEqual(Rat.fromMillis(Date.UTC(1980, JAN, 1, 11, 59, 58, 999)).plus(new Rat(86_398_999n, 86_399_000n)))
+        expect(converter.atomicToUnix(Rat.fromMillis(Date.UTC(1980, JAN, 1, 11, 59, 59, 0))))
+          .toEqual(Rat.fromMillis(Date.UTC(1980, JAN, 1, 12, 0, 0, 0)))
+        expect(converter.atomicToUnix(Rat.fromMillis(Date.UTC(1980, JAN, 1, 11, 59, 59, 1))))
+          .toEqual(Rat.fromMillis(Date.UTC(1980, JAN, 1, 12, 0, 0, 1)))
       })
 
       it('atomicMillisToUnixMillis', () => {

--- a/src/converter.spec.js
+++ b/src/converter.spec.js
@@ -96,606 +96,523 @@ describe('Converter', () => {
     describe('OVERRUN', () => {
       const converter = Converter(data, MODELS.OVERRUN)
 
-      describe('conversions grouped by instant', () => {
-        it('start of time', () => {
-          expect(converter.unixToAtomic(new Rat(0n))).toEqual([{ start: new Rat(0n), end: new Rat(0n), closed: true }])
-          expect(converter.unixMillisToAtomicMillis(0, { array: true })).toEqual([0])
-          expect(converter.unixMillisToAtomicMillis(0)).toBe(0)
-          expect(converter.atomicToUnix(new Rat(0n))).toEqual(new Rat(0n))
-          expect(converter.atomicMillisToUnixMillis(0)).toBe(0)
-        })
+      it('unixToAtomic', () => {
+        expect(converter.unixToAtomic(new Rat(0n)))
+          .toEqual([{
+            start: new Rat(0n),
+            end: new Rat(0n),
+            closed: true
+          }])
 
-        it('millisecond before inserted leap second discontinuity begins', () => {
-          expect(converter.unixToAtomic(millisToExact(Date.UTC(1979, DEC, 31, 23, 59, 59, 999))))
-            .toEqual([{
-              start: millisToExact(Date.UTC(1979, DEC, 31, 23, 59, 59, 999)),
-              end: millisToExact(Date.UTC(1979, DEC, 31, 23, 59, 59, 999)),
-              closed: true
-            }])
-          expect(converter.unixMillisToAtomicMillis(Date.UTC(1979, DEC, 31, 23, 59, 59, 999), { array: true }))
-            .toEqual([
-              Date.UTC(1979, DEC, 31, 23, 59, 59, 999)
-            ])
-          expect(converter.unixMillisToAtomicMillis(Date.UTC(1979, DEC, 31, 23, 59, 59, 999)))
-            .toBe(Date.UTC(1979, DEC, 31, 23, 59, 59, 999))
-          expect(converter.atomicToUnix(millisToExact(Date.UTC(1979, DEC, 31, 23, 59, 59, 999))))
-            .toEqual(millisToExact(Date.UTC(1979, DEC, 31, 23, 59, 59, 999)))
-          expect(converter.atomicMillisToUnixMillis(Date.UTC(1979, DEC, 31, 23, 59, 59, 999)))
-            .toBe(Date.UTC(1979, DEC, 31, 23, 59, 59, 999))
-        })
+        // BIFURCATION
+        expect(converter.unixToAtomic(millisToExact(Date.UTC(1979, DEC, 31, 23, 59, 59, 999))))
+          .toEqual([{
+            start: millisToExact(Date.UTC(1979, DEC, 31, 23, 59, 59, 999)),
+            end: millisToExact(Date.UTC(1979, DEC, 31, 23, 59, 59, 999)),
+            closed: true
+          }])
+        expect(converter.unixToAtomic(millisToExact(Date.UTC(1980, JAN, 1, 0, 0, 0, 0))))
+          .toEqual([{
+            start: millisToExact(Date.UTC(1980, JAN, 1, 0, 0, 0, 0)),
+            end: millisToExact(Date.UTC(1980, JAN, 1, 0, 0, 0, 0)),
+            closed: true
+          }, {
+            start: millisToExact(Date.UTC(1980, JAN, 1, 0, 0, 1)),
+            end: millisToExact(Date.UTC(1980, JAN, 1, 0, 0, 1)),
+            closed: true
+          }])
+        expect(converter.unixToAtomic(millisToExact(Date.UTC(1980, JAN, 1, 0, 0, 0, 1))))
+          .toEqual([{
+            start: millisToExact(Date.UTC(1980, JAN, 1, 0, 0, 0, 1)),
+            end: millisToExact(Date.UTC(1980, JAN, 1, 0, 0, 0, 1)),
+            closed: true
+          }, {
+            start: millisToExact(Date.UTC(1980, JAN, 1, 0, 0, 1, 1)),
+            end: millisToExact(Date.UTC(1980, JAN, 1, 0, 0, 1, 1)),
+            closed: true
+          }])
 
-        it('first instant of the Unix time discontinuity: one Unix time is two TAI times', () => {
-          expect(converter.unixToAtomic(millisToExact(Date.UTC(1980, JAN, 1, 0, 0, 0))))
-            .toEqual([{
-              start: millisToExact(Date.UTC(1980, JAN, 1, 0, 0, 0)),
-              end: millisToExact(Date.UTC(1980, JAN, 1, 0, 0, 0)),
-              closed: true
-            }, {
-              start: millisToExact(Date.UTC(1980, JAN, 1, 0, 0, 1)),
-              end: millisToExact(Date.UTC(1980, JAN, 1, 0, 0, 1)),
-              closed: true
-            }])
-          expect(converter.unixMillisToAtomicMillis(Date.UTC(1980, JAN, 1, 0, 0, 0), { array: true }))
-            .toEqual([
-              Date.UTC(1980, JAN, 1, 0, 0, 0),
-              Date.UTC(1980, JAN, 1, 0, 0, 1)
-            ])
-          expect(converter.unixMillisToAtomicMillis(Date.UTC(1980, JAN, 1, 0, 0, 0)))
-            .toBe(Date.UTC(1980, JAN, 1, 0, 0, 1))
-          expect(converter.atomicToUnix(millisToExact(Date.UTC(1980, JAN, 1, 0, 0, 0))))
-            .toEqual(millisToExact(Date.UTC(1980, JAN, 1, 0, 0, 0)))
-          expect(converter.atomicMillisToUnixMillis(Date.UTC(1980, JAN, 1, 0, 0, 0)))
-            .toBe(Date.UTC(1980, JAN, 1, 0, 0, 0))
-          expect(converter.atomicMillisToUnixMillis(Date.UTC(1980, JAN, 1, 0, 0, 1)))
-            .toBe(Date.UTC(1980, JAN, 1, 0, 0, 0))
-        })
-
-        it('final instant of the Unix time discontinuity: one Unix time is two TAI times', () => {
-          expect(converter.unixToAtomic(millisToExact(Date.UTC(1980, JAN, 1, 0, 0, 0, 999))))
-            .toEqual([{
-              start: millisToExact(Date.UTC(1980, JAN, 1, 0, 0, 0, 999)),
-              end: millisToExact(Date.UTC(1980, JAN, 1, 0, 0, 0, 999)),
-              closed: true
-            }, {
-              start: millisToExact(Date.UTC(1980, JAN, 1, 0, 0, 1, 999)),
-              end: millisToExact(Date.UTC(1980, JAN, 1, 0, 0, 1, 999)),
-              closed: true
-            }])
-          expect(converter.unixMillisToAtomicMillis(Date.UTC(1980, JAN, 1, 0, 0, 0, 999), { array: true }))
-            .toEqual([
-              Date.UTC(1980, JAN, 1, 0, 0, 0, 999),
-              Date.UTC(1980, JAN, 1, 0, 0, 1, 999)
-            ])
-          expect(converter.unixMillisToAtomicMillis(Date.UTC(1980, JAN, 1, 0, 0, 0, 999)))
-            .toBe(Date.UTC(1980, JAN, 1, 0, 0, 1, 999))
-          expect(converter.atomicToUnix(millisToExact(Date.UTC(1980, JAN, 1, 0, 0, 0, 999))))
-            .toEqual(millisToExact(Date.UTC(1980, JAN, 1, 0, 0, 0, 999)))
-          expect(converter.atomicMillisToUnixMillis(Date.UTC(1980, JAN, 1, 0, 0, 0, 999)))
-            .toBe(Date.UTC(1980, JAN, 1, 0, 0, 0, 999))
-          expect(converter.atomicMillisToUnixMillis(Date.UTC(1980, JAN, 1, 0, 0, 1, 999)))
-            .toBe(Date.UTC(1980, JAN, 1, 0, 0, 0, 999))
-        })
-
-        it('millisecond after discontinuity ends', () => {
-          expect(converter.unixToAtomic(millisToExact(Date.UTC(1980, JAN, 1, 0, 0, 1))))
-            .toEqual([{
-              start: millisToExact(Date.UTC(1980, JAN, 1, 0, 0, 2)),
-              end: millisToExact(Date.UTC(1980, JAN, 1, 0, 0, 2)),
-              closed: true
-            }])
-          expect(converter.unixMillisToAtomicMillis(Date.UTC(1980, JAN, 1, 0, 0, 1), { array: true }))
-            .toEqual([
-              Date.UTC(1980, JAN, 1, 0, 0, 2)
-            ])
-          expect(converter.unixMillisToAtomicMillis(Date.UTC(1980, JAN, 1, 0, 0, 1)))
-            .toBe(Date.UTC(1980, JAN, 1, 0, 0, 2))
-          expect(converter.atomicToUnix(millisToExact(Date.UTC(1980, JAN, 1, 0, 0, 2))))
-            .toEqual(millisToExact(Date.UTC(1980, JAN, 1, 0, 0, 1)))
-          expect(converter.atomicMillisToUnixMillis(Date.UTC(1980, JAN, 1, 0, 0, 2)))
-            .toBe(Date.UTC(1980, JAN, 1, 0, 0, 1))
-        })
+        // COLLAPSE
+        expect(converter.unixToAtomic(millisToExact(Date.UTC(1980, JAN, 1, 0, 0, 0, 999))))
+          .toEqual([{
+            start: millisToExact(Date.UTC(1980, JAN, 1, 0, 0, 0, 999)),
+            end: millisToExact(Date.UTC(1980, JAN, 1, 0, 0, 0, 999)),
+            closed: true
+          }, {
+            start: millisToExact(Date.UTC(1980, JAN, 1, 0, 0, 1, 999)),
+            end: millisToExact(Date.UTC(1980, JAN, 1, 0, 0, 1, 999)),
+            closed: true
+          }])
+        expect(converter.unixToAtomic(millisToExact(Date.UTC(1980, JAN, 1, 0, 0, 1, 0))))
+          .toEqual([{
+            start: millisToExact(Date.UTC(1980, JAN, 1, 0, 0, 2, 0)),
+            end: millisToExact(Date.UTC(1980, JAN, 1, 0, 0, 2, 0)),
+            closed: true
+          }])
+        expect(converter.unixToAtomic(millisToExact(Date.UTC(1980, JAN, 1, 0, 0, 1, 1))))
+          .toEqual([{
+            start: millisToExact(Date.UTC(1980, JAN, 1, 0, 0, 2, 1)),
+            end: millisToExact(Date.UTC(1980, JAN, 1, 0, 0, 2, 1)),
+            closed: true
+          }])
       })
 
-      describe('conversions grouped by method', () => {
-        it('unixToAtomic', () => {
-          expect(converter.unixToAtomic(new Rat(0n))).toEqual([{ start: new Rat(0n), end: new Rat(0n), closed: true }])
-          expect(converter.unixToAtomic(millisToExact(Date.UTC(1979, DEC, 31, 23, 59, 59, 999))))
-            .toEqual([{
-              start: millisToExact(Date.UTC(1979, DEC, 31, 23, 59, 59, 999)),
-              end: millisToExact(Date.UTC(1979, DEC, 31, 23, 59, 59, 999)),
-              closed: true
-            }])
-          expect(converter.unixToAtomic(millisToExact(Date.UTC(1980, JAN, 1, 0, 0, 0))))
-            .toEqual([{
-              start: millisToExact(Date.UTC(1980, JAN, 1, 0, 0, 0)),
-              end: millisToExact(Date.UTC(1980, JAN, 1, 0, 0, 0)),
-              closed: true
-            }, {
-              start: millisToExact(Date.UTC(1980, JAN, 1, 0, 0, 1)),
-              end: millisToExact(Date.UTC(1980, JAN, 1, 0, 0, 1)),
-              closed: true
-            }])
-          expect(converter.unixToAtomic(millisToExact(Date.UTC(1980, JAN, 1, 0, 0, 0, 999))))
-            .toEqual([{
-              start: millisToExact(Date.UTC(1980, JAN, 1, 0, 0, 0, 999)),
-              end: millisToExact(Date.UTC(1980, JAN, 1, 0, 0, 0, 999)),
-              closed: true
-            }, {
-              start: millisToExact(Date.UTC(1980, JAN, 1, 0, 0, 1, 999)),
-              end: millisToExact(Date.UTC(1980, JAN, 1, 0, 0, 1, 999)),
-              closed: true
-            }])
-          expect(converter.unixToAtomic(millisToExact(Date.UTC(1980, JAN, 1, 0, 0, 1))))
-            .toEqual([{
-              start: millisToExact(Date.UTC(1980, JAN, 1, 0, 0, 2)),
-              end: millisToExact(Date.UTC(1980, JAN, 1, 0, 0, 2)),
-              closed: true
-            }])
-        })
+      it('unixMillisToAtomicMillis (array mode)', () => {
+        expect(converter.unixMillisToAtomicMillis(0, { array: true }))
+          .toEqual([
+            0
+          ])
 
-        it('unixMillisToAtomicMillis (array mode)', () => {
-          expect(converter.unixMillisToAtomicMillis(0, { array: true })).toEqual([0])
-          expect(converter.unixMillisToAtomicMillis(Date.UTC(1979, DEC, 31, 23, 59, 59, 999), { array: true }))
-            .toEqual([
-              Date.UTC(1979, DEC, 31, 23, 59, 59, 999)
-            ])
-          expect(converter.unixMillisToAtomicMillis(Date.UTC(1980, JAN, 1, 0, 0, 0), { array: true }))
-            .toEqual([
-              Date.UTC(1980, JAN, 1, 0, 0, 0),
-              Date.UTC(1980, JAN, 1, 0, 0, 1)
-            ])
-          expect(converter.unixMillisToAtomicMillis(Date.UTC(1980, JAN, 1, 0, 0, 0, 999), { array: true }))
-            .toEqual([
-              Date.UTC(1980, JAN, 1, 0, 0, 0, 999),
-              Date.UTC(1980, JAN, 1, 0, 0, 1, 999)
-            ])
-          expect(converter.unixMillisToAtomicMillis(Date.UTC(1980, JAN, 1, 0, 0, 1), { array: true }))
-            .toEqual([
-              Date.UTC(1980, JAN, 1, 0, 0, 2)
-            ])
-        })
+        // BIFURCATION
+        expect(converter.unixMillisToAtomicMillis(Date.UTC(1979, DEC, 31, 23, 59, 59, 999), { array: true }))
+          .toEqual([
+            Date.UTC(1979, DEC, 31, 23, 59, 59, 999)
+          ])
+        expect(converter.unixMillisToAtomicMillis(Date.UTC(1980, JAN, 1, 0, 0, 0, 0), { array: true }))
+          .toEqual([
+            Date.UTC(1980, JAN, 1, 0, 0, 0, 0),
+            Date.UTC(1980, JAN, 1, 0, 0, 1, 0)
+          ])
+        expect(converter.unixMillisToAtomicMillis(Date.UTC(1980, JAN, 1, 0, 0, 0, 1), { array: true }))
+          .toEqual([
+            Date.UTC(1980, JAN, 1, 0, 0, 0, 1),
+            Date.UTC(1980, JAN, 1, 0, 0, 1, 1)
+          ])
 
-        it('unixMillisToAtomicMillis', () => {
-          expect(converter.unixMillisToAtomicMillis(0)).toBe(0)
-          expect(converter.unixMillisToAtomicMillis(Date.UTC(1979, DEC, 31, 23, 59, 59, 999)))
-            .toBe(Date.UTC(1979, DEC, 31, 23, 59, 59, 999))
-          expect(converter.unixMillisToAtomicMillis(Date.UTC(1980, JAN, 1, 0, 0, 0)))
-            .toBe(Date.UTC(1980, JAN, 1, 0, 0, 1))
-          expect(converter.unixMillisToAtomicMillis(Date.UTC(1980, JAN, 1, 0, 0, 0, 999)))
-            .toBe(Date.UTC(1980, JAN, 1, 0, 0, 1, 999))
-          expect(converter.unixMillisToAtomicMillis(Date.UTC(1980, JAN, 1, 0, 0, 1)))
-            .toBe(Date.UTC(1980, JAN, 1, 0, 0, 2))
-        })
+        // COLLAPSE
+        expect(converter.unixMillisToAtomicMillis(Date.UTC(1980, JAN, 1, 0, 0, 0, 999), { array: true }))
+          .toEqual([
+            Date.UTC(1980, JAN, 1, 0, 0, 0, 999),
+            Date.UTC(1980, JAN, 1, 0, 0, 1, 999)
+          ])
+        expect(converter.unixMillisToAtomicMillis(Date.UTC(1980, JAN, 1, 0, 0, 1, 0), { array: true }))
+          .toEqual([
+            Date.UTC(1980, JAN, 1, 0, 0, 2, 0)
+          ])
+        expect(converter.unixMillisToAtomicMillis(Date.UTC(1980, JAN, 1, 0, 0, 1, 1), { array: true }))
+          .toEqual([
+            Date.UTC(1980, JAN, 1, 0, 0, 2, 1)
+          ])
+      })
 
-        it('atomicToUnix', () => {
-          expect(converter.atomicToUnix(new Rat(0n))).toEqual(new Rat(0n))
-          expect(converter.atomicToUnix(millisToExact(Date.UTC(1979, DEC, 31, 23, 59, 59, 999))))
-            .toEqual(millisToExact(Date.UTC(1979, DEC, 31, 23, 59, 59, 999)))
-          expect(converter.atomicToUnix(millisToExact(Date.UTC(1980, JAN, 1, 0, 0, 0))))
-            .toEqual(millisToExact(Date.UTC(1980, JAN, 1, 0, 0, 0)))
-          expect(converter.atomicToUnix(millisToExact(Date.UTC(1980, JAN, 1, 0, 0, 0, 999))))
-            .toEqual(millisToExact(Date.UTC(1980, JAN, 1, 0, 0, 0, 999)))
-          expect(converter.atomicToUnix(millisToExact(Date.UTC(1980, JAN, 1, 0, 0, 2))))
-            .toEqual(millisToExact(Date.UTC(1980, JAN, 1, 0, 0, 1)))
-        })
+      it('unixMillisToAtomicMillis', () => {
+        expect(converter.unixMillisToAtomicMillis(0))
+          .toBe(0)
 
-        it('atomicMillisToUnixMillis', () => {
-          expect(converter.atomicMillisToUnixMillis(0)).toBe(0)
-          expect(converter.atomicMillisToUnixMillis(Date.UTC(1979, DEC, 31, 23, 59, 59, 999)))
-            .toBe(Date.UTC(1979, DEC, 31, 23, 59, 59, 999))
-          expect(converter.atomicMillisToUnixMillis(Date.UTC(1980, JAN, 1, 0, 0, 0)))
-            .toBe(Date.UTC(1980, JAN, 1, 0, 0, 0))
-          expect(converter.atomicMillisToUnixMillis(Date.UTC(1980, JAN, 1, 0, 0, 0, 999)))
-            .toBe(Date.UTC(1980, JAN, 1, 0, 0, 0, 999))
-          expect(converter.atomicMillisToUnixMillis(Date.UTC(1980, JAN, 1, 0, 0, 1)))
-            .toBe(Date.UTC(1980, JAN, 1, 0, 0, 0))
-          expect(converter.atomicMillisToUnixMillis(Date.UTC(1980, JAN, 1, 0, 0, 1, 999)))
-            .toBe(Date.UTC(1980, JAN, 1, 0, 0, 0, 999))
-          expect(converter.atomicMillisToUnixMillis(Date.UTC(1980, JAN, 1, 0, 0, 2)))
-            .toBe(Date.UTC(1980, JAN, 1, 0, 0, 1))
-        })
+        // FORWARD JUMP
+        expect(converter.unixMillisToAtomicMillis(Date.UTC(1979, DEC, 31, 23, 59, 59, 999)))
+          .toBe(Date.UTC(1979, DEC, 31, 23, 59, 59, 999))
+        expect(converter.unixMillisToAtomicMillis(Date.UTC(1980, JAN, 1, 0, 0, 0, 0)))
+          .toBe(Date.UTC(1980, JAN, 1, 0, 0, 1, 0))
+        expect(converter.unixMillisToAtomicMillis(Date.UTC(1980, JAN, 1, 0, 0, 0, 1)))
+          .toBe(Date.UTC(1980, JAN, 1, 0, 0, 1, 1))
+
+        expect(converter.unixMillisToAtomicMillis(Date.UTC(1980, JAN, 1, 0, 0, 0, 999)))
+          .toBe(Date.UTC(1980, JAN, 1, 0, 0, 1, 999))
+        expect(converter.unixMillisToAtomicMillis(Date.UTC(1980, JAN, 1, 0, 0, 1, 0)))
+          .toBe(Date.UTC(1980, JAN, 1, 0, 0, 2, 0))
+        expect(converter.unixMillisToAtomicMillis(Date.UTC(1980, JAN, 1, 0, 0, 1, 1)))
+          .toBe(Date.UTC(1980, JAN, 1, 0, 0, 2, 1))
+      })
+
+      it('atomicToUnix', () => {
+        expect(converter.atomicToUnix(new Rat(0n)))
+          .toEqual(new Rat(0n))
+
+        expect(converter.atomicToUnix(millisToExact(Date.UTC(1979, DEC, 31, 23, 59, 59, 999))))
+          .toEqual(millisToExact(Date.UTC(1979, DEC, 31, 23, 59, 59, 999)))
+        expect(converter.atomicToUnix(millisToExact(Date.UTC(1980, JAN, 1, 0, 0, 0, 0))))
+          .toEqual(millisToExact(Date.UTC(1980, JAN, 1, 0, 0, 0, 0)))
+        expect(converter.atomicToUnix(millisToExact(Date.UTC(1980, JAN, 1, 0, 0, 0, 1))))
+          .toEqual(millisToExact(Date.UTC(1980, JAN, 1, 0, 0, 0, 1)))
+
+        // BACKTRACK
+        expect(converter.atomicToUnix(millisToExact(Date.UTC(1980, JAN, 1, 0, 0, 0, 999))))
+          .toEqual(millisToExact(Date.UTC(1980, JAN, 1, 0, 0, 0, 999)))
+        expect(converter.atomicToUnix(millisToExact(Date.UTC(1980, JAN, 1, 0, 0, 1, 0))))
+          .toEqual(millisToExact(Date.UTC(1980, JAN, 1, 0, 0, 0, 0)))
+        expect(converter.atomicToUnix(millisToExact(Date.UTC(1980, JAN, 1, 0, 0, 1, 1))))
+          .toEqual(millisToExact(Date.UTC(1980, JAN, 1, 0, 0, 0, 1)))
+      })
+
+      it('atomicMillisToUnixMillis', () => {
+        expect(converter.atomicMillisToUnixMillis(0))
+          .toBe(0)
+
+        expect(converter.atomicMillisToUnixMillis(Date.UTC(1979, DEC, 31, 23, 59, 59, 999)))
+          .toBe(Date.UTC(1979, DEC, 31, 23, 59, 59, 999))
+        expect(converter.atomicMillisToUnixMillis(Date.UTC(1980, JAN, 1, 0, 0, 0, 0)))
+          .toBe(Date.UTC(1980, JAN, 1, 0, 0, 0, 0))
+        expect(converter.atomicMillisToUnixMillis(Date.UTC(1980, JAN, 1, 0, 0, 0, 1)))
+          .toBe(Date.UTC(1980, JAN, 1, 0, 0, 0, 1))
+
+        // BACKTRACK
+        expect(converter.atomicMillisToUnixMillis(Date.UTC(1980, JAN, 1, 0, 0, 0, 999)))
+          .toBe(Date.UTC(1980, JAN, 1, 0, 0, 0, 999))
+        expect(converter.atomicMillisToUnixMillis(Date.UTC(1980, JAN, 1, 0, 0, 1, 0)))
+          .toBe(Date.UTC(1980, JAN, 1, 0, 0, 0, 0))
+        expect(converter.atomicMillisToUnixMillis(Date.UTC(1980, JAN, 1, 0, 0, 1, 1)))
+          .toBe(Date.UTC(1980, JAN, 1, 0, 0, 0, 1))
       })
     })
 
     describe('BREAK', () => {
       const converter = Converter(data, MODELS.BREAK)
 
-      describe('conversions grouped by instant', () => {
-        it('start of time', () => {
-          expect(converter.unixToAtomic(new Rat(0n))).toEqual([{ start: new Rat(0n), end: new Rat(0n), closed: true }])
-          expect(converter.unixMillisToAtomicMillis(0)).toBe(0)
-          expect(converter.atomicToUnix(new Rat(0n))).toEqual(new Rat(0n))
-          expect(converter.atomicMillisToUnixMillis(0)).toBe(0)
-        })
+      it('unixToAtomic', () => {
+        expect(converter.unixToAtomic(new Rat(0n)))
+          .toEqual([{
+            start: new Rat(0n),
+            end: new Rat(0n),
+            closed: true
+          }])
 
-        it('millisecond before inserted leap second discontinuity begins', () => {
-          expect(converter.unixToAtomic(millisToExact(Date.UTC(1979, DEC, 31, 23, 59, 59, 999))))
-            .toEqual([{
-              start: millisToExact(Date.UTC(1979, DEC, 31, 23, 59, 59, 999)),
-              end: millisToExact(Date.UTC(1979, DEC, 31, 23, 59, 59, 999)),
-              closed: true
-            }])
-          expect(converter.unixMillisToAtomicMillis(Date.UTC(1979, DEC, 31, 23, 59, 59, 999)))
-            .toBe(Date.UTC(1979, DEC, 31, 23, 59, 59, 999))
-          expect(converter.atomicToUnix(millisToExact(Date.UTC(1979, DEC, 31, 23, 59, 59, 999))))
-            .toEqual(millisToExact(Date.UTC(1979, DEC, 31, 23, 59, 59, 999)))
-          expect(converter.atomicMillisToUnixMillis(Date.UTC(1979, DEC, 31, 23, 59, 59, 999)))
-            .toBe(Date.UTC(1979, DEC, 31, 23, 59, 59, 999))
-        })
+        // FORWARD JUMP
+        expect(converter.unixToAtomic(millisToExact(Date.UTC(1979, DEC, 31, 23, 59, 59, 999))))
+          .toEqual([{
+            start: millisToExact(Date.UTC(1979, DEC, 31, 23, 59, 59, 999)),
+            end: millisToExact(Date.UTC(1979, DEC, 31, 23, 59, 59, 999)),
+            closed: true
+          }])
+        expect(converter.unixToAtomic(millisToExact(Date.UTC(1980, JAN, 1, 0, 0, 0, 0))))
+          .toEqual([{
+            start: millisToExact(Date.UTC(1980, JAN, 1, 0, 0, 1, 0)),
+            end: millisToExact(Date.UTC(1980, JAN, 1, 0, 0, 1, 0)),
+            closed: true
+          }])
+        expect(converter.unixToAtomic(millisToExact(Date.UTC(1980, JAN, 1, 0, 0, 0, 1))))
+          .toEqual([{
+            start: millisToExact(Date.UTC(1980, JAN, 1, 0, 0, 1, 1)),
+            end: millisToExact(Date.UTC(1980, JAN, 1, 0, 0, 1, 1)),
+            closed: true
+          }])
 
-        it('first instant of the Unix time discontinuity: one Unix time is two TAI times', () => {
-          expect(converter.unixToAtomic(millisToExact(Date.UTC(1980, JAN, 1, 0, 0, 0))))
-            .toEqual([{
-              start: millisToExact(Date.UTC(1980, JAN, 1, 0, 0, 1)),
-              end: millisToExact(Date.UTC(1980, JAN, 1, 0, 0, 1)),
-              closed: true
-            }])
-          expect(converter.unixMillisToAtomicMillis(Date.UTC(1980, JAN, 1, 0, 0, 0)))
-            .toBe(Date.UTC(1980, JAN, 1, 0, 0, 1))
-          expect(converter.atomicToUnix(millisToExact(Date.UTC(1980, JAN, 1, 0, 0, 0))))
-            .toBe(NaN)
-          expect(converter.atomicMillisToUnixMillis(Date.UTC(1980, JAN, 1, 0, 0, 0)))
-            .toBe(NaN)
-          expect(converter.atomicToUnix(millisToExact(Date.UTC(1980, JAN, 1, 0, 0, 1))))
-            .toEqual(millisToExact(Date.UTC(1980, JAN, 1, 0, 0, 0)))
-          expect(converter.atomicMillisToUnixMillis(Date.UTC(1980, JAN, 1, 0, 0, 1)))
-            .toBe(Date.UTC(1980, JAN, 1, 0, 0, 0))
-        })
-
-        it('final instant of the Unix time discontinuity: one Unix time is two TAI times', () => {
-          expect(converter.unixToAtomic(millisToExact(Date.UTC(1980, JAN, 1, 0, 0, 0, 999))))
-            .toEqual([{
-              start: millisToExact(Date.UTC(1980, JAN, 1, 0, 0, 1, 999)),
-              end: millisToExact(Date.UTC(1980, JAN, 1, 0, 0, 1, 999)),
-              closed: true
-            }])
-          expect(converter.unixMillisToAtomicMillis(Date.UTC(1980, JAN, 1, 0, 0, 0, 999)))
-            .toBe(Date.UTC(1980, JAN, 1, 0, 0, 1, 999))
-          expect(converter.atomicToUnix(millisToExact(Date.UTC(1980, JAN, 1, 0, 0, 0, 999))))
-            .toBe(NaN)
-          expect(converter.atomicMillisToUnixMillis(Date.UTC(1980, JAN, 1, 0, 0, 0, 999)))
-            .toBe(NaN)
-          expect(converter.atomicToUnix(millisToExact(Date.UTC(1980, JAN, 1, 0, 0, 1, 999))))
-            .toEqual(millisToExact(Date.UTC(1980, JAN, 1, 0, 0, 0, 999)))
-          expect(converter.atomicMillisToUnixMillis(Date.UTC(1980, JAN, 1, 0, 0, 1, 999)))
-            .toBe(Date.UTC(1980, JAN, 1, 0, 0, 0, 999))
-        })
-
-        it('millisecond after discontinuity ends', () => {
-          expect(converter.unixToAtomic(millisToExact(Date.UTC(1980, JAN, 1, 0, 0, 1))))
-            .toEqual([{
-              start: millisToExact(Date.UTC(1980, JAN, 1, 0, 0, 2)),
-              end: millisToExact(Date.UTC(1980, JAN, 1, 0, 0, 2)),
-              closed: true
-            }])
-          expect(converter.unixMillisToAtomicMillis(Date.UTC(1980, JAN, 1, 0, 0, 1)))
-            .toBe(Date.UTC(1980, JAN, 1, 0, 0, 2))
-          expect(converter.atomicToUnix(millisToExact(Date.UTC(1980, JAN, 1, 0, 0, 2))))
-            .toEqual(millisToExact(Date.UTC(1980, JAN, 1, 0, 0, 1)))
-          expect(converter.atomicMillisToUnixMillis(Date.UTC(1980, JAN, 1, 0, 0, 2)))
-            .toBe(Date.UTC(1980, JAN, 1, 0, 0, 1))
-        })
+        expect(converter.unixToAtomic(millisToExact(Date.UTC(1980, JAN, 1, 0, 0, 0, 999))))
+          .toEqual([{
+            start: millisToExact(Date.UTC(1980, JAN, 1, 0, 0, 1, 999)),
+            end: millisToExact(Date.UTC(1980, JAN, 1, 0, 0, 1, 999)),
+            closed: true
+          }])
+        expect(converter.unixToAtomic(millisToExact(Date.UTC(1980, JAN, 1, 0, 0, 1, 0))))
+          .toEqual([{
+            start: millisToExact(Date.UTC(1980, JAN, 1, 0, 0, 2, 0)),
+            end: millisToExact(Date.UTC(1980, JAN, 1, 0, 0, 2, 0)),
+            closed: true
+          }])
+        expect(converter.unixToAtomic(millisToExact(Date.UTC(1980, JAN, 1, 0, 0, 1, 1))))
+          .toEqual([{
+            start: millisToExact(Date.UTC(1980, JAN, 1, 0, 0, 2, 1)),
+            end: millisToExact(Date.UTC(1980, JAN, 1, 0, 0, 2, 1)),
+            closed: true
+          }])
       })
 
-      describe('conversions grouped by method', () => {
-        it('unixToAtomic', () => {
-          expect(converter.unixToAtomic(new Rat(0n))).toEqual([{ start: new Rat(0n), end: new Rat(0n), closed: true }])
-          expect(converter.unixToAtomic(millisToExact(Date.UTC(1979, DEC, 31, 23, 59, 59, 999))))
-            .toEqual([{
-              start: millisToExact(Date.UTC(1979, DEC, 31, 23, 59, 59, 999)),
-              end: millisToExact(Date.UTC(1979, DEC, 31, 23, 59, 59, 999)),
-              closed: true
-            }])
-          expect(converter.unixToAtomic(millisToExact(Date.UTC(1980, JAN, 1, 0, 0, 0))))
-            .toEqual([{
-              start: millisToExact(Date.UTC(1980, JAN, 1, 0, 0, 1)),
-              end: millisToExact(Date.UTC(1980, JAN, 1, 0, 0, 1)),
-              closed: true
-            }])
-          expect(converter.unixToAtomic(millisToExact(Date.UTC(1980, JAN, 1, 0, 0, 0, 999))))
-            .toEqual([{
-              start: millisToExact(Date.UTC(1980, JAN, 1, 0, 0, 1, 999)),
-              end: millisToExact(Date.UTC(1980, JAN, 1, 0, 0, 1, 999)),
-              closed: true
-            }])
-          expect(converter.unixToAtomic(millisToExact(Date.UTC(1980, JAN, 1, 0, 0, 1))))
-            .toEqual([{
-              start: millisToExact(Date.UTC(1980, JAN, 1, 0, 0, 2)),
-              end: millisToExact(Date.UTC(1980, JAN, 1, 0, 0, 2)),
-              closed: true
-            }])
-        })
+      it('unixMillisToAtomicMillis', () => {
+        expect(converter.unixMillisToAtomicMillis(0))
+          .toBe(0)
 
-        it('unixMillisToAtomicMillis', () => {
-          expect(converter.unixMillisToAtomicMillis(0)).toBe(0)
-          expect(converter.unixMillisToAtomicMillis(Date.UTC(1979, DEC, 31, 23, 59, 59, 999)))
-            .toBe(Date.UTC(1979, DEC, 31, 23, 59, 59, 999))
-          expect(converter.unixMillisToAtomicMillis(Date.UTC(1980, JAN, 1, 0, 0, 0)))
-            .toBe(Date.UTC(1980, JAN, 1, 0, 0, 1))
-          expect(converter.unixMillisToAtomicMillis(Date.UTC(1980, JAN, 1, 0, 0, 0, 999)))
-            .toBe(Date.UTC(1980, JAN, 1, 0, 0, 1, 999))
-          expect(converter.unixMillisToAtomicMillis(Date.UTC(1980, JAN, 1, 0, 0, 1)))
-            .toBe(Date.UTC(1980, JAN, 1, 0, 0, 2))
-        })
+        // FORWARD JUMP
+        expect(converter.unixMillisToAtomicMillis(Date.UTC(1979, DEC, 31, 23, 59, 59, 999)))
+          .toBe(Date.UTC(1979, DEC, 31, 23, 59, 59, 999))
+        expect(converter.unixMillisToAtomicMillis(Date.UTC(1980, JAN, 1, 0, 0, 0, 0)))
+          .toBe(Date.UTC(1980, JAN, 1, 0, 0, 1, 0))
+        expect(converter.unixMillisToAtomicMillis(Date.UTC(1980, JAN, 1, 0, 0, 0, 1)))
+          .toBe(Date.UTC(1980, JAN, 1, 0, 0, 1, 1))
 
-        it('atomicToUnix', () => {
-          expect(converter.atomicToUnix(new Rat(0n))).toEqual(new Rat(0n))
-          expect(converter.atomicToUnix(millisToExact(Date.UTC(1979, DEC, 31, 23, 59, 59, 999))))
-            .toEqual(millisToExact(Date.UTC(1979, DEC, 31, 23, 59, 59, 999)))
-          expect(converter.atomicToUnix(millisToExact(Date.UTC(1980, JAN, 1, 0, 0, 0, 999))))
-            .toBe(NaN)
-          expect(converter.atomicToUnix(millisToExact(Date.UTC(1980, JAN, 1, 0, 0, 1))))
-            .toEqual(millisToExact(Date.UTC(1980, JAN, 1, 0, 0, 0)))
-          expect(converter.atomicToUnix(millisToExact(Date.UTC(1980, JAN, 1, 0, 0, 1, 999))))
-            .toEqual(millisToExact(Date.UTC(1980, JAN, 1, 0, 0, 0, 999)))
-          expect(converter.atomicToUnix(millisToExact(Date.UTC(1980, JAN, 1, 0, 0, 2))))
-            .toEqual(millisToExact(Date.UTC(1980, JAN, 1, 0, 0, 1)))
-        })
+        expect(converter.unixMillisToAtomicMillis(Date.UTC(1980, JAN, 1, 0, 0, 0, 999)))
+          .toBe(Date.UTC(1980, JAN, 1, 0, 0, 1, 999))
+        expect(converter.unixMillisToAtomicMillis(Date.UTC(1980, JAN, 1, 0, 0, 1, 0)))
+          .toBe(Date.UTC(1980, JAN, 1, 0, 0, 2, 0))
+        expect(converter.unixMillisToAtomicMillis(Date.UTC(1980, JAN, 1, 0, 0, 1, 1)))
+          .toBe(Date.UTC(1980, JAN, 1, 0, 0, 2, 1))
+      })
 
-        it('atomicMillisToUnixMillis', () => {
-          expect(converter.atomicMillisToUnixMillis(0)).toBe(0)
-          expect(converter.atomicMillisToUnixMillis(Date.UTC(1979, DEC, 31, 23, 59, 59, 999)))
-            .toBe(Date.UTC(1979, DEC, 31, 23, 59, 59, 999))
-          expect(converter.atomicMillisToUnixMillis(Date.UTC(1980, JAN, 1, 0, 0, 0)))
-            .toBe(NaN)
-          expect(converter.atomicMillisToUnixMillis(Date.UTC(1980, JAN, 1, 0, 0, 0, 999)))
-            .toBe(NaN)
-          expect(converter.atomicMillisToUnixMillis(Date.UTC(1980, JAN, 1, 0, 0, 1)))
-            .toBe(Date.UTC(1980, JAN, 1, 0, 0, 0))
-          expect(converter.atomicMillisToUnixMillis(Date.UTC(1980, JAN, 1, 0, 0, 1, 999)))
-            .toBe(Date.UTC(1980, JAN, 1, 0, 0, 0, 999))
-          expect(converter.atomicMillisToUnixMillis(Date.UTC(1980, JAN, 1, 0, 0, 2)))
-            .toBe(Date.UTC(1980, JAN, 1, 0, 0, 1))
-        })
+      it('atomicToUnix', () => {
+        expect(converter.atomicToUnix(new Rat(0n)))
+          .toEqual(new Rat(0n))
+
+        // UNDEFINED UNIX TIME STARTS
+        expect(converter.atomicToUnix(millisToExact(Date.UTC(1979, DEC, 31, 23, 59, 59, 999))))
+          .toEqual(millisToExact(Date.UTC(1979, DEC, 31, 23, 59, 59, 999)))
+        expect(converter.atomicToUnix(millisToExact(Date.UTC(1980, JAN, 1, 0, 0, 0, 0))))
+          .toBe(NaN)
+        expect(converter.atomicToUnix(millisToExact(Date.UTC(1980, JAN, 1, 0, 0, 0, 1))))
+          .toBe(NaN)
+
+        // UNDEFINED UNIX TIME ENDS
+        expect(converter.atomicToUnix(millisToExact(Date.UTC(1980, JAN, 1, 0, 0, 0, 999))))
+          .toBe(NaN)
+        expect(converter.atomicToUnix(millisToExact(Date.UTC(1980, JAN, 1, 0, 0, 1, 0))))
+          .toEqual(millisToExact(Date.UTC(1980, JAN, 1, 0, 0, 0, 0)))
+        expect(converter.atomicToUnix(millisToExact(Date.UTC(1980, JAN, 1, 0, 0, 1, 1))))
+          .toEqual(millisToExact(Date.UTC(1980, JAN, 1, 0, 0, 0, 1)))
+      })
+
+      it('atomicMillisToUnixMillis', () => {
+        expect(converter.atomicMillisToUnixMillis(0))
+          .toBe(0)
+
+        // UNDEFINED UNIX TIME STARTS
+        expect(converter.atomicMillisToUnixMillis(Date.UTC(1979, DEC, 31, 23, 59, 59, 999)))
+          .toBe(Date.UTC(1979, DEC, 31, 23, 59, 59, 999))
+        expect(converter.atomicMillisToUnixMillis(Date.UTC(1980, JAN, 1, 0, 0, 0, 0)))
+          .toBe(NaN)
+        expect(converter.atomicMillisToUnixMillis(Date.UTC(1980, JAN, 1, 0, 0, 0, 1)))
+          .toBe(NaN)
+
+        // UNDEFINED UNIX TIME ENDS
+        expect(converter.atomicMillisToUnixMillis(Date.UTC(1980, JAN, 1, 0, 0, 0, 999)))
+          .toBe(NaN)
+        expect(converter.atomicMillisToUnixMillis(Date.UTC(1980, JAN, 1, 0, 0, 1, 0)))
+          .toBe(Date.UTC(1980, JAN, 1, 0, 0, 0, 0))
+        expect(converter.atomicMillisToUnixMillis(Date.UTC(1980, JAN, 1, 0, 0, 1, 1)))
+          .toBe(Date.UTC(1980, JAN, 1, 0, 0, 0, 1))
       })
     })
 
     describe('STALL', () => {
       const converter = Converter(data, MODELS.STALL)
 
-      describe('conversions grouped by instant', () => {
-        it('start of time', () => {
-          expect(converter.unixToAtomic(new Rat(0n))).toEqual([{
+      it('unixToAtomic', () => {
+        expect(converter.unixToAtomic(new Rat(0n)))
+          .toEqual([{
             start: new Rat(0n),
             end: new Rat(0n),
             closed: true
           }])
-          expect(converter.unixMillisToAtomicMillis(0, { range: true })).toEqual([0, 0])
-          expect(converter.unixMillisToAtomicMillis(0)).toBe(0)
-          expect(converter.atomicToUnix(new Rat(0n))).toEqual(new Rat(0n))
-          expect(converter.atomicMillisToUnixMillis(0)).toBe(0)
-        })
 
-        it('millisecond before inserted leap second discontinuity begins', () => {
-          expect(converter.unixToAtomic(millisToExact(Date.UTC(1979, DEC, 31, 23, 59, 59, 999))))
-            .toEqual([{
-              start: millisToExact(Date.UTC(1979, DEC, 31, 23, 59, 59, 999)),
-              end: millisToExact(Date.UTC(1979, DEC, 31, 23, 59, 59, 999)),
-              closed: true
-            }])
-          expect(converter.unixMillisToAtomicMillis(Date.UTC(1979, DEC, 31, 23, 59, 59, 999), { range: true }))
-            .toEqual([
-              Date.UTC(1979, DEC, 31, 23, 59, 59, 999),
-              Date.UTC(1979, DEC, 31, 23, 59, 59, 999)
-            ])
-          expect(converter.unixMillisToAtomicMillis(Date.UTC(1979, DEC, 31, 23, 59, 59, 999)))
-            .toBe(Date.UTC(1979, DEC, 31, 23, 59, 59, 999))
-          expect(converter.atomicToUnix(millisToExact(Date.UTC(1979, DEC, 31, 23, 59, 59, 999))))
-            .toEqual(millisToExact(Date.UTC(1979, DEC, 31, 23, 59, 59, 999)))
-          expect(converter.atomicMillisToUnixMillis(Date.UTC(1979, DEC, 31, 23, 59, 59, 999)))
-            .toBe(Date.UTC(1979, DEC, 31, 23, 59, 59, 999))
-        })
-
-        it('first instant of the Unix time discontinuity: one Unix time is two TAI times', () => {
-          expect(converter.unixToAtomic(millisToExact(Date.UTC(1980, JAN, 1, 0, 0, 0))))
-            .toEqual([{
-              start: millisToExact(Date.UTC(1980, JAN, 1, 0, 0, 0, 0)),
-              end: millisToExact(Date.UTC(1980, JAN, 1, 0, 0, 1, 0)),
-              closed: true
-            }])
-          expect(converter.unixMillisToAtomicMillis(Date.UTC(1980, JAN, 1, 0, 0, 0), { range: true }))
-            .toEqual([
-              Date.UTC(1980, JAN, 1, 0, 0, 0, 0),
-              Date.UTC(1980, JAN, 1, 0, 0, 1, 0) // stalled
-            ])
-          expect(converter.unixMillisToAtomicMillis(Date.UTC(1980, JAN, 1, 0, 0, 0)))
-            .toBe(Date.UTC(1980, JAN, 1, 0, 0, 1))
-          expect(converter.atomicToUnix(millisToExact(Date.UTC(1980, JAN, 1, 0, 0, 0))))
-            .toEqual(millisToExact(Date.UTC(1980, JAN, 1, 0, 0, 0)))
-          expect(converter.atomicMillisToUnixMillis(Date.UTC(1980, JAN, 1, 0, 0, 0)))
-            .toBe(Date.UTC(1980, JAN, 1, 0, 0, 0))
-          expect(converter.atomicToUnix(millisToExact(Date.UTC(1980, JAN, 1, 0, 0, 1))))
-            .toEqual(millisToExact(Date.UTC(1980, JAN, 1, 0, 0, 0)))
-          expect(converter.atomicMillisToUnixMillis(Date.UTC(1980, JAN, 1, 0, 0, 1)))
-            .toBe(Date.UTC(1980, JAN, 1, 0, 0, 0))
-        })
-
-        it('final instant of the Unix time discontinuity: one Unix time is two TAI times', () => {
-          expect(converter.unixToAtomic(millisToExact(Date.UTC(1980, JAN, 1, 0, 0, 0, 999))))
-            .toEqual([{
-              start: millisToExact(Date.UTC(1980, JAN, 1, 0, 0, 1, 999)),
-              end: millisToExact(Date.UTC(1980, JAN, 1, 0, 0, 1, 999)),
-              closed: true
-            }])
-          expect(converter.unixMillisToAtomicMillis(Date.UTC(1980, JAN, 1, 0, 0, 0, 999), { range: true }))
-            .toEqual([
-              Date.UTC(1980, JAN, 1, 0, 0, 1, 999),
-              Date.UTC(1980, JAN, 1, 0, 0, 1, 999)
-            ])
-          expect(converter.unixMillisToAtomicMillis(Date.UTC(1980, JAN, 1, 0, 0, 0, 999)))
-            .toBe(Date.UTC(1980, JAN, 1, 0, 0, 1, 999))
-          expect(converter.atomicToUnix(millisToExact(Date.UTC(1980, JAN, 1, 0, 0, 0, 999))))
-            .toEqual(millisToExact(Date.UTC(1980, JAN, 1, 0, 0, 0))) // stalled
-          expect(converter.atomicMillisToUnixMillis(Date.UTC(1980, JAN, 1, 0, 0, 0, 999)))
-            .toBe(Date.UTC(1980, JAN, 1, 0, 0, 0)) // stalled
-          expect(converter.atomicToUnix(millisToExact(Date.UTC(1980, JAN, 1, 0, 0, 1, 999))))
-            .toEqual(millisToExact(Date.UTC(1980, JAN, 1, 0, 0, 0, 999)))
-          expect(converter.atomicMillisToUnixMillis(Date.UTC(1980, JAN, 1, 0, 0, 1, 999)))
-            .toBe(Date.UTC(1980, JAN, 1, 0, 0, 0, 999))
-        })
-
-        it('millisecond after discontinuity ends', () => {
-          expect(converter.unixToAtomic(millisToExact(Date.UTC(1980, JAN, 1, 0, 0, 1, 0))))
-            .toEqual([{
-              start: millisToExact(Date.UTC(1980, JAN, 1, 0, 0, 2, 0)),
-              end: millisToExact(Date.UTC(1980, JAN, 1, 0, 0, 2, 0)),
-              closed: true
-            }])
-          expect(converter.unixMillisToAtomicMillis(Date.UTC(1980, JAN, 1, 0, 0, 1, 0), { range: true }))
-            .toEqual([
-              Date.UTC(1980, JAN, 1, 0, 0, 2, 0),
-              Date.UTC(1980, JAN, 1, 0, 0, 2, 0)
-            ])
-          expect(converter.unixMillisToAtomicMillis(Date.UTC(1980, JAN, 1, 0, 0, 1)))
-            .toBe(Date.UTC(1980, JAN, 1, 0, 0, 2, 0))
-          expect(converter.atomicToUnix(millisToExact(Date.UTC(1980, JAN, 1, 0, 0, 2, 0))))
-            .toEqual(millisToExact(Date.UTC(1980, JAN, 1, 0, 0, 1, 0)))
-          expect(converter.atomicMillisToUnixMillis(Date.UTC(1980, JAN, 1, 0, 0, 2, 0)))
-            .toBe(Date.UTC(1980, JAN, 1, 0, 0, 1, 0))
-        })
+        // STALL POINT
+        expect(converter.unixToAtomic(millisToExact(Date.UTC(1979, DEC, 31, 23, 59, 59, 999))))
+          .toEqual([{
+            start: millisToExact(Date.UTC(1979, DEC, 31, 23, 59, 59, 999)),
+            end: millisToExact(Date.UTC(1979, DEC, 31, 23, 59, 59, 999)),
+            closed: true
+          }])
+        expect(converter.unixToAtomic(millisToExact(Date.UTC(1980, JAN, 1, 0, 0, 0, 0))))
+          .toEqual([{
+            start: millisToExact(Date.UTC(1980, JAN, 1, 0, 0, 0, 0)),
+            end: millisToExact(Date.UTC(1980, JAN, 1, 0, 0, 1, 0)),
+            closed: true
+          }])
+        expect(converter.unixToAtomic(millisToExact(Date.UTC(1980, JAN, 1, 0, 0, 0, 1))))
+          .toEqual([{
+            start: millisToExact(Date.UTC(1980, JAN, 1, 0, 0, 1, 1)),
+            end: millisToExact(Date.UTC(1980, JAN, 1, 0, 0, 1, 1)),
+            closed: true
+          }])
       })
 
-      describe('conversions grouped by method', () => {
-        it('unixToAtomic', () => {
-          expect(converter.unixToAtomic(new Rat(0n))).toEqual([{
-            start: new Rat(0n),
-            end: new Rat(0n),
-            closed: true
-          }])
-          expect(converter.unixToAtomic(millisToExact(Date.UTC(1979, DEC, 31, 23, 59, 59, 999))))
-            .toEqual([{
-              start: millisToExact(Date.UTC(1979, DEC, 31, 23, 59, 59, 999)),
-              end: millisToExact(Date.UTC(1979, DEC, 31, 23, 59, 59, 999)),
-              closed: true
-            }])
-          expect(converter.unixToAtomic(millisToExact(Date.UTC(1980, JAN, 1, 0, 0, 0))))
-            .toEqual([{
-              start: millisToExact(Date.UTC(1980, JAN, 1, 0, 0, 0, 0)),
-              end: millisToExact(Date.UTC(1980, JAN, 1, 0, 0, 1, 0)),
-              closed: true
-            }])
-          expect(converter.unixToAtomic(millisToExact(Date.UTC(1980, JAN, 1, 0, 0, 0, 999))))
-            .toEqual([{
-              start: millisToExact(Date.UTC(1980, JAN, 1, 0, 0, 1, 999)),
-              end: millisToExact(Date.UTC(1980, JAN, 1, 0, 0, 1, 999)),
-              closed: true
-            }])
-          expect(converter.unixToAtomic(millisToExact(Date.UTC(1980, JAN, 1, 0, 0, 1, 0))))
-            .toEqual([{
-              start: millisToExact(Date.UTC(1980, JAN, 1, 0, 0, 2, 0)),
-              end: millisToExact(Date.UTC(1980, JAN, 1, 0, 0, 2, 0)),
-              closed: true
-            }])
-        })
+      it('unixMillisToAtomicMillis (range mode)', () => {
+        expect(converter.unixMillisToAtomicMillis(0, { range: true }))
+          .toEqual([0, 0])
 
-        it('unixMillisToAtomicMillis (range mode)', () => {
-          expect(converter.unixMillisToAtomicMillis(0, { range: true })).toEqual([0, 0])
-          expect(converter.unixMillisToAtomicMillis(Date.UTC(1979, DEC, 31, 23, 59, 59, 999), { range: true }))
-            .toEqual([
-              Date.UTC(1979, DEC, 31, 23, 59, 59, 999),
-              Date.UTC(1979, DEC, 31, 23, 59, 59, 999)
-            ])
-          expect(converter.unixMillisToAtomicMillis(Date.UTC(1980, JAN, 1, 0, 0, 0, 0), { range: true }))
-            .toEqual([
-              Date.UTC(1980, JAN, 1, 0, 0, 0, 0),
-              Date.UTC(1980, JAN, 1, 0, 0, 1, 0)
-            ])
-          expect(converter.unixMillisToAtomicMillis(Date.UTC(1980, JAN, 1, 0, 0, 0, 1), { range: true }))
-            .toEqual([
-              Date.UTC(1980, JAN, 1, 0, 0, 1, 1),
-              Date.UTC(1980, JAN, 1, 0, 0, 1, 1)
-            ])
-          expect(converter.unixMillisToAtomicMillis(Date.UTC(1980, JAN, 1, 0, 0, 0, 999), { range: true }))
-            .toEqual([
-              Date.UTC(1980, JAN, 1, 0, 0, 1, 999),
-              Date.UTC(1980, JAN, 1, 0, 0, 1, 999)
-            ])
-          expect(converter.unixMillisToAtomicMillis(Date.UTC(1980, JAN, 1, 0, 0, 1, 0), { range: true }))
-            .toEqual([
-              Date.UTC(1980, JAN, 1, 0, 0, 2, 0),
-              Date.UTC(1980, JAN, 1, 0, 0, 2, 0)
-            ])
-        })
+        // STALL POINT
+        expect(converter.unixMillisToAtomicMillis(Date.UTC(1979, DEC, 31, 23, 59, 59, 999), { range: true }))
+          .toEqual([
+            Date.UTC(1979, DEC, 31, 23, 59, 59, 999),
+            Date.UTC(1979, DEC, 31, 23, 59, 59, 999)
+          ])
+        expect(converter.unixMillisToAtomicMillis(Date.UTC(1980, JAN, 1, 0, 0, 0, 0), { range: true }))
+          .toEqual([
+            Date.UTC(1980, JAN, 1, 0, 0, 0, 0),
+            Date.UTC(1980, JAN, 1, 0, 0, 1, 0)
+          ])
+        expect(converter.unixMillisToAtomicMillis(Date.UTC(1980, JAN, 1, 0, 0, 0, 1), { range: true }))
+          .toEqual([
+            Date.UTC(1980, JAN, 1, 0, 0, 1, 1),
+            Date.UTC(1980, JAN, 1, 0, 0, 1, 1)
+          ])
+      })
 
-        it('unixMillisToAtomicMillis', () => {
-          expect(converter.unixMillisToAtomicMillis(0)).toBe(0)
-          expect(converter.unixMillisToAtomicMillis(Date.UTC(1979, DEC, 31, 23, 59, 59, 999)))
-            .toBe(Date.UTC(1979, DEC, 31, 23, 59, 59, 999))
-          expect(converter.unixMillisToAtomicMillis(Date.UTC(1980, JAN, 1, 0, 0, 0)))
-            .toBe(Date.UTC(1980, JAN, 1, 0, 0, 1))
-          expect(converter.unixMillisToAtomicMillis(Date.UTC(1980, JAN, 1, 0, 0, 0, 999)))
-            .toBe(Date.UTC(1980, JAN, 1, 0, 0, 1, 999))
-          expect(converter.unixMillisToAtomicMillis(Date.UTC(1980, JAN, 1, 0, 0, 1)))
-            .toBe(Date.UTC(1980, JAN, 1, 0, 0, 2))
-        })
+      it('unixMillisToAtomicMillis', () => {
+        expect(converter.unixMillisToAtomicMillis(0))
+          .toBe(0)
 
-        it('atomicToUnix', () => {
-          expect(converter.atomicToUnix(new Rat(0n))).toEqual(new Rat(0n))
-          expect(converter.atomicToUnix(millisToExact(Date.UTC(1979, DEC, 31, 23, 59, 59, 999))))
-            .toEqual(millisToExact(Date.UTC(1979, DEC, 31, 23, 59, 59, 999)))
-          expect(converter.atomicToUnix(millisToExact(Date.UTC(1980, JAN, 1, 0, 0, 0))))
-            .toEqual(millisToExact(Date.UTC(1980, JAN, 1, 0, 0, 0)))
-          expect(converter.atomicToUnix(millisToExact(Date.UTC(1980, JAN, 1, 0, 0, 0, 999))))
-            .toEqual(millisToExact(Date.UTC(1980, JAN, 1, 0, 0, 0))) // stalled
-          expect(converter.atomicToUnix(millisToExact(Date.UTC(1980, JAN, 1, 0, 0, 1))))
-            .toEqual(millisToExact(Date.UTC(1980, JAN, 1, 0, 0, 0)))
-          expect(converter.atomicToUnix(millisToExact(Date.UTC(1980, JAN, 1, 0, 0, 1, 999))))
-            .toEqual(millisToExact(Date.UTC(1980, JAN, 1, 0, 0, 0, 999)))
-          expect(converter.atomicToUnix(millisToExact(Date.UTC(1980, JAN, 1, 0, 0, 2, 0))))
-            .toEqual(millisToExact(Date.UTC(1980, JAN, 1, 0, 0, 1, 0)))
-        })
+        // FORWARD JUMP
+        expect(converter.unixMillisToAtomicMillis(Date.UTC(1979, DEC, 31, 23, 59, 59, 999)))
+          .toBe(Date.UTC(1979, DEC, 31, 23, 59, 59, 999))
+        expect(converter.unixMillisToAtomicMillis(Date.UTC(1980, JAN, 1, 0, 0, 0, 0)))
+          .toBe(Date.UTC(1980, JAN, 1, 0, 0, 1, 0))
+        expect(converter.unixMillisToAtomicMillis(Date.UTC(1980, JAN, 1, 0, 0, 0, 1)))
+          .toBe(Date.UTC(1980, JAN, 1, 0, 0, 1, 1))
+      })
 
-        it('atomicMillisToUnixMillis', () => {
-          expect(converter.atomicMillisToUnixMillis(0)).toBe(0)
-          expect(converter.atomicMillisToUnixMillis(Date.UTC(1979, DEC, 31, 23, 59, 59, 999)))
-            .toBe(Date.UTC(1979, DEC, 31, 23, 59, 59, 999))
-          expect(converter.atomicMillisToUnixMillis(Date.UTC(1980, JAN, 1, 0, 0, 0)))
-            .toBe(Date.UTC(1980, JAN, 1, 0, 0, 0)) // stalled
-          expect(converter.atomicMillisToUnixMillis(Date.UTC(1980, JAN, 1, 0, 0, 0, 999)))
-            .toBe(Date.UTC(1980, JAN, 1, 0, 0, 0)) // stalled
-          expect(converter.atomicMillisToUnixMillis(Date.UTC(1980, JAN, 1, 0, 0, 1)))
-            .toBe(Date.UTC(1980, JAN, 1, 0, 0, 0))
-          expect(converter.atomicMillisToUnixMillis(Date.UTC(1980, JAN, 1, 0, 0, 1, 999)))
-            .toBe(Date.UTC(1980, JAN, 1, 0, 0, 0, 999))
-          expect(converter.atomicMillisToUnixMillis(Date.UTC(1980, JAN, 1, 0, 0, 2)))
-            .toBe(Date.UTC(1980, JAN, 1, 0, 0, 1))
-        })
+      it('atomicToUnix', () => {
+        expect(converter.atomicToUnix(new Rat(0n)))
+          .toEqual(new Rat(0n))
+
+        // STALL STARTS
+        expect(converter.atomicToUnix(millisToExact(Date.UTC(1979, DEC, 31, 23, 59, 59, 999))))
+          .toEqual(millisToExact(Date.UTC(1979, DEC, 31, 23, 59, 59, 999)))
+        expect(converter.atomicToUnix(millisToExact(Date.UTC(1980, JAN, 1, 0, 0, 0, 0))))
+          .toEqual(millisToExact(Date.UTC(1980, JAN, 1, 0, 0, 0, 0)))
+        expect(converter.atomicToUnix(millisToExact(Date.UTC(1980, JAN, 1, 0, 0, 0, 1))))
+          .toEqual(millisToExact(Date.UTC(1980, JAN, 1, 0, 0, 0, 0)))
+
+        // STALL ENDS
+        expect(converter.atomicToUnix(millisToExact(Date.UTC(1980, JAN, 1, 0, 0, 0, 999))))
+          .toEqual(millisToExact(Date.UTC(1980, JAN, 1, 0, 0, 0, 0)))
+        expect(converter.atomicToUnix(millisToExact(Date.UTC(1980, JAN, 1, 0, 0, 1, 0))))
+          .toEqual(millisToExact(Date.UTC(1980, JAN, 1, 0, 0, 0, 0)))
+        expect(converter.atomicToUnix(millisToExact(Date.UTC(1980, JAN, 1, 0, 0, 1, 1))))
+          .toEqual(millisToExact(Date.UTC(1980, JAN, 1, 0, 0, 0, 1)))
+      })
+
+      it('atomicMillisToUnixMillis', () => {
+        expect(converter.atomicMillisToUnixMillis(0))
+          .toBe(0)
+
+        // STALL STARTS
+        expect(converter.atomicMillisToUnixMillis(Date.UTC(1979, DEC, 31, 23, 59, 59, 999)))
+          .toBe(Date.UTC(1979, DEC, 31, 23, 59, 59, 999))
+        expect(converter.atomicMillisToUnixMillis(Date.UTC(1980, JAN, 1, 0, 0, 0, 0)))
+          .toBe(Date.UTC(1980, JAN, 1, 0, 0, 0, 0))
+        expect(converter.atomicMillisToUnixMillis(Date.UTC(1980, JAN, 1, 0, 0, 0, 1)))
+          .toBe(Date.UTC(1980, JAN, 1, 0, 0, 0, 0))
+
+        // STALL ENDS
+        expect(converter.atomicMillisToUnixMillis(Date.UTC(1980, JAN, 1, 0, 0, 0, 999)))
+          .toBe(Date.UTC(1980, JAN, 1, 0, 0, 0, 0))
+        expect(converter.atomicMillisToUnixMillis(Date.UTC(1980, JAN, 1, 0, 0, 1, 0)))
+          .toBe(Date.UTC(1980, JAN, 1, 0, 0, 0, 0))
+        expect(converter.atomicMillisToUnixMillis(Date.UTC(1980, JAN, 1, 0, 0, 1, 1)))
+          .toBe(Date.UTC(1980, JAN, 1, 0, 0, 0, 1))
       })
     })
 
     describe('SMEAR', () => {
       const converter = Converter(data, MODELS.SMEAR)
 
+      it('unixToAtomic', () => {
+        expect(converter.unixToAtomic(new Rat(0n)))
+          .toEqual([{
+            start: new Rat(0n),
+            end: new Rat(0n),
+            closed: true
+          }])
+
+        // SMEAR STARTS
+        expect(converter.unixToAtomic(millisToExact(Date.UTC(1979, DEC, 31, 11, 59, 59, 999))))
+          .toEqual([{
+            start: millisToExact(Date.UTC(1979, DEC, 31, 11, 59, 59, 999)),
+            end: millisToExact(Date.UTC(1979, DEC, 31, 11, 59, 59, 999)),
+            closed: true
+          }])
+        expect(converter.unixToAtomic(millisToExact(Date.UTC(1979, DEC, 31, 12, 0, 0, 0))))
+          .toEqual([{
+            start: millisToExact(Date.UTC(1979, DEC, 31, 12, 0, 0, 0)),
+            end: millisToExact(Date.UTC(1979, DEC, 31, 12, 0, 0, 0)),
+            closed: true
+          }])
+        expect(converter.unixToAtomic(millisToExact(Date.UTC(1979, DEC, 31, 12, 0, 0, 1))))
+          .toEqual([{
+            start: millisToExact(Date.UTC(1979, DEC, 31, 12, 0, 0, 0)).plus(new Rat(86_401n, 86_400_000n)),
+            end: millisToExact(Date.UTC(1979, DEC, 31, 12, 0, 0, 0)).plus(new Rat(86_401n, 86_400_000n)),
+            closed: true
+          }])
+
+        // SMEAR MIDPOINT
+        expect(converter.unixToAtomic(millisToExact(Date.UTC(1980, JAN, 1, 0, 0, 0, 0))))
+          .toEqual([{
+            start: millisToExact(Date.UTC(1980, JAN, 1, 0, 0, 0, 500)),
+            end: millisToExact(Date.UTC(1980, JAN, 1, 0, 0, 0, 500)),
+            closed: true
+          }])
+
+        // SMEAR ENDS
+        expect(converter.unixToAtomic(millisToExact(Date.UTC(1980, JAN, 1, 11, 59, 59, 999))))
+          .toEqual([{
+            start: millisToExact(Date.UTC(1980, JAN, 1, 12, 0, 0, 998)).plus(new Rat(86_399n, 86_400_000n)),
+            end: millisToExact(Date.UTC(1980, JAN, 1, 12, 0, 0, 998)).plus(new Rat(86_399n, 86_400_000n)),
+            closed: true
+          }])
+        expect(converter.unixToAtomic(millisToExact(Date.UTC(1980, JAN, 1, 12, 0, 0, 0))))
+          .toEqual([{
+            start: millisToExact(Date.UTC(1980, JAN, 1, 12, 0, 1, 0)),
+            end: millisToExact(Date.UTC(1980, JAN, 1, 12, 0, 1, 0)),
+            closed: true
+          }])
+        expect(converter.unixToAtomic(millisToExact(Date.UTC(1980, JAN, 1, 12, 0, 0, 1))))
+          .toEqual([{
+            start: millisToExact(Date.UTC(1980, JAN, 1, 12, 0, 1, 1)),
+            end: millisToExact(Date.UTC(1980, JAN, 1, 12, 0, 1, 1)),
+            closed: true
+          }])
+      })
+
       it('unixMillisToAtomicMillis', () => {
-        expect(converter.unixMillisToAtomicMillis(0)).toBe(0)
+        expect(converter.unixMillisToAtomicMillis(0))
+          .toBe(0)
+
+        // SMEAR STARTS
         expect(converter.unixMillisToAtomicMillis(Date.UTC(1979, DEC, 31, 11, 59, 59, 999)))
           .toBe(Date.UTC(1979, DEC, 31, 11, 59, 59, 999))
         expect(converter.unixMillisToAtomicMillis(Date.UTC(1979, DEC, 31, 12, 0, 0, 0)))
           .toBe(Date.UTC(1979, DEC, 31, 12, 0, 0, 0))
+        expect(converter.unixMillisToAtomicMillis(Date.UTC(1979, DEC, 31, 12, 0, 0, 1)))
+          .toBe(Date.UTC(1979, DEC, 31, 12, 0, 0, 1))
+
+        // SMEAR MIDPOINT
         expect(converter.unixMillisToAtomicMillis(Date.UTC(1980, JAN, 1, 0, 0, 0, 0)))
           .toBe(Date.UTC(1980, JAN, 1, 0, 0, 0, 500))
+
+        // SMEAR ENDS
+        expect(converter.unixMillisToAtomicMillis(Date.UTC(1980, JAN, 1, 11, 59, 59, 999)))
+          .toBe(Date.UTC(1980, JAN, 1, 12, 0, 0, 998)) // truncated down
         expect(converter.unixMillisToAtomicMillis(Date.UTC(1980, JAN, 1, 12, 0, 0, 0)))
           .toBe(Date.UTC(1980, JAN, 1, 12, 0, 1, 0))
         expect(converter.unixMillisToAtomicMillis(Date.UTC(1980, JAN, 1, 12, 0, 0, 1)))
           .toBe(Date.UTC(1980, JAN, 1, 12, 0, 1, 1))
-        expect(converter.unixMillisToAtomicMillis(Date.UTC(1980, JAN, 1, 12, 0, 1, 0)))
-          .toBe(Date.UTC(1980, JAN, 1, 12, 0, 2, 0))
+      })
+
+      it('atomicToUnix', () => {
+        expect(converter.atomicToUnix(new Rat(0n)))
+          .toEqual(new Rat(0n))
+
+        // SMEAR STARTS
+        expect(converter.atomicToUnix(millisToExact(Date.UTC(1979, DEC, 31, 11, 59, 59, 999))))
+          .toEqual(millisToExact(Date.UTC(1979, DEC, 31, 11, 59, 59, 999)))
+        expect(converter.atomicToUnix(millisToExact(Date.UTC(1979, DEC, 31, 12, 0, 0, 0))))
+          .toEqual(millisToExact(Date.UTC(1979, DEC, 31, 12, 0, 0, 0)))
+        expect(converter.atomicToUnix(millisToExact(Date.UTC(1979, DEC, 31, 12, 0, 0, 1))))
+          .toEqual(millisToExact(Date.UTC(1979, DEC, 31, 12, 0, 0, 1)).minus(new Rat(1n, 86_401_000n)))
+
+        // SMEAR MIDPOINT
+        expect(converter.atomicToUnix(millisToExact(Date.UTC(1980, JAN, 1, 0, 0, 0, 500))))
+          .toEqual(millisToExact(Date.UTC(1980, JAN, 1, 0, 0, 0, 0)))
+
+        // SMEAR ENDS
+        expect(converter.atomicToUnix(millisToExact(Date.UTC(1980, JAN, 1, 12, 0, 0, 999))))
+          .toEqual(millisToExact(Date.UTC(1980, JAN, 1, 12, 0, 0, 0)).minus(new Rat(86_400n, 86_401_000n)))
+        expect(converter.atomicToUnix(millisToExact(Date.UTC(1980, JAN, 1, 12, 0, 1, 0))))
+          .toEqual(millisToExact(Date.UTC(1980, JAN, 1, 12, 0, 0, 0)))
+        expect(converter.atomicToUnix(millisToExact(Date.UTC(1980, JAN, 1, 12, 0, 1, 1))))
+          .toEqual(millisToExact(Date.UTC(1980, JAN, 1, 12, 0, 0, 1)))
       })
 
       it('atomicMillisToUnixMillis', () => {
-        expect(converter.atomicMillisToUnixMillis(0)).toBe(0)
+        expect(converter.atomicMillisToUnixMillis(0))
+          .toBe(0)
+
+        // SMEAR STARTS
         expect(converter.atomicMillisToUnixMillis(Date.UTC(1979, DEC, 31, 11, 59, 59, 999)))
           .toBe(Date.UTC(1979, DEC, 31, 11, 59, 59, 999))
         expect(converter.atomicMillisToUnixMillis(Date.UTC(1979, DEC, 31, 12, 0, 0, 0)))
           .toBe(Date.UTC(1979, DEC, 31, 12, 0, 0, 0))
+        expect(converter.atomicMillisToUnixMillis(Date.UTC(1979, DEC, 31, 12, 0, 0, 1)))
+          .toBe(Date.UTC(1979, DEC, 31, 12, 0, 0, 0)) // truncated down
+
+        // SMEAR MIDPOINT
         expect(converter.atomicMillisToUnixMillis(Date.UTC(1980, JAN, 1, 0, 0, 0, 500)))
           .toBe(Date.UTC(1980, JAN, 1, 0, 0, 0, 0))
+
+        // SMEAR ENDS
+        expect(converter.atomicMillisToUnixMillis(Date.UTC(1980, JAN, 1, 12, 0, 0, 999)))
+          .toBe(Date.UTC(1980, JAN, 1, 11, 59, 59, 999))
         expect(converter.atomicMillisToUnixMillis(Date.UTC(1980, JAN, 1, 12, 0, 1, 0)))
           .toBe(Date.UTC(1980, JAN, 1, 12, 0, 0, 0))
         expect(converter.atomicMillisToUnixMillis(Date.UTC(1980, JAN, 1, 12, 0, 1, 1)))
           .toBe(Date.UTC(1980, JAN, 1, 12, 0, 0, 1))
-        expect(converter.atomicMillisToUnixMillis(Date.UTC(1980, JAN, 1, 12, 0, 2, 0)))
-          .toBe(Date.UTC(1980, JAN, 1, 12, 0, 1, 0))
       })
     })
   })

--- a/src/converter.spec.js
+++ b/src/converter.spec.js
@@ -18,13 +18,20 @@ describe('Converter', () => {
       const converter = Converter(data, MODELS.OVERRUN)
 
       it('manages basic conversions', () => {
-        expect(converter.unixToAtomic(new Rat(0n))).toEqual([{ start: new Rat(0n), end: new Rat(0n) }])
-        expect(converter.unixMillisToAtomicMillis(0, { range: true, array: true })).toEqual([[0, 0]])
-        expect(converter.unixMillisToAtomicMillis(0, { range: true })).toEqual([0, 0])
-        expect(converter.unixMillisToAtomicMillis(0, { array: true })).toEqual([0])
-        expect(converter.unixMillisToAtomicMillis(0)).toEqual(0)
-        expect(converter.atomicToUnix(new Rat(0n))).toEqual(new Rat(0n))
-        expect(converter.atomicMillisToUnixMillis(0)).toBe(0)
+        expect(converter.unixToAtomic(Rat.fromMillis(0)))
+          .toEqual([{ start: Rat.fromMillis(0), end: Rat.fromMillis(0) }])
+        expect(converter.unixMillisToAtomicMillis(0, { range: true, array: true }))
+          .toEqual([[0, 0]])
+        expect(converter.unixMillisToAtomicMillis(0, { range: true }))
+          .toEqual([0, 0])
+        expect(converter.unixMillisToAtomicMillis(0, { array: true }))
+          .toEqual([0])
+        expect(converter.unixMillisToAtomicMillis(0))
+          .toBe(0)
+        expect(converter.atomicToUnix(Rat.fromMillis(0)))
+          .toEqual(Rat.fromMillis(0))
+        expect(converter.atomicMillisToUnixMillis(0))
+          .toBe(0)
       })
     })
 
@@ -32,10 +39,14 @@ describe('Converter', () => {
       const converter = Converter(data, MODELS.BREAK)
 
       it('manages basic conversions', () => {
-        expect(converter.unixToAtomic(new Rat(0n))).toEqual([{ start: new Rat(0n), end: new Rat(0n) }])
-        expect(converter.unixMillisToAtomicMillis(0)).toEqual(0)
-        expect(converter.atomicToUnix(new Rat(0n))).toEqual(new Rat(0n))
-        expect(converter.atomicMillisToUnixMillis(0)).toBe(0)
+        expect(converter.unixToAtomic(Rat.fromMillis(0)))
+          .toEqual([{ start: Rat.fromMillis(0), end: Rat.fromMillis(0) }])
+        expect(converter.unixMillisToAtomicMillis(0))
+          .toBe(0)
+        expect(converter.atomicToUnix(Rat.fromMillis(0)))
+          .toEqual(Rat.fromMillis(0))
+        expect(converter.atomicMillisToUnixMillis(0))
+          .toBe(0)
       })
     })
 
@@ -50,26 +61,34 @@ describe('Converter', () => {
       })
 
       it('fails when the atomic count is out of bounds', () => {
-        expect(converter.atomicToUnix(new Rat(0n))).toEqual(new Rat(0n))
-        expect(converter.atomicMillisToUnixMillis(0)).toBe(0)
-        expect(converter.atomicToUnix(new Rat(-1n, 1_000n))).toBe(NaN)
-        expect(converter.atomicMillisToUnixMillis(-1)).toBe(NaN)
+        expect(converter.atomicToUnix(Rat.fromMillis(0)))
+          .toEqual(Rat.fromMillis(0))
+        expect(converter.atomicMillisToUnixMillis(0))
+          .toBe(0)
+        expect(converter.atomicToUnix(Rat.fromMillis(-1)))
+          .toBe(NaN)
+        expect(converter.atomicMillisToUnixMillis(-1))
+          .toBe(NaN)
       })
 
       it('fails when the Unix count is out of bounds', () => {
-        expect(converter.unixToAtomic(new Rat(0n))).toEqual([{ start: new Rat(0n), end: new Rat(0n) }])
-        expect(converter.unixMillisToAtomicMillis(0)).toBe(0)
-        expect(converter.unixToAtomic(new Rat(-1n, 1_000n))).toEqual([])
-        expect(converter.unixMillisToAtomicMillis(-1)).toBe(NaN)
+        expect(converter.unixToAtomic(Rat.fromMillis(0)))
+          .toEqual([{ start: Rat.fromMillis(0), end: Rat.fromMillis(0) }])
+        expect(converter.unixMillisToAtomicMillis(0))
+          .toBe(0)
+        expect(converter.unixToAtomic(Rat.fromMillis(-1)))
+          .toEqual([])
+        expect(converter.unixMillisToAtomicMillis(-1))
+          .toBe(NaN)
       })
 
       it('manages basic conversions', () => {
-        expect(converter.unixToAtomic(new Rat(0n))).toEqual([{ start: new Rat(0n), end: new Rat(0n) }])
+        expect(converter.unixToAtomic(Rat.fromMillis(0))).toEqual([{ start: Rat.fromMillis(0), end: Rat.fromMillis(0) }])
         expect(converter.unixMillisToAtomicMillis(0, { range: true, array: true })).toEqual([[0, 0]])
         expect(converter.unixMillisToAtomicMillis(0, { range: true })).toEqual([0, 0])
         expect(converter.unixMillisToAtomicMillis(0, { array: true })).toEqual([0])
         expect(converter.unixMillisToAtomicMillis(0)).toBe(0)
-        expect(converter.atomicToUnix(new Rat(0n))).toEqual(new Rat(0n))
+        expect(converter.atomicToUnix(Rat.fromMillis(0))).toEqual(Rat.fromMillis(0))
         expect(converter.atomicMillisToUnixMillis(0)).toBe(0)
       })
     })
@@ -78,10 +97,14 @@ describe('Converter', () => {
       const converter = Converter(data, MODELS.SMEAR)
 
       it('manages basic conversions', () => {
-        expect(converter.unixToAtomic(new Rat(0n))).toEqual([{ start: new Rat(0n), end: new Rat(0n) }])
-        expect(converter.unixMillisToAtomicMillis(0)).toEqual(0)
-        expect(converter.atomicToUnix(new Rat(0n))).toEqual(new Rat(0n))
-        expect(converter.atomicMillisToUnixMillis(0)).toBe(0)
+        expect(converter.unixToAtomic(Rat.fromMillis(0)))
+          .toEqual([{ start: Rat.fromMillis(0), end: Rat.fromMillis(0) }])
+        expect(converter.unixMillisToAtomicMillis(0))
+          .toBe(0)
+        expect(converter.atomicToUnix(Rat.fromMillis(0)))
+          .toEqual(Rat.fromMillis(0))
+        expect(converter.atomicMillisToUnixMillis(0))
+          .toBe(0)
       })
     })
   })
@@ -96,10 +119,10 @@ describe('Converter', () => {
       const converter = Converter(data, MODELS.OVERRUN)
 
       it('unixToAtomic', () => {
-        expect(converter.unixToAtomic(new Rat(0n)))
+        expect(converter.unixToAtomic(Rat.fromMillis(0)))
           .toEqual([{
-            start: new Rat(0n),
-            end: new Rat(0n)
+            start: Rat.fromMillis(0),
+            end: Rat.fromMillis(0)
           }])
 
         // BIFURCATION
@@ -205,8 +228,8 @@ describe('Converter', () => {
       })
 
       it('atomicToUnix', () => {
-        expect(converter.atomicToUnix(new Rat(0n)))
-          .toEqual(new Rat(0n))
+        expect(converter.atomicToUnix(Rat.fromMillis(0)))
+          .toEqual(Rat.fromMillis(0))
 
         expect(converter.atomicToUnix(Rat.fromMillis(Date.UTC(1979, DEC, 31, 23, 59, 59, 999))))
           .toEqual(Rat.fromMillis(Date.UTC(1979, DEC, 31, 23, 59, 59, 999)))
@@ -249,10 +272,10 @@ describe('Converter', () => {
       const converter = Converter(data, MODELS.BREAK)
 
       it('unixToAtomic', () => {
-        expect(converter.unixToAtomic(new Rat(0n)))
+        expect(converter.unixToAtomic(Rat.fromMillis(0)))
           .toEqual([{
-            start: new Rat(0n),
-            end: new Rat(0n)
+            start: Rat.fromMillis(0),
+            end: Rat.fromMillis(0)
           }])
 
         // FORWARD JUMP
@@ -310,8 +333,8 @@ describe('Converter', () => {
       })
 
       it('atomicToUnix', () => {
-        expect(converter.atomicToUnix(new Rat(0n)))
-          .toEqual(new Rat(0n))
+        expect(converter.atomicToUnix(Rat.fromMillis(0)))
+          .toEqual(Rat.fromMillis(0))
 
         // UNDEFINED UNIX TIME STARTS
         expect(converter.atomicToUnix(Rat.fromMillis(Date.UTC(1979, DEC, 31, 23, 59, 59, 999))))
@@ -356,10 +379,10 @@ describe('Converter', () => {
       const converter = Converter(data, MODELS.STALL)
 
       it('unixToAtomic', () => {
-        expect(converter.unixToAtomic(new Rat(0n)))
+        expect(converter.unixToAtomic(Rat.fromMillis(0)))
           .toEqual([{
-            start: new Rat(0n),
-            end: new Rat(0n)
+            start: Rat.fromMillis(0),
+            end: Rat.fromMillis(0)
           }])
 
         // STALL POINT
@@ -416,8 +439,8 @@ describe('Converter', () => {
       })
 
       it('atomicToUnix', () => {
-        expect(converter.atomicToUnix(new Rat(0n)))
-          .toEqual(new Rat(0n))
+        expect(converter.atomicToUnix(Rat.fromMillis(0)))
+          .toEqual(Rat.fromMillis(0))
 
         // STALL STARTS
         expect(converter.atomicToUnix(Rat.fromMillis(Date.UTC(1979, DEC, 31, 23, 59, 59, 999))))
@@ -462,10 +485,10 @@ describe('Converter', () => {
       const converter = Converter(data, MODELS.SMEAR)
 
       it('unixToAtomic', () => {
-        expect(converter.unixToAtomic(new Rat(0n)))
+        expect(converter.unixToAtomic(Rat.fromMillis(0)))
           .toEqual([{
-            start: new Rat(0n),
-            end: new Rat(0n)
+            start: Rat.fromMillis(0),
+            end: Rat.fromMillis(0)
           }])
 
         // SMEAR STARTS, ATOMIC TIME "RUNS A LITTLE FASTER" THAN UNIX (actually Unix is slower)
@@ -536,8 +559,8 @@ describe('Converter', () => {
       })
 
       it('atomicToUnix', () => {
-        expect(converter.atomicToUnix(new Rat(0n)))
-          .toEqual(new Rat(0n))
+        expect(converter.atomicToUnix(Rat.fromMillis(0)))
+          .toEqual(Rat.fromMillis(0))
 
         // SMEAR STARTS, UNIX TIME RUNS A LITTLE SLOWER THAN ATOMIC
         expect(converter.atomicToUnix(Rat.fromMillis(Date.UTC(1979, DEC, 31, 11, 59, 59, 999))))
@@ -597,10 +620,10 @@ describe('Converter', () => {
       const converter = Converter(data, MODELS.OVERRUN)
 
       it('unixToAtomic', () => {
-        expect(converter.unixToAtomic(new Rat(0n)))
+        expect(converter.unixToAtomic(Rat.fromMillis(0)))
           .toEqual([{
-            start: new Rat(0n),
-            end: new Rat(0n)
+            start: Rat.fromMillis(0),
+            end: Rat.fromMillis(0)
           }])
 
         // START OF MISSING TIME
@@ -610,16 +633,13 @@ describe('Converter', () => {
             end: Rat.fromMillis(Date.UTC(1979, DEC, 31, 23, 59, 58, 999))
           }])
         expect(converter.unixToAtomic(Rat.fromMillis(Date.UTC(1979, DEC, 31, 23, 59, 59, 0))))
-          .toEqual([
-          ])
+          .toEqual([])
         expect(converter.unixToAtomic(Rat.fromMillis(Date.UTC(1979, DEC, 31, 23, 59, 59, 1))))
-          .toEqual([
-          ])
+          .toEqual([])
 
         // END OF MISSING TIME
         expect(converter.unixToAtomic(Rat.fromMillis(Date.UTC(1979, DEC, 31, 23, 59, 59, 999))))
-          .toEqual([
-          ])
+          .toEqual([])
         expect(converter.unixToAtomic(Rat.fromMillis(Date.UTC(1980, JAN, 1, 0, 0, 0, 0))))
           .toEqual([{
             start: Rat.fromMillis(Date.UTC(1979, DEC, 31, 23, 59, 59, 0)),
@@ -642,16 +662,13 @@ describe('Converter', () => {
             Date.UTC(1979, DEC, 31, 23, 59, 58, 999)
           ])
         expect(converter.unixMillisToAtomicMillis(Date.UTC(1979, DEC, 31, 23, 59, 59, 0), { array: true }))
-          .toEqual([
-          ])
+          .toEqual([])
         expect(converter.unixMillisToAtomicMillis(Date.UTC(1979, DEC, 31, 23, 59, 59, 1), { array: true }))
-          .toEqual([
-          ])
+          .toEqual([])
 
         // END OF MISSING TIME
         expect(converter.unixMillisToAtomicMillis(Date.UTC(1979, DEC, 31, 23, 59, 59, 999), { array: true }))
-          .toEqual([
-          ])
+          .toEqual([])
         expect(converter.unixMillisToAtomicMillis(Date.UTC(1980, JAN, 1, 0, 0, 0, 0), { array: true }))
           .toEqual([
             Date.UTC(1979, DEC, 31, 23, 59, 59, 0)
@@ -684,8 +701,8 @@ describe('Converter', () => {
       })
 
       it('atomicToUnix', () => {
-        expect(converter.atomicToUnix(new Rat(0n)))
-          .toEqual(new Rat(0n))
+        expect(converter.atomicToUnix(Rat.fromMillis(0)))
+          .toEqual(Rat.fromMillis(0))
 
         // JUMP AHEAD
         expect(converter.atomicToUnix(Rat.fromMillis(Date.UTC(1979, DEC, 31, 23, 59, 58, 999))))
@@ -714,10 +731,10 @@ describe('Converter', () => {
       const converter = Converter(data, MODELS.BREAK)
 
       it('unixToAtomic', () => {
-        expect(converter.unixToAtomic(new Rat(0n)))
+        expect(converter.unixToAtomic(Rat.fromMillis(0)))
           .toEqual([{
-            start: new Rat(0n),
-            end: new Rat(0n)
+            start: Rat.fromMillis(0),
+            end: Rat.fromMillis(0)
           }])
 
         // START OF MISSING TIME
@@ -727,16 +744,13 @@ describe('Converter', () => {
             end: Rat.fromMillis(Date.UTC(1979, DEC, 31, 23, 59, 58, 999))
           }])
         expect(converter.unixToAtomic(Rat.fromMillis(Date.UTC(1979, DEC, 31, 23, 59, 59, 0))))
-          .toEqual([
-          ])
+          .toEqual([])
         expect(converter.unixToAtomic(Rat.fromMillis(Date.UTC(1979, DEC, 31, 23, 59, 59, 1))))
-          .toEqual([
-          ])
+          .toEqual([])
 
         // END OF MISSING TIME
         expect(converter.unixToAtomic(Rat.fromMillis(Date.UTC(1979, DEC, 31, 23, 59, 59, 999))))
-          .toEqual([
-          ])
+          .toEqual([])
         expect(converter.unixToAtomic(Rat.fromMillis(Date.UTC(1980, JAN, 1, 0, 0, 0, 0))))
           .toEqual([{
             start: Rat.fromMillis(Date.UTC(1979, DEC, 31, 23, 59, 59, 0)),
@@ -771,8 +785,8 @@ describe('Converter', () => {
       })
 
       it('atomicToUnix', () => {
-        expect(converter.atomicToUnix(new Rat(0n)))
-          .toEqual(new Rat(0n))
+        expect(converter.atomicToUnix(Rat.fromMillis(0)))
+          .toEqual(Rat.fromMillis(0))
 
         // JUMP AHEAD
         expect(converter.atomicToUnix(Rat.fromMillis(Date.UTC(1979, DEC, 31, 23, 59, 58, 999))))
@@ -801,10 +815,10 @@ describe('Converter', () => {
       const converter = Converter(data, MODELS.STALL)
 
       it('unixToAtomic', () => {
-        expect(converter.unixToAtomic(new Rat(0n)))
+        expect(converter.unixToAtomic(Rat.fromMillis(0)))
           .toEqual([{
-            start: new Rat(0n),
-            end: new Rat(0n)
+            start: Rat.fromMillis(0),
+            end: Rat.fromMillis(0)
           }])
 
         // START OF MISSING TIME
@@ -814,16 +828,13 @@ describe('Converter', () => {
             end: Rat.fromMillis(Date.UTC(1979, DEC, 31, 23, 59, 58, 999))
           }])
         expect(converter.unixToAtomic(Rat.fromMillis(Date.UTC(1979, DEC, 31, 23, 59, 59, 0))))
-          .toEqual([
-          ])
+          .toEqual([])
         expect(converter.unixToAtomic(Rat.fromMillis(Date.UTC(1979, DEC, 31, 23, 59, 59, 1))))
-          .toEqual([
-          ])
+          .toEqual([])
 
         // END OF MISSING TIME
         expect(converter.unixToAtomic(Rat.fromMillis(Date.UTC(1979, DEC, 31, 23, 59, 59, 999))))
-          .toEqual([
-          ])
+          .toEqual([])
         expect(converter.unixToAtomic(Rat.fromMillis(Date.UTC(1980, JAN, 1, 0, 0, 0, 0))))
           .toEqual([{
             start: Rat.fromMillis(Date.UTC(1979, DEC, 31, 23, 59, 59, 0)),
@@ -900,8 +911,8 @@ describe('Converter', () => {
       })
 
       it('atomicToUnix', () => {
-        expect(converter.atomicToUnix(new Rat(0n)))
-          .toEqual(new Rat(0n))
+        expect(converter.atomicToUnix(Rat.fromMillis(0)))
+          .toEqual(Rat.fromMillis(0))
 
         // JUMP AHEAD
         expect(converter.atomicToUnix(Rat.fromMillis(Date.UTC(1979, DEC, 31, 23, 59, 58, 999))))
@@ -930,10 +941,10 @@ describe('Converter', () => {
       const converter = Converter(data, MODELS.SMEAR)
 
       it('unixToAtomic', () => {
-        expect(converter.unixToAtomic(new Rat(0n)))
+        expect(converter.unixToAtomic(Rat.fromMillis(0)))
           .toEqual([{
-            start: new Rat(0n),
-            end: new Rat(0n)
+            start: Rat.fromMillis(0),
+            end: Rat.fromMillis(0)
           }])
 
         // SMEAR STARTS, ATOMIC "RUNS A LITTLE SLOWER" THAN UNIX (actually Unix runs faster)
@@ -1004,8 +1015,8 @@ describe('Converter', () => {
       })
 
       it('atomicToUnix', () => {
-        expect(converter.atomicToUnix(new Rat(0n)))
-          .toEqual(new Rat(0n))
+        expect(converter.atomicToUnix(Rat.fromMillis(0)))
+          .toEqual(Rat.fromMillis(0))
 
         // SMEAR STARTS, UNIX TIME RUNS A LITTLE FASTER THAN ATOMIC
         expect(converter.atomicToUnix(Rat.fromMillis(Date.UTC(1979, DEC, 31, 11, 59, 59, 999))))
@@ -1063,16 +1074,16 @@ describe('Converter', () => {
         ]
         const converter = Converter(data, MODELS.OVERRUN)
 
-        expect(converter.unixToAtomic(new Rat(1n, 1_000n)))
+        expect(converter.unixToAtomic(Rat.fromMillis(1)))
           .toEqual([{
             start: new Rat(900n, 1_000_000n),
             end: new Rat(900n, 1_000_000n)
           }])
         expect(converter.atomicToUnix(new Rat(900n, 1_000_000n)))
-          .toEqual(new Rat(1n, 1_000n))
+          .toEqual(Rat.fromMillis(1))
 
         expect(converter.unixMillisToAtomicMillis(1, { array: true }))
-          .toEqual([0])
+          .toEqual([0]) // truncated from .9 to 0
         expect(converter.atomicMillisToUnixMillis(0))
           .toBe(NaN)
       })
@@ -1084,13 +1095,13 @@ describe('Converter', () => {
         ]
         const converter = Converter(data, MODELS.OVERRUN)
 
-        expect(converter.unixToAtomic(new Rat(-1n, 1_000n)))
+        expect(converter.unixToAtomic(Rat.fromMillis(-1)))
           .toEqual([{
             start: new Rat(-900n, 1_000_000n),
             end: new Rat(-900n, 1_000_000n)
           }])
         expect(converter.atomicToUnix(new Rat(-900n, 1_000_000n)))
-          .toEqual(new Rat(-1n, 1_000n))
+          .toEqual(Rat.fromMillis(-1))
 
         expect(converter.unixMillisToAtomicMillis(-1, { array: true }))
           .toEqual([-1])

--- a/src/div.js
+++ b/src/div.js
@@ -27,12 +27,10 @@ const div = (a, b) => {
 // Return value always has the same sign as `b`, so we can divide both `a` and `b`
 // by the return value to always end up with a positive `b`
 const gcd = (a, b) => {
-  const bNegative = b < 0n
   while (b !== 0n) {
     [a, b] = [b, a % b]
   }
-  const aNegative = a < 0n
-  return aNegative === bNegative ? a : -a
+  return a
 }
 
 module.exports.sign = sign

--- a/src/div.spec.js
+++ b/src/div.spec.js
@@ -57,8 +57,8 @@ describe('gcd', () => {
   it('works', () => {
     expect(gcd(252n, 105n)).toBe(21n)
     expect(gcd(105n, 252n)).toBe(21n)
-    expect(gcd(-105n, 252n)).toBe(21n)
-    expect(gcd(105n, -252n)).toBe(-21n)
+    expect(gcd(-105n, 252n)).toBe(-21n) // sign kind of varies
+    expect(gcd(105n, -252n)).toBe(21n)
     expect(gcd(-105n, -252n)).toBe(-21n)
     expect(gcd(6n, 35n)).toBe(1n)
     expect(gcd(35n, 6n)).toBe(1n)

--- a/src/index.js
+++ b/src/index.js
@@ -1,7 +1,16 @@
 const { Converter, MODELS } = require('./converter')
-const { taiData, UNIX_START, UNIX_END } = require('./tai-data')
+const { taiData, UNIX_START_MILLIS, UNIX_END_MILLIS } = require('./tai-data')
+const { Rat } = require('./rat')
 
-module.exports.UNIX_START = UNIX_START
-module.exports.UNIX_END = UNIX_END
+// Some of the externals' names aren't quite right so rename them here
+module.exports.UNIX_START = UNIX_START_MILLIS
+module.exports.UNIX_END = UNIX_END_MILLIS
 module.exports.MODELS = MODELS
-module.exports.TaiConverter = model => Converter(taiData, model)
+module.exports.Rat = Rat
+module.exports.TaiConverter = model => {
+  const converter = Converter(taiData, model)
+  return {
+    atomicToUnix: converter.atomicMillisToUnixMillis,
+    unixToAtomic: converter.unixMillisToAtomicMillis
+  }
+}

--- a/src/index.spec.js
+++ b/src/index.spec.js
@@ -1,6 +1,6 @@
 /* eslint-env jest */
 
-const { TaiConverter, MODELS } = require('.')
+const { TaiConverter, MODELS, UNIX_START, UNIX_END } = require('.')
 
 const JAN = 0
 const FEB = 1
@@ -12,6 +12,18 @@ const SEP = 8
 const OCT = 9
 const DEC = 11
 
+describe('UNIX_START', () => {
+  it('is correct', () => {
+    expect(UNIX_START).toBe(Date.UTC(1961, JAN, 1))
+  })
+})
+
+describe('UNIX_END', () => {
+  it('is correct', () => {
+    expect(UNIX_END).toBe(Date.UTC(2022, DEC, 31, 12, 0, 0, 0))
+  })
+})
+
 describe('TaiConverter', () => {
   describe('OVERRUN', () => {
     const converter = TaiConverter(MODELS.OVERRUN)
@@ -20,7 +32,7 @@ describe('TaiConverter', () => {
       const unixToAtomic = unixMillis => converter.unixToAtomic(unixMillis, { array: true })
 
       it('starts TAI at 1961-01-01 00:00:01.422_818', () => {
-        // 00:00:01.422_818 is in range, but rounds down to 00:00:01.422 which is not
+        // 00:00:01.422_818 is in range, but rounds down to 00:00:01.422 which technically is not
         expect(unixToAtomic(Date.UTC(1961, JAN, 1, 0, 0, 0, 0)))
           .toEqual([-283_996_798_578])
       })

--- a/src/munge.js
+++ b/src/munge.js
@@ -32,10 +32,6 @@ const MODELS = {
   SMEAR: Symbol('SMEAR')
 }
 
-const exactToMillis = rat => Number.isNaN(rat)
-  ? rat
-  : Number(rat.times(new Rat(1_000n)).trunc())
-
 const NOV = 10
 const secondsPerDay = new Rat(86_400n)
 const mjdEpoch = {
@@ -209,5 +205,4 @@ const munge = (data, model) => {
 }
 
 module.exports.MODELS = MODELS
-module.exports.exactToMillis = exactToMillis
 module.exports.munge = munge

--- a/src/munge.js
+++ b/src/munge.js
@@ -160,7 +160,8 @@ const munge = (data, model) => {
         .plus(b.start.atomic)
 
       if (smearEnd.atomic.le(smearStart.atomic)) {
-        // No negative-length or zero-length smears
+        // No negative-length or zero-length smears.
+        // This handles negative leap seconds correctly.
         continue
       }
 
@@ -169,6 +170,9 @@ const munge = (data, model) => {
       a.end = smearStart // includes unix but we'll ignore that
       b.start = smearEnd
 
+      // This can reduce `a` to length 0, in which case we elide it.
+      // No point checking for negative-length segments, those throw an
+      // exception later
       if (a.start.atomic.eq(a.end.atomic)) {
         munged.splice(i, 1)
         i--

--- a/src/munge.js
+++ b/src/munge.js
@@ -32,8 +32,17 @@ const MODELS = {
   SMEAR: Symbol('SMEAR')
 }
 
-const millisToExact = millis => new Rat(BigInt(millis), 1_000n)
-const exactToMillis = rat => Number(rat.times(new Rat(1_000n)).trunc())
+const millisToExact = millis => {
+  if (!Number.isInteger(millis)) {
+    throw Error(`Not an integer: ${millis}`)
+  }
+
+  return new Rat(BigInt(millis), 1_000n)
+}
+
+const exactToMillis = rat => Number.isNaN(rat)
+  ? rat
+  : Number(rat.times(new Rat(1_000n)).trunc())
 
 const NOV = 10
 const secondsPerDay = new Rat(86_400n)

--- a/src/munge.js
+++ b/src/munge.js
@@ -32,14 +32,6 @@ const MODELS = {
   SMEAR: Symbol('SMEAR')
 }
 
-const millisToExact = millis => {
-  if (!Number.isInteger(millis)) {
-    throw Error(`Not an integer: ${millis}`)
-  }
-
-  return new Rat(BigInt(millis), 1_000n)
-}
-
 const exactToMillis = rat => Number.isNaN(rat)
   ? rat
   : Number(rat.times(new Rat(1_000n)).trunc())
@@ -47,7 +39,7 @@ const exactToMillis = rat => Number.isNaN(rat)
 const NOV = 10
 const secondsPerDay = new Rat(86_400n)
 const mjdEpoch = {
-  unix: millisToExact(Date.UTC(1858, NOV, 17))
+  unix: Rat.fromMillis(Date.UTC(1858, NOV, 17))
 }
 
 // Input some raw TAI-UTC data, output the same data but altered to be more consumable for our
@@ -69,7 +61,7 @@ const munge = (data, model) => {
     ] = datum
 
     // Convert from a millisecond count to a precise ratio of seconds
-    start.unix = millisToExact(start.unixMillis)
+    start.unix = Rat.fromMillis(start.unixMillis)
 
     // Convert from a floating point number to a precise ratio
     // Offsets are given in TAI seconds to seven decimal places, e.g. `1.422_818_0`.
@@ -217,6 +209,5 @@ const munge = (data, model) => {
 }
 
 module.exports.MODELS = MODELS
-module.exports.millisToExact = millisToExact
 module.exports.exactToMillis = exactToMillis
 module.exports.munge = munge

--- a/src/munge.js
+++ b/src/munge.js
@@ -169,6 +169,11 @@ const munge = (data, model) => {
       a.end = smearStart // includes unix but we'll ignore that
       b.start = smearEnd
 
+      if (a.start.atomic.eq(a.end.atomic)) {
+        munged.splice(i, 1)
+        i--
+      }
+
       if (model === MODELS.BREAK) {
         // Just leave a gap
         continue

--- a/src/munge.spec.js
+++ b/src/munge.spec.js
@@ -43,7 +43,7 @@ describe('munge', () => {
       expect(munge([
         [Date.UTC(1970, JAN, 1), 0]
       ], MODELS.OVERRUN)).toEqual([new Segment(
-        { atomic: new Rat(0n), unix: new Rat(0n) },
+        { atomic: Rat.fromMillis(0), unix: Rat.fromMillis(0) },
         { atomic: Infinity },
         new Rat(1n)
       )])
@@ -53,7 +53,7 @@ describe('munge', () => {
       expect(munge([
         [7, -4]
       ], MODELS.OVERRUN)).toEqual([new Segment(
-        { atomic: new Rat(-3_993n, 1_000n), unix: new Rat(7n, 1_000n) },
+        { atomic: Rat.fromMillis(-3_993), unix: Rat.fromMillis(7) },
         { atomic: Infinity },
         new Rat(1n)
       )])
@@ -88,7 +88,7 @@ describe('munge', () => {
       expect(munge([
         [Date.UTC(1970, JAN, 1), 0, 40_587, 8.640_0]
       ], MODELS.OVERRUN)).toEqual([new Segment(
-        { atomic: new Rat(0n), unix: new Rat(0n) },
+        { atomic: Rat.fromMillis(0), unix: Rat.fromMillis(0) },
         { atomic: Infinity },
         new Rat(10_000n, 10_001n)
       )])
@@ -97,7 +97,7 @@ describe('munge', () => {
       expect(munge([
         [Date.UTC(1970, JAN, 1), 0, 40_587, 0]
       ], MODELS.OVERRUN)).toEqual([new Segment(
-        { atomic: new Rat(0n), unix: new Rat(0n) },
+        { atomic: Rat.fromMillis(0), unix: Rat.fromMillis(0) },
         { atomic: Infinity },
         new Rat(1n)
       )])
@@ -106,7 +106,7 @@ describe('munge', () => {
       expect(munge([
         [Date.UTC(1970, JAN, 1), 0, 40_587, -8.640_0]
       ], MODELS.OVERRUN)).toEqual([new Segment(
-        { atomic: new Rat(0n), unix: new Rat(0n) },
+        { atomic: Rat.fromMillis(0), unix: Rat.fromMillis(0) },
         { atomic: Infinity },
         new Rat(10_000n, 9_999n)
       )])
@@ -116,7 +116,7 @@ describe('munge', () => {
       expect(munge([
         [Date.UTC(1970, JAN, 1), 0, 40_587, -86_400 + 8.640_0]
       ], MODELS.OVERRUN)).toEqual([new Segment(
-        { atomic: new Rat(0n), unix: new Rat(0n) },
+        { atomic: Rat.fromMillis(0), unix: Rat.fromMillis(0) },
         { atomic: Infinity },
         new Rat(10_000n)
       )])
@@ -129,7 +129,7 @@ describe('munge', () => {
       expect(munge([
         [Date.UTC(1970, JAN, 1), 0, 40_587, -86_400 - 8.640_0]
       ], MODELS.OVERRUN)).toEqual([new Segment(
-        { atomic: new Rat(0n), unix: new Rat(0n) },
+        { atomic: Rat.fromMillis(0), unix: Rat.fromMillis(0) },
         { atomic: Infinity },
         new Rat(-10_000n)
       )])
@@ -265,7 +265,7 @@ describe('munge', () => {
         expect(munge([
           [Date.UTC(1970, JAN, 1, 0, 0, 0, 1), -0.000_1]
         ], MODELS.OVERRUN)).toEqual([new Segment(
-          { atomic: new Rat(900n, 1_000_000n), unix: new Rat(1n, 1_000n) }, // ray start intentionally doesn't include TAI epoch
+          { atomic: new Rat(900n, 1_000_000n), unix: Rat.fromMillis(1) }, // ray start intentionally doesn't include TAI epoch
           { atomic: Infinity },
           new Rat(1n)
         )])
@@ -277,11 +277,11 @@ describe('munge', () => {
           [Date.UTC(1969, DEC, 31, 23, 59, 59, 999), 0.000_1],
           [Date.UTC(1970, JAN, 1, 0, 0, 0, 1), -0.001_1]
         ], MODELS.OVERRUN)).toEqual([new Segment(
-          { atomic: new Rat(-900n, 1_000_000n), unix: new Rat(-1n, 1_000n) },
+          { atomic: new Rat(-900n, 1_000_000n), unix: Rat.fromMillis(-1) },
           { atomic: new Rat(-100n, 1_000_000n) },
           new Rat(1n)
         ), new Segment(
-          { atomic: new Rat(-100n, 1_000_000n), unix: new Rat(1n, 1_000n) },
+          { atomic: new Rat(-100n, 1_000_000n), unix: Rat.fromMillis(1) },
           { atomic: Infinity },
           new Rat(1n)
         )])
@@ -294,7 +294,7 @@ describe('munge', () => {
       expect(munge([
         [Date.UTC(1970, JAN, 1), 0]
       ], MODELS.BREAK)).toEqual([new Segment(
-        { atomic: new Rat(0n), unix: new Rat(0n) },
+        { atomic: Rat.fromMillis(0), unix: Rat.fromMillis(0) },
         { atomic: Infinity },
         new Rat(1n)
       )])
@@ -338,7 +338,7 @@ describe('munge', () => {
       expect(munge([
         [Date.UTC(1970, JAN, 1), 0]
       ], MODELS.STALL)).toEqual([new Segment(
-        { atomic: new Rat(0n), unix: new Rat(0n) },
+        { atomic: Rat.fromMillis(0), unix: Rat.fromMillis(0) },
         { atomic: Infinity },
         new Rat(1n)
       )])
@@ -348,7 +348,7 @@ describe('munge', () => {
       expect(munge([
         [7, -4]
       ], MODELS.STALL)).toEqual([new Segment(
-        { atomic: new Rat(-3_993n, 1_000n), unix: new Rat(7n, 1_000n) },
+        { atomic: Rat.fromMillis(-3_993), unix: Rat.fromMillis(7) },
         { atomic: Infinity },
         new Rat(1n)
       )])
@@ -388,7 +388,7 @@ describe('munge', () => {
       expect(munge([
         [Date.UTC(1970, JAN, 1), 0, 40_587, 8.640_0]
       ], MODELS.STALL)).toEqual([new Segment(
-        { atomic: new Rat(0n), unix: new Rat(0n) },
+        { atomic: Rat.fromMillis(0), unix: Rat.fromMillis(0) },
         { atomic: Infinity },
         new Rat(10_000n, 10_001n)
       )])
@@ -397,7 +397,7 @@ describe('munge', () => {
       expect(munge([
         [Date.UTC(1970, JAN, 1), 0, 40_587, 0]
       ], MODELS.STALL)).toEqual([new Segment(
-        { atomic: new Rat(0n), unix: new Rat(0n) },
+        { atomic: Rat.fromMillis(0), unix: Rat.fromMillis(0) },
         { atomic: Infinity },
         new Rat(1n)
       )])
@@ -406,7 +406,7 @@ describe('munge', () => {
       expect(munge([
         [Date.UTC(1970, JAN, 1), 0, 40_587, -8.640_0]
       ], MODELS.STALL)).toEqual([new Segment(
-        { atomic: new Rat(0n), unix: new Rat(0n) },
+        { atomic: Rat.fromMillis(0), unix: Rat.fromMillis(0) },
         { atomic: Infinity },
         new Rat(10_000n, 9_999n)
       )])
@@ -416,7 +416,7 @@ describe('munge', () => {
       expect(munge([
         [Date.UTC(1970, JAN, 1), 0, 40_587, -86_400 + 8.640_0]
       ], MODELS.STALL)).toEqual([new Segment(
-        { atomic: new Rat(0n), unix: new Rat(0n) },
+        { atomic: Rat.fromMillis(0), unix: Rat.fromMillis(0) },
         { atomic: Infinity },
         new Rat(10_000n)
       )])
@@ -429,7 +429,7 @@ describe('munge', () => {
       expect(munge([
         [Date.UTC(1970, JAN, 1), 0, 40_587, -86_400 - 8.640_0]
       ], MODELS.STALL)).toEqual([new Segment(
-        { atomic: new Rat(0n), unix: new Rat(0n) },
+        { atomic: Rat.fromMillis(0), unix: Rat.fromMillis(0) },
         { atomic: Infinity },
         new Rat(-10_000n)
       )])
@@ -643,7 +643,7 @@ describe('munge', () => {
       expect(munge([
         [Date.UTC(1970, JAN, 1), 0]
       ], MODELS.SMEAR)).toEqual([new Segment(
-        { atomic: new Rat(0n), unix: new Rat(0n) },
+        { atomic: Rat.fromMillis(0), unix: Rat.fromMillis(0) },
         { atomic: Infinity },
         new Rat(1n)
       )])
@@ -654,7 +654,7 @@ describe('munge', () => {
         [0, 0],
         [86_400_000, 1] // inserted leap second after one day
       ], MODELS.SMEAR)).toEqual([new Segment(
-        { atomic: new Rat(0n), unix: new Rat(0n) },
+        { atomic: Rat.fromMillis(0), unix: Rat.fromMillis(0) },
         { atomic: new Rat(43_200n) }, // midday
         new Rat(1n) // perfectly diagonal
       ), new Segment(
@@ -673,7 +673,7 @@ describe('munge', () => {
         [0, 0],
         [86_400_000, -1] // removed leap second after one day
       ], MODELS.SMEAR)).toEqual([new Segment(
-        { atomic: new Rat(0n), unix: new Rat(0n) },
+        { atomic: Rat.fromMillis(0), unix: Rat.fromMillis(0) },
         { atomic: new Rat(43_200n) }, // midday
         new Rat(1n) // perfectly diagonal
       ), new Segment(

--- a/src/rat.js
+++ b/src/rat.js
@@ -58,4 +58,12 @@ class Rat {
   }
 }
 
+Rat.fromMillis = millis => {
+  if (!Number.isInteger(millis)) {
+    throw Error(`Not an integer: ${millis}`)
+  }
+
+  return new Rat(BigInt(millis), 1_000n)
+}
+
 module.exports.Rat = Rat

--- a/src/rat.js
+++ b/src/rat.js
@@ -12,12 +12,12 @@ class Rat {
       throw Error('Denominator must be non-zero')
     }
 
-    const g = gcd(nu, de)
-    this.nu = nu / g
-    this.de = de / g
+    const g = gcd(nu, de) // non-zero
 
-    // `this.de` is always positive
-    // which means the sign of `this.nu` is the sign of the represented rational
+    const g2 = (de < 0) === (g < 0) ? g : -g // has the same sign as `de`
+
+    this.de = de / g2 // positive
+    this.nu = nu / g2 // sign of `this.nu` is the sign of the represented rational
   }
 
   plus (other) {
@@ -52,6 +52,7 @@ class Rat {
     return this.minus(other).nu > 0n
   }
 
+  // Truncate the fraction towards negative infinity
   trunc () {
     return div(this.nu, this.de)
   }

--- a/src/rat.js
+++ b/src/rat.js
@@ -14,7 +14,10 @@ class Rat {
 
     const g = gcd(nu, de)
     this.nu = nu / g
-    this.de = de / g // `this.de` is always positive
+    this.de = de / g
+
+    // `this.de` is always positive
+    // which means the sign of `this.nu` is the sign of the represented rational
   }
 
   plus (other) {
@@ -33,25 +36,20 @@ class Rat {
     return this.times(new Rat(other.de, other.nu))
   }
 
-  cmp (other) {
-    // It's always safe to do this as `de` is always positive
-    return this.nu * other.de - this.de * other.nu
-  }
-
   eq (other) {
-    return this.cmp(other) === 0n
+    return this.minus(other).nu === 0n
   }
 
   lt (other) {
-    return this.cmp(other) < 0n
+    return this.minus(other).nu < 0n
   }
 
   le (other) {
-    return this.cmp(other) <= 0n
+    return this.minus(other).nu <= 0n
   }
 
   gt (other) {
-    return this.cmp(other) > 0n
+    return this.minus(other).nu > 0n
   }
 
   trunc () {

--- a/src/rat.js
+++ b/src/rat.js
@@ -56,6 +56,10 @@ class Rat {
   trunc () {
     return div(this.nu, this.de)
   }
+
+  toMillis () {
+    return Number(this.times(new Rat(1_000n)).trunc())
+  }
 }
 
 Rat.fromMillis = millis => {

--- a/src/segment.js
+++ b/src/segment.js
@@ -1,6 +1,6 @@
 const { Rat } = require('./rat')
 
-// A segment is a closed linear relationship between TAI and Unix time.
+// A segment is a closed-open linear relationship between TAI and Unix time.
 // It should be able to handle arbitrary ratios between the two.
 // For precision, we deal with ratios of BigInts.
 // Segment validity ranges are inclusive-exclusive.
@@ -36,7 +36,7 @@ class Segment {
       return {
         start: this.start.atomic,
         end: this.end.atomic,
-        closed: false
+        open: true
       }
     }
 
@@ -47,8 +47,7 @@ class Segment {
 
     return {
       start: atomic,
-      end: atomic,
-      closed: true
+      end: atomic
     }
   }
 

--- a/src/segment.spec.js
+++ b/src/segment.spec.js
@@ -8,7 +8,7 @@ const MAY = 4
 describe('Segment', () => {
   it('disallows rays which run backwards', () => {
     expect(() => new Segment(
-      { atomic: new Rat(0n), unix: new Rat(0n) },
+      { atomic: Rat.fromMillis(0), unix: Rat.fromMillis(0) },
       { atomic: new Rat(-1n, 1_000_000_000_000n) },
       new Rat(1n)
     )).toThrowError('Segment length must be positive')
@@ -16,25 +16,25 @@ describe('Segment', () => {
 
   it('disallows zero-length rays which run backwards', () => {
     expect(() => new Segment(
-      { atomic: new Rat(0n), unix: new Rat(0n) },
-      { atomic: new Rat(0n) },
+      { atomic: Rat.fromMillis(0), unix: Rat.fromMillis(0) },
+      { atomic: Rat.fromMillis(0) },
       new Rat(1n)
     )).toThrowError('Segment length must be positive')
   })
 
   describe('basic infinite ray', () => {
     const segment = new Segment(
-      { atomic: new Rat(0n), unix: new Rat(0n) },
+      { atomic: Rat.fromMillis(0), unix: Rat.fromMillis(0) },
       { atomic: Infinity },
       new Rat(1n)
     )
 
     it('zero point', () => {
-      expect(segment.unixOnSegment(new Rat(0n))).toBe(true)
-      expect(segment.unixToAtomicRange(new Rat(0n)))
-        .toEqual({ start: new Rat(0n), end: new Rat(0n) })
-      expect(segment.atomicOnSegment(new Rat(0n))).toBe(true)
-      expect(segment.atomicToUnix(new Rat(0n))).toEqual(new Rat(0n))
+      expect(segment.unixOnSegment(Rat.fromMillis(0))).toBe(true)
+      expect(segment.unixToAtomicRange(Rat.fromMillis(0)))
+        .toEqual({ start: Rat.fromMillis(0), end: Rat.fromMillis(0) })
+      expect(segment.atomicOnSegment(Rat.fromMillis(0))).toBe(true)
+      expect(segment.atomicToUnix(Rat.fromMillis(0))).toEqual(Rat.fromMillis(0))
     })
 
     it('modern day', () => {
@@ -50,82 +50,82 @@ describe('Segment', () => {
     })
 
     it('before start point', () => {
-      expect(segment.unixOnSegment(new Rat(-1n, 1_000n))).toBe(false)
-      expect(segment.unixToAtomicRange(new Rat(-1n, 1_000n)))
-        .toEqual({ start: new Rat(-1n, 1_000n), end: new Rat(-1n, 1_000n) })
-      expect(segment.atomicOnSegment(new Rat(-1n, 1_000n))).toBe(false)
-      expect(segment.atomicToUnix(new Rat(-1n, 1_000n))).toEqual(new Rat(-1n, 1_000n))
+      expect(segment.unixOnSegment(Rat.fromMillis(-1))).toBe(false)
+      expect(segment.unixToAtomicRange(Rat.fromMillis(-1)))
+        .toEqual({ start: Rat.fromMillis(-1), end: Rat.fromMillis(-1) })
+      expect(segment.atomicOnSegment(Rat.fromMillis(-1))).toBe(false)
+      expect(segment.atomicToUnix(Rat.fromMillis(-1))).toEqual(Rat.fromMillis(-1))
     })
   })
 
   describe('sloped, finite ray', () => {
     const segment = new Segment(
-      { atomic: new Rat(0n), unix: new Rat(0n) },
-      { atomic: new Rat(2n) }, // 2 TAI seconds
+      { atomic: Rat.fromMillis(0), unix: Rat.fromMillis(0) },
+      { atomic: Rat.fromMillis(2_000n) }, // 2 TAI seconds
       new Rat(1n, 2n) // TAI runs twice as fast as Unix time
     )
 
     it('zero point', () => {
-      expect(segment.unixOnSegment(new Rat(0n))).toBe(true)
-      expect(segment.unixToAtomicRange(new Rat(0n)))
-        .toEqual({ start: new Rat(0n), end: new Rat(0n) })
-      expect(segment.atomicOnSegment(new Rat(0n))).toBe(true)
-      expect(segment.atomicToUnix(new Rat(0n))).toEqual(new Rat(0n))
+      expect(segment.unixOnSegment(Rat.fromMillis(0))).toBe(true)
+      expect(segment.unixToAtomicRange(Rat.fromMillis(0)))
+        .toEqual({ start: Rat.fromMillis(0), end: Rat.fromMillis(0) })
+      expect(segment.atomicOnSegment(Rat.fromMillis(0))).toBe(true)
+      expect(segment.atomicToUnix(Rat.fromMillis(0))).toEqual(Rat.fromMillis(0))
     })
 
     it('a little later', () => {
-      expect(segment.unixOnSegment(new Rat(501n, 1_000n))).toBe(true)
-      expect(segment.unixToAtomicRange(new Rat(501n, 1_000n)))
-        .toEqual({ start: new Rat(1_002n, 1_000n), end: new Rat(1_002n, 1_000n) })
-      expect(segment.atomicOnSegment(new Rat(1_002n, 1_000n))).toBe(true)
-      expect(segment.atomicToUnix(new Rat(1_002n, 1_000n))).toEqual(new Rat(501n, 1_000n))
+      expect(segment.unixOnSegment(Rat.fromMillis(501))).toBe(true)
+      expect(segment.unixToAtomicRange(Rat.fromMillis(501)))
+        .toEqual({ start: Rat.fromMillis(1_002), end: Rat.fromMillis(1_002) })
+      expect(segment.atomicOnSegment(Rat.fromMillis(1_002))).toBe(true)
+      expect(segment.atomicToUnix(Rat.fromMillis(1_002))).toEqual(Rat.fromMillis(501))
     })
 
     it('right before end point', () => {
-      expect(segment.unixOnSegment(new Rat(999n, 1_000n))).toBe(true)
-      expect(segment.unixToAtomicRange(new Rat(999n, 1_000n)))
-        .toEqual({ start: new Rat(1_998n, 1_000n), end: new Rat(1_998n, 1_000n) })
+      expect(segment.unixOnSegment(Rat.fromMillis(999))).toBe(true)
+      expect(segment.unixToAtomicRange(Rat.fromMillis(999)))
+        .toEqual({ start: Rat.fromMillis(1_998), end: Rat.fromMillis(1_998) })
 
-      expect(segment.atomicOnSegment(new Rat(1_998n, 1_000n))).toBe(true)
-      expect(segment.atomicToUnix(new Rat(1_998n, 1_000n))).toEqual(new Rat(999n, 1_000n))
-      expect(segment.atomicOnSegment(new Rat(1_999n, 1_000n))).toBe(true)
-      expect(segment.atomicToUnix(new Rat(1_999n, 1_000n))).toEqual(new Rat(1_999n, 2_000n)) // truncates to 999ms
+      expect(segment.atomicOnSegment(Rat.fromMillis(1_998))).toBe(true)
+      expect(segment.atomicToUnix(Rat.fromMillis(1_998))).toEqual(Rat.fromMillis(999))
+      expect(segment.atomicOnSegment(Rat.fromMillis(1_999))).toBe(true)
+      expect(segment.atomicToUnix(Rat.fromMillis(1_999))).toEqual(new Rat(1_999n, 2_000n)) // truncates to 999ms
     })
 
     it('end point', () => {
-      expect(segment.unixOnSegment(new Rat(1n))).toBe(false)
-      expect(segment.unixToAtomicRange(new Rat(1n)))
-        .toEqual({ start: new Rat(2_000n, 1_000n), end: new Rat(2_000n, 1_000n) })
-      expect(segment.atomicOnSegment(new Rat(2n))).toBe(false)
-      expect(segment.atomicToUnix(new Rat(2n))).toEqual(new Rat(1n))
+      expect(segment.unixOnSegment(Rat.fromMillis(1_000n))).toBe(false)
+      expect(segment.unixToAtomicRange(Rat.fromMillis(1_000n)))
+        .toEqual({ start: Rat.fromMillis(2_000), end: Rat.fromMillis(2_000) })
+      expect(segment.atomicOnSegment(Rat.fromMillis(2_000n))).toBe(false)
+      expect(segment.atomicToUnix(Rat.fromMillis(2_000n))).toEqual(Rat.fromMillis(1_000n))
     })
   })
 
   describe('horizontal ray', () => {
     const segment = new Segment(
-      { atomic: new Rat(0n), unix: new Rat(0n) },
-      { atomic: new Rat(2n) }, // 2 TAI seconds
+      { atomic: Rat.fromMillis(0), unix: Rat.fromMillis(0) },
+      { atomic: Rat.fromMillis(2_000n) }, // 2 TAI seconds
       new Rat(0n)
     )
 
     it('zero point', () => {
-      expect(segment.unixOnSegment(new Rat(0n))).toBe(true)
-      expect(segment.unixToAtomicRange(new Rat(0n)))
-        .toEqual({ start: new Rat(0n), end: new Rat(2_000n, 1_000n), open: true })
-      expect(segment.atomicOnSegment(new Rat(0n))).toBe(true)
-      expect(segment.atomicToUnix(new Rat(0n))).toEqual(new Rat(0n))
+      expect(segment.unixOnSegment(Rat.fromMillis(0))).toBe(true)
+      expect(segment.unixToAtomicRange(Rat.fromMillis(0)))
+        .toEqual({ start: Rat.fromMillis(0), end: Rat.fromMillis(2_000), open: true })
+      expect(segment.atomicOnSegment(Rat.fromMillis(0))).toBe(true)
+      expect(segment.atomicToUnix(Rat.fromMillis(0))).toEqual(Rat.fromMillis(0))
     })
 
     it('later in TAI', () => {
-      expect(segment.atomicOnSegment(new Rat(1_999n, 1_000n))).toBe(true)
-      expect(segment.atomicToUnix(new Rat(1_999n, 1_000n))).toEqual(new Rat(0n))
-      expect(segment.atomicOnSegment(new Rat(2_000n, 1_000n))).toBe(false)
-      expect(segment.atomicToUnix(new Rat(2_000n, 1_000n))).toEqual(new Rat(0n))
+      expect(segment.atomicOnSegment(Rat.fromMillis(1_999))).toBe(true)
+      expect(segment.atomicToUnix(Rat.fromMillis(1_999))).toEqual(Rat.fromMillis(0))
+      expect(segment.atomicOnSegment(Rat.fromMillis(2_000))).toBe(false)
+      expect(segment.atomicToUnix(Rat.fromMillis(2_000))).toEqual(Rat.fromMillis(0))
     })
 
     it('later in Unix time', () => {
-      expect(segment.unixOnSegment(new Rat(1n))).toBe(false)
-      expect(() => segment.unixToAtomicRange(new Rat(-1n, 1_000n)))
+      expect(segment.unixOnSegment(Rat.fromMillis(1_000n))).toBe(false)
+      expect(() => segment.unixToAtomicRange(Rat.fromMillis(-1)))
         .toThrowError('This Unix time never happened')
     })
   })

--- a/src/segment.spec.js
+++ b/src/segment.spec.js
@@ -33,7 +33,7 @@ describe('Segment', () => {
     it('zero point', () => {
       expect(segment.unixOnSegment(new Rat(0n))).toBe(true)
       expect(segment.unixToAtomicRange(new Rat(0n)))
-        .toEqual({ start: new Rat(0n), end: new Rat(0n), closed: true })
+        .toEqual({ start: new Rat(0n), end: new Rat(0n) })
       expect(segment.atomicOnSegment(new Rat(0n))).toBe(true)
       expect(segment.atomicToUnix(new Rat(0n))).toEqual(new Rat(0n))
     })
@@ -43,8 +43,7 @@ describe('Segment', () => {
       expect(segment.unixToAtomicRange(millisToExact(Date.UTC(2021, MAY, 16, 12, 11, 10, 9))))
         .toEqual({
           start: millisToExact(Date.UTC(2021, MAY, 16, 12, 11, 10, 9)),
-          end: millisToExact(Date.UTC(2021, MAY, 16, 12, 11, 10, 9)),
-          closed: true
+          end: millisToExact(Date.UTC(2021, MAY, 16, 12, 11, 10, 9))
         })
       expect(segment.atomicOnSegment(millisToExact(Date.UTC(2021, MAY, 16, 12, 11, 10, 9)))).toBe(true)
       expect(segment.atomicToUnix(millisToExact(Date.UTC(2021, MAY, 16, 12, 11, 10, 9))))
@@ -54,7 +53,7 @@ describe('Segment', () => {
     it('before start point', () => {
       expect(segment.unixOnSegment(new Rat(-1n, 1_000n))).toBe(false)
       expect(segment.unixToAtomicRange(new Rat(-1n, 1_000n)))
-        .toEqual({ start: new Rat(-1n, 1_000n), end: new Rat(-1n, 1_000n), closed: true })
+        .toEqual({ start: new Rat(-1n, 1_000n), end: new Rat(-1n, 1_000n) })
       expect(segment.atomicOnSegment(new Rat(-1n, 1_000n))).toBe(false)
       expect(segment.atomicToUnix(new Rat(-1n, 1_000n))).toEqual(new Rat(-1n, 1_000n))
     })
@@ -70,7 +69,7 @@ describe('Segment', () => {
     it('zero point', () => {
       expect(segment.unixOnSegment(new Rat(0n))).toBe(true)
       expect(segment.unixToAtomicRange(new Rat(0n)))
-        .toEqual({ start: new Rat(0n), end: new Rat(0n), closed: true })
+        .toEqual({ start: new Rat(0n), end: new Rat(0n) })
       expect(segment.atomicOnSegment(new Rat(0n))).toBe(true)
       expect(segment.atomicToUnix(new Rat(0n))).toEqual(new Rat(0n))
     })
@@ -78,7 +77,7 @@ describe('Segment', () => {
     it('a little later', () => {
       expect(segment.unixOnSegment(new Rat(501n, 1_000n))).toBe(true)
       expect(segment.unixToAtomicRange(new Rat(501n, 1_000n)))
-        .toEqual({ start: new Rat(1_002n, 1_000n), end: new Rat(1_002n, 1_000n), closed: true })
+        .toEqual({ start: new Rat(1_002n, 1_000n), end: new Rat(1_002n, 1_000n) })
       expect(segment.atomicOnSegment(new Rat(1_002n, 1_000n))).toBe(true)
       expect(segment.atomicToUnix(new Rat(1_002n, 1_000n))).toEqual(new Rat(501n, 1_000n))
     })
@@ -86,7 +85,7 @@ describe('Segment', () => {
     it('right before end point', () => {
       expect(segment.unixOnSegment(new Rat(999n, 1_000n))).toBe(true)
       expect(segment.unixToAtomicRange(new Rat(999n, 1_000n)))
-        .toEqual({ start: new Rat(1_998n, 1_000n), end: new Rat(1_998n, 1_000n), closed: true })
+        .toEqual({ start: new Rat(1_998n, 1_000n), end: new Rat(1_998n, 1_000n) })
 
       expect(segment.atomicOnSegment(new Rat(1_998n, 1_000n))).toBe(true)
       expect(segment.atomicToUnix(new Rat(1_998n, 1_000n))).toEqual(new Rat(999n, 1_000n))
@@ -97,7 +96,7 @@ describe('Segment', () => {
     it('end point', () => {
       expect(segment.unixOnSegment(new Rat(1n))).toBe(false)
       expect(segment.unixToAtomicRange(new Rat(1n)))
-        .toEqual({ start: new Rat(2_000n, 1_000n), end: new Rat(2_000n, 1_000n), closed: true })
+        .toEqual({ start: new Rat(2_000n, 1_000n), end: new Rat(2_000n, 1_000n) })
       expect(segment.atomicOnSegment(new Rat(2n))).toBe(false)
       expect(segment.atomicToUnix(new Rat(2n))).toEqual(new Rat(1n))
     })
@@ -113,7 +112,7 @@ describe('Segment', () => {
     it('zero point', () => {
       expect(segment.unixOnSegment(new Rat(0n))).toBe(true)
       expect(segment.unixToAtomicRange(new Rat(0n)))
-        .toEqual({ start: new Rat(0n), end: new Rat(2_000n, 1_000n), closed: false })
+        .toEqual({ start: new Rat(0n), end: new Rat(2_000n, 1_000n), open: true })
       expect(segment.atomicOnSegment(new Rat(0n))).toBe(true)
       expect(segment.atomicToUnix(new Rat(0n))).toEqual(new Rat(0n))
     })

--- a/src/segment.spec.js
+++ b/src/segment.spec.js
@@ -1,7 +1,6 @@
 /* eslint-env jest */
 
 const { Segment } = require('./segment')
-const { millisToExact } = require('./munge')
 const { Rat } = require('./rat')
 
 const MAY = 4
@@ -39,15 +38,15 @@ describe('Segment', () => {
     })
 
     it('modern day', () => {
-      expect(segment.unixOnSegment(millisToExact(Date.UTC(2021, MAY, 16, 12, 11, 10, 9)))).toBe(true)
-      expect(segment.unixToAtomicRange(millisToExact(Date.UTC(2021, MAY, 16, 12, 11, 10, 9))))
+      expect(segment.unixOnSegment(Rat.fromMillis(Date.UTC(2021, MAY, 16, 12, 11, 10, 9)))).toBe(true)
+      expect(segment.unixToAtomicRange(Rat.fromMillis(Date.UTC(2021, MAY, 16, 12, 11, 10, 9))))
         .toEqual({
-          start: millisToExact(Date.UTC(2021, MAY, 16, 12, 11, 10, 9)),
-          end: millisToExact(Date.UTC(2021, MAY, 16, 12, 11, 10, 9))
+          start: Rat.fromMillis(Date.UTC(2021, MAY, 16, 12, 11, 10, 9)),
+          end: Rat.fromMillis(Date.UTC(2021, MAY, 16, 12, 11, 10, 9))
         })
-      expect(segment.atomicOnSegment(millisToExact(Date.UTC(2021, MAY, 16, 12, 11, 10, 9)))).toBe(true)
-      expect(segment.atomicToUnix(millisToExact(Date.UTC(2021, MAY, 16, 12, 11, 10, 9))))
-        .toEqual(millisToExact(Date.UTC(2021, MAY, 16, 12, 11, 10, 9)))
+      expect(segment.atomicOnSegment(Rat.fromMillis(Date.UTC(2021, MAY, 16, 12, 11, 10, 9)))).toBe(true)
+      expect(segment.atomicToUnix(Rat.fromMillis(Date.UTC(2021, MAY, 16, 12, 11, 10, 9))))
+        .toEqual(Rat.fromMillis(Date.UTC(2021, MAY, 16, 12, 11, 10, 9)))
     })
 
     it('before start point', () => {

--- a/src/segment.spec.js
+++ b/src/segment.spec.js
@@ -61,7 +61,7 @@ describe('Segment', () => {
   describe('sloped, finite ray', () => {
     const segment = new Segment(
       { atomic: Rat.fromMillis(0), unix: Rat.fromMillis(0) },
-      { atomic: Rat.fromMillis(2_000n) }, // 2 TAI seconds
+      { atomic: Rat.fromMillis(2_000) }, // 2 TAI seconds
       new Rat(1n, 2n) // TAI runs twice as fast as Unix time
     )
 
@@ -93,18 +93,18 @@ describe('Segment', () => {
     })
 
     it('end point', () => {
-      expect(segment.unixOnSegment(Rat.fromMillis(1_000n))).toBe(false)
-      expect(segment.unixToAtomicRange(Rat.fromMillis(1_000n)))
+      expect(segment.unixOnSegment(Rat.fromMillis(1_000))).toBe(false)
+      expect(segment.unixToAtomicRange(Rat.fromMillis(1_000)))
         .toEqual({ start: Rat.fromMillis(2_000), end: Rat.fromMillis(2_000) })
-      expect(segment.atomicOnSegment(Rat.fromMillis(2_000n))).toBe(false)
-      expect(segment.atomicToUnix(Rat.fromMillis(2_000n))).toEqual(Rat.fromMillis(1_000n))
+      expect(segment.atomicOnSegment(Rat.fromMillis(2_000))).toBe(false)
+      expect(segment.atomicToUnix(Rat.fromMillis(2_000))).toEqual(Rat.fromMillis(1_000))
     })
   })
 
   describe('horizontal ray', () => {
     const segment = new Segment(
       { atomic: Rat.fromMillis(0), unix: Rat.fromMillis(0) },
-      { atomic: Rat.fromMillis(2_000n) }, // 2 TAI seconds
+      { atomic: Rat.fromMillis(2_000) }, // 2 TAI seconds
       new Rat(0n)
     )
 
@@ -124,7 +124,7 @@ describe('Segment', () => {
     })
 
     it('later in Unix time', () => {
-      expect(segment.unixOnSegment(Rat.fromMillis(1_000n))).toBe(false)
+      expect(segment.unixOnSegment(Rat.fromMillis(1_000))).toBe(false)
       expect(() => segment.unixToAtomicRange(Rat.fromMillis(-1)))
         .toThrowError('This Unix time never happened')
     })

--- a/src/tai-data.js
+++ b/src/tai-data.js
@@ -2,6 +2,8 @@
 // <http://hpiers.obspm.fr/eop-pc/earthor/utc/TAI-UTC_tab.html>
 // <ftp://maia.usno.navy.mil/ser7/tai-utc.dat>
 
+const { millisToExact } = require('./munge.js')
+
 const JAN = 0
 const FEB = 1
 const MAR = 2
@@ -61,11 +63,18 @@ const taiData = [
   [Date.UTC(2017, JAN, 1), 37]
 ]
 
-module.exports.taiData = taiData
-module.exports.UNIX_START = taiData[0][0]
+const UNIX_START_MILLIS = taiData[0][0]
+const UNIX_START = millisToExact(UNIX_START_MILLIS)
 
 // Because we don't know whether or not a leap second will be inserted or removed at this time,
 // the relationship between Unix time and TAI is unpredictable at or beyond this point.
 // (This is the start of a possible smear.)
 // Updating this value? Don't forget to update the README too!
-module.exports.UNIX_END = Date.UTC(2022, DEC, 31, 12, 0, 0, 0)
+const UNIX_END_MILLIS = Date.UTC(2022, DEC, 31, 12, 0, 0, 0)
+const UNIX_END = millisToExact(UNIX_END_MILLIS)
+
+module.exports.taiData = taiData
+module.exports.UNIX_START_MILLIS = UNIX_START_MILLIS
+module.exports.UNIX_START = UNIX_START
+module.exports.UNIX_END_MILLIS = UNIX_END_MILLIS
+module.exports.UNIX_END = UNIX_END

--- a/src/tai-data.js
+++ b/src/tai-data.js
@@ -2,7 +2,7 @@
 // <http://hpiers.obspm.fr/eop-pc/earthor/utc/TAI-UTC_tab.html>
 // <ftp://maia.usno.navy.mil/ser7/tai-utc.dat>
 
-const { millisToExact } = require('./munge.js')
+const { Rat } = require('./rat.js')
 
 const JAN = 0
 const FEB = 1
@@ -64,14 +64,14 @@ const taiData = [
 ]
 
 const UNIX_START_MILLIS = taiData[0][0]
-const UNIX_START = millisToExact(UNIX_START_MILLIS)
+const UNIX_START = Rat.fromMillis(UNIX_START_MILLIS)
 
 // Because we don't know whether or not a leap second will be inserted or removed at this time,
 // the relationship between Unix time and TAI is unpredictable at or beyond this point.
 // (This is the start of a possible smear.)
 // Updating this value? Don't forget to update the README too!
 const UNIX_END_MILLIS = Date.UTC(2022, DEC, 31, 12, 0, 0, 0)
-const UNIX_END = millisToExact(UNIX_END_MILLIS)
+const UNIX_END = Rat.fromMillis(UNIX_END_MILLIS)
 
 module.exports.taiData = taiData
 module.exports.UNIX_START_MILLIS = UNIX_START_MILLIS


### PR DESCRIPTION
* `Converter`'s methods `unixToAtomic` and `atomicToUnix` are renamed to `unixMillisToAtomicMillis` and `atomicMillisToUnixMillis` respectively. New methods `unixToAtomic` and `atomicToUnix` are introduced; these perform exact calculations on `Rat`s. `unixMillisToAtomicMillis` and `atomicMillisToUnixMillis` now call out to these.
  * Methods are renamed back in `index.js`.
* Open/closed ranges are now handled a little differently internally. We now flag `open: true` or just omit that flag entirely.
* Massively overhaul `Converter`'s unit tests to test the new `unixToAtomic` and `atomicToUnix` methods, and to be much more exhaustive testing time conversions around points of interest.
* `gcd`'s behaviour is no longer to always return a GCD with the same sign as `b`. It's now `Rat`'s job to do that sign conversion.
* Function `millisToExact` is now `Rat.fromMillis`, a static method.
* `exactToMillis` is now `Rat.prototype.toMillis`.
* Behaviour of `munge` has been modified slightly to account for the possibility of zero-length segments *between* two smears, specifically between two stalls.
* Stop using `Rat.prototype.cmp` and eliminate it. Just subtract. The "numerator sign is authoritative" property makes this much easier.
* `tai-data.js`'s exports `UNIX_START` and `UNIX_END` are been renamed to `UNIX_START_MILLIS` and `UNIX_END_MILLIS` respectively. New exports `UNIX_START` and `UNIX_END` are introduced; these are `Rat`s.
  * These constants are renamed back in `index.js`.

Future work:

* Probably move all of these "exact" APIs off into a separate silo you can import using `require('t-a-i/exact')`
* Rename `Rat` to `Exact`? Not all existing `Rat`s represent instants in time, though. I need to think about this a little.
* Think more about this new API...
* What about ES modules?