### PR TITLE
Version 4

### DIFF
--- a/.github/workflows/workflow-1.yml
+++ b/.github/workflows/workflow-1.yml
@@ -11,7 +11,7 @@ jobs:
 
     strategy:
       matrix:
-        node-version: ['14.x', '16.x', '18.x']
+        node-version: ['16.x', '18.x', '20.x']
 
     steps:
     - uses: 'actions/checkout@v2'

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,9 +1,9 @@
 # CHANGELOG
 
-## Forthcoming changes in 4.0.0, expected May 2023
+## 4.0.0
 
-* `t-a-i` will drop support for Node.js 14.
-* `t-a-i` will switch over from providing [CommonJS modules](https://nodejs.org/docs/latest/api/modules.html) (which use `require` and `module.exports`) to using [ECMAScript modules](https://nodejs.org/docs/latest/api/esm.html) (which use `import` and `export`).
+* `t-a-i` has dropped support for Node.js 14.
+* `t-a-i` is now provided as [ECMAScript modules](https://nodejs.org/docs/latest/api/esm.html) (which use `import` and `export`), not [CommonJS modules](https://nodejs.org/docs/latest/api/modules.html) (which use `require` and `module.exports`).
 
 ## 3.0.x
 

--- a/README.md
+++ b/README.md
@@ -67,7 +67,7 @@ None these proposed/implied models are perfect; each has its own disadvantages, 
 Exactly how long was 1972?
 
 ```javascript
-const { TaiConverter, MODELS } = require('t-a-i')
+import { TaiConverter, MODELS } from 't-a-i'
 
 const unixStart = Date.UTC(1972, 0, 1) // 63_072_000_000
 const unixEnd   = Date.UTC(1973, 0, 1) // 94_694_400_000
@@ -134,7 +134,7 @@ Instead, consider using a [`TaiDate`](https://github.com/ferno/tai-date)!
 
 ```js
 // do this instead
-const TaiDate = require('tai-date')
+import { TaiDate } from 'tai-date'
 const taiDate = new TaiDate(taiConverter.unixToAtomic(unixDate.getTime())
 ```
 
@@ -211,7 +211,7 @@ When Unix time is removed,
 With the `OVERRUN` model, you can do `taiConverter.unixToAtomic(unix, { array: true })` to receive an array of TAI millisecond counts. Normally this array has a single entry. If the input Unix millisecond count is prior to the beginning of TAI, or was removed, an empty array `[]` is returned. During inserted time, an array containing two entries is returned.
 
 ```javascript
-const { TaiConverter, MODELS } = require('t-a-i')
+import { TaiConverter, MODELS } from 't-a-i'
 
 const taiConverter = TaiConverter(MODELS.OVERRUN)
 
@@ -230,7 +230,7 @@ taiConverter.unixToAtomic(unix, { array: true })
 With the `STALL` model, you can do `taiConverter.unixToAtomic(unix, { range: true })` to receive a closed range `[first, last]` of TAI millisecond counts. Normally `first` and `last` will be equal. If the input Unix millisecond count is prior to the beginning of TAI, or was removed, `[NaN, NaN]` is returned. During inserted time, Unix time stalls; if the input Unix millisecond count is precisely the value at which Unix time stalled, the array's entries indicate the first and last TAI millisecond counts in the stall.
 
 ```javascript
-const { TaiConverter, MODELS } = require('t-a-i')
+import { TaiConverter, MODELS } from 't-a-i'
 
 const taiConverter = TaiConverter(MODELS.STALL)
 

--- a/docs/index.html
+++ b/docs/index.html
@@ -1,1 +1,0 @@
-hello world

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "t-a-i",
-  "version": "3.0.7",
+  "version": "4.0.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "t-a-i",
-      "version": "3.0.7",
+      "version": "4.0.0",
       "license": "MIT",
       "devDependencies": {
         "c8": "^7.13.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "t-a-i",
-  "version": "3.0.7",
+  "version": "4.0.0",
   "description": "Converts Unix milliseconds to and from International Atomic Time (TAI) milliseconds",
   "homepage": "https://github.com/qntm/t-a-i",
   "repository": {
@@ -8,6 +8,7 @@
     "url": "git://github.com/qntm/t-a-i.git"
   },
   "main": "./src",
+  "type": "module",
   "scripts": {
     "mocha": "c8 --100 mocha",
     "standard": "standard",

--- a/src/converter.js
+++ b/src/converter.js
@@ -10,10 +10,10 @@
 // map to multiple TAI times. We can return an array of these, or just the result from the latest
 // segment (according to its numbering).
 
-const { munge } = require('./munge.js')
-const { Range } = require('./range.js')
+import { munge } from './munge.js'
+import { Range } from './range.js'
 
-module.exports.Converter = class {
+export class Converter {
   constructor (data, model) {
     this.segments = munge(data, model)
   }

--- a/src/div.js
+++ b/src/div.js
@@ -1,9 +1,9 @@
 // Divide two BigInts and round the result towards negative infinity
 
 // Why doesn't JavaScript have this?
-const sign = a => a > 0n ? 1n : a === 0n ? 0n : -1n
+export const sign = a => a > 0n ? 1n : a === 0n ? 0n : -1n
 
-const div = (a, b) => {
+export const div = (a, b) => {
   const q = a / b
 
   // `b` must be non-zero or we would have thrown an exception by now
@@ -24,13 +24,9 @@ const div = (a, b) => {
   return q - 1n
 }
 
-const gcd = (a, b) => {
+export const gcd = (a, b) => {
   while (b !== 0n) {
     [a, b] = [b, a % b]
   }
   return a
 }
-
-module.exports.sign = sign
-module.exports.div = div
-module.exports.gcd = gcd

--- a/src/exact.js
+++ b/src/exact.js
@@ -1,10 +1,10 @@
-const { taiData, UNIX_START_MILLIS, UNIX_END_MILLIS } = require('./tai-data.js')
-const { MODELS } = require('./munge.js')
-const { Converter } = require('./converter.js')
-const { Second } = require('./second.js')
+import { taiData, UNIX_START_MILLIS, UNIX_END_MILLIS } from './tai-data.js'
+import { Converter } from './converter.js'
+import { Second } from './second.js'
 
-module.exports.UNIX_START = Second.fromMillis(UNIX_START_MILLIS)
-module.exports.UNIX_END = Second.fromMillis(UNIX_END_MILLIS)
-module.exports.MODELS = MODELS
-module.exports.TaiConverter = model => new Converter(taiData, model)
-module.exports.Second = Second
+export { MODELS } from './munge.js'
+export { Second }
+
+export const UNIX_START = Second.fromMillis(UNIX_START_MILLIS)
+export const UNIX_END = Second.fromMillis(UNIX_END_MILLIS)
+export const TaiConverter = model => new Converter(taiData, model)

--- a/src/index.js
+++ b/src/index.js
@@ -1,8 +1,8 @@
-const { taiData, UNIX_START_MILLIS, UNIX_END_MILLIS } = require('./tai-data.js')
-const { MODELS } = require('./munge.js')
-const { MillisConverter } = require('./millis-converter.js')
+import { taiData, UNIX_START_MILLIS, UNIX_END_MILLIS } from './tai-data.js'
+import { MillisConverter } from './millis-converter.js'
 
-module.exports.UNIX_START = UNIX_START_MILLIS
-module.exports.UNIX_END = UNIX_END_MILLIS
-module.exports.MODELS = MODELS
-module.exports.TaiConverter = model => new MillisConverter(taiData, model)
+export { MODELS } from './munge.js'
+
+export const UNIX_START = UNIX_START_MILLIS
+export const UNIX_END = UNIX_END_MILLIS
+export const TaiConverter = model => new MillisConverter(taiData, model)

--- a/src/millis-converter.js
+++ b/src/millis-converter.js
@@ -1,8 +1,8 @@
-const { Second } = require('./second.js')
-const { Converter } = require('./converter.js')
+import { Second } from './second.js'
+import { Converter } from './converter.js'
 
 // Do not subclass `Converter` as we do not expose the same interface
-module.exports.MillisConverter = class {
+export class MillisConverter {
   constructor (data, model) {
     this.converter = new Converter(data, model)
   }

--- a/src/munge.js
+++ b/src/munge.js
@@ -1,12 +1,12 @@
 // So what do we ACTUALLY need from our data?
 
-const { Rat } = require('./rat.js')
-const { Second } = require('./second.js')
-const { Segment } = require('./segment.js')
+import { Rat } from './rat.js'
+import { Second } from './second.js'
+import { Segment } from './segment.js'
 
 // In all models, TAI to Unix conversions are one-to-one (or one-to-NaN). At any given instant in
 // TAI, at most one segment applies and at most one Unix time corresponds.
-const MODELS = {
+export const MODELS = {
   // Each segment continues until it reaches the TAI start of the next segment, even if that start
   // point is in the past (Unix time) due to inserted time and the result is a backtrack. Unix to
   // TAI conversions are potentially one-to-many but the many are discrete instants in time.
@@ -43,7 +43,7 @@ const mjdEpoch = {
 // purposes: start point is expressed both in Unix milliseconds and TAI picoseconds, ratio between
 // TAI picoseconds and UTC milliseconds is given as a precise BigInt, and the root is moved to the
 // Unix epoch
-const munge = (data, model) => {
+export const munge = (data, model) => {
   const munged = data.map(datum => {
     const start = {}
     const offsetAtRoot = {}
@@ -203,6 +203,3 @@ const munge = (data, model) => {
     datum.slope
   ))
 }
-
-module.exports.MODELS = MODELS
-module.exports.munge = munge

--- a/src/range.js
+++ b/src/range.js
@@ -1,4 +1,4 @@
-module.exports.Range = class {
+export class Range {
   constructor (start, end = start, open = false) {
     this.start = start
     this.end = end

--- a/src/rat.js
+++ b/src/rat.js
@@ -1,6 +1,6 @@
-const { div, gcd } = require('./div')
+import { div, gcd } from './div.js'
 
-class Rat {
+export class Rat {
   constructor (nu, de = 1n) {
     if (typeof nu !== 'bigint') {
       throw Error('Numerator must be a BigInt')
@@ -58,5 +58,3 @@ class Rat {
 }
 
 Rat.INFINITY = new Rat(1n, 0n)
-
-module.exports.Rat = Rat

--- a/src/second.js
+++ b/src/second.js
@@ -1,6 +1,6 @@
-const { Rat } = require('./rat.js')
+import { Rat } from './rat.js'
 
-class Second {
+export class Second {
   constructor (nu, de) {
     this.rat = new Rat(nu, de)
   }
@@ -58,5 +58,3 @@ Second.fromMillis = millis => {
 // a correct, meaningful result, or throws an exception - it does NOT return
 // bad results.
 Second.END_OF_TIME = new Second(1n, 0n)
-
-module.exports.Second = Second

--- a/src/segment.js
+++ b/src/segment.js
@@ -1,12 +1,12 @@
-const { Rat } = require('./rat.js')
-const { Range } = require('./range.js')
-const { Second } = require('./second.js')
+import { Rat } from './rat.js'
+import { Range } from './range.js'
+import { Second } from './second.js'
 
 // A segment is a closed-open linear relationship between TAI and Unix time.
 // It should be able to handle arbitrary ratios between the two.
 // For precision, we deal with ratios of BigInts.
 // Segment validity ranges are inclusive-exclusive.
-class Segment {
+export class Segment {
   constructor (start, end = { atomic: Second.END_OF_TIME }, slope = { unixPerAtomic: new Rat(1n) }) {
     if (!(start.atomic instanceof Second)) {
       throw Error('TAI start must be a rational number of seconds')
@@ -80,5 +80,3 @@ class Segment {
       : this.start.unix.leS(unix) && this.end.unix.gtS(unix)
   }
 }
-
-module.exports.Segment = Segment

--- a/src/tai-data.js
+++ b/src/tai-data.js
@@ -17,7 +17,7 @@ const DEC = 11
 // Third column: "root" point in UTC days since MJD epoch, defaults to 0
 // Fourth column: Drift rate in TAI seconds per UTC day, defaults to 0
 
-const taiData = [
+export const taiData = [
   [Date.UTC(1961, JAN, 1), 1.422_818_0, 37_300, 0.001_296],
   [Date.UTC(1961, AUG, 1), 1.372_818_0, 37_300, 0.001_296], // 0.05 TAI seconds removed from UTC
   [Date.UTC(1962, JAN, 1), 1.845_858_0, 37_665, 0.001_123_2], // drift rate reduced, no discontinuity
@@ -61,14 +61,10 @@ const taiData = [
   [Date.UTC(2017, JAN, 1), 37]
 ]
 
-const UNIX_START_MILLIS = taiData[0][0]
+export const UNIX_START_MILLIS = taiData[0][0]
 
 // Because we don't know whether or not a leap second will be inserted or removed at this time,
 // the relationship between Unix time and TAI is unpredictable at or beyond this point.
 // (This is the start of a possible smear.)
 // Updating this value? Don't forget to update the README too!
-const UNIX_END_MILLIS = Date.UTC(2023, DEC, 31, 12, 0, 0, 0)
-
-module.exports.taiData = taiData
-module.exports.UNIX_START_MILLIS = UNIX_START_MILLIS
-module.exports.UNIX_END_MILLIS = UNIX_END_MILLIS
+export const UNIX_END_MILLIS = Date.UTC(2023, DEC, 31, 12, 0, 0, 0)

--- a/test/converter.spec.js
+++ b/test/converter.spec.js
@@ -1,9 +1,9 @@
-const assert = require('node:assert')
-const { describe, it } = require('mocha')
-const { Converter } = require('../src/converter.js')
-const { MODELS } = require('../src/munge.js')
-const { Range } = require('../src/range.js')
-const { Second } = require('../src/second.js')
+import assert from 'node:assert'
+import { describe, it } from 'mocha'
+import { Converter } from '../src/converter.js'
+import { MODELS } from '../src/munge.js'
+import { Range } from '../src/range.js'
+import { Second } from '../src/second.js'
 
 const JAN = 0
 const DEC = 11

--- a/test/div.spec.js
+++ b/test/div.spec.js
@@ -1,6 +1,6 @@
-const assert = require('node:assert')
-const { describe, it } = require('mocha')
-const { sign, div, gcd } = require('../src/div.js')
+import assert from 'node:assert'
+import { describe, it } from 'mocha'
+import { sign, div, gcd } from '../src/div.js'
 
 describe('sign', () => {
   it('works', () => {

--- a/test/exact.spec.js
+++ b/test/exact.spec.js
@@ -1,7 +1,7 @@
-const assert = require('node:assert')
-const { describe, it } = require('mocha')
-const { TaiConverter, Second, MODELS, UNIX_START, UNIX_END } = require('../src/exact.js')
-const { Range } = require('../src/range.js')
+import assert from 'node:assert'
+import { describe, it } from 'mocha'
+import { TaiConverter, Second, MODELS, UNIX_START, UNIX_END } from '../src/exact.js'
+import { Range } from '../src/range.js'
 
 const JAN = 0
 const FEB = 1

--- a/test/index.spec.js
+++ b/test/index.spec.js
@@ -1,6 +1,6 @@
-const assert = require('node:assert')
-const { describe, it } = require('mocha')
-const { TaiConverter, MODELS, UNIX_START, UNIX_END } = require('../src/index.js')
+import assert from 'node:assert'
+import { describe, it } from 'mocha'
+import { TaiConverter, MODELS, UNIX_START, UNIX_END } from '../src/index.js'
 
 const JAN = 0
 const FEB = 1

--- a/test/millis-converter.spec.js
+++ b/test/millis-converter.spec.js
@@ -1,7 +1,7 @@
-const assert = require('node:assert')
-const { describe, it } = require('mocha')
-const { MODELS } = require('../src/munge.js')
-const { MillisConverter } = require('../src/millis-converter.js')
+import assert from 'node:assert'
+import { describe, it } from 'mocha'
+import { MODELS } from '../src/munge.js'
+import { MillisConverter } from '../src/millis-converter.js'
 
 const JAN = 0
 const OCT = 9

--- a/test/munge.spec.js
+++ b/test/munge.spec.js
@@ -1,10 +1,10 @@
-const assert = require('node:assert')
-const { describe, it } = require('mocha')
-const { taiData } = require('../src/tai-data.js')
-const { munge, MODELS } = require('../src/munge.js')
-const { Second } = require('../src/second.js')
-const { Segment } = require('../src/segment.js')
-const { Rat } = require('../src/rat.js')
+import assert from 'node:assert'
+import { describe, it } from 'mocha'
+import { taiData } from '../src/tai-data.js'
+import { munge, MODELS } from '../src/munge.js'
+import { Second } from '../src/second.js'
+import { Segment } from '../src/segment.js'
+import { Rat } from '../src/rat.js'
 
 const JAN = 0
 const DEC = 11

--- a/test/rat.spec.js
+++ b/test/rat.spec.js
@@ -1,6 +1,6 @@
-const assert = require('node:assert')
-const { describe, it } = require('mocha')
-const { Rat } = require('../src/rat')
+import assert from 'node:assert'
+import { describe, it } from 'mocha'
+import { Rat } from '../src/rat.js'
 
 describe('Rat', () => {
   it('type checking', () => {

--- a/test/second.spec.js
+++ b/test/second.spec.js
@@ -1,7 +1,7 @@
-const assert = require('node:assert')
-const { describe, it } = require('mocha')
-const { Rat } = require('../src/rat.js')
-const { Second } = require('../src/second.js')
+import assert from 'node:assert'
+import { describe, it } from 'mocha'
+import { Rat } from '../src/rat.js'
+import { Second } from '../src/second.js'
 
 describe('Second', () => {
   it('type checking', () => {

--- a/test/segment.spec.js
+++ b/test/segment.spec.js
@@ -1,9 +1,9 @@
-const assert = require('node:assert')
-const { describe, it } = require('mocha')
-const { Rat } = require('../src/rat.js')
-const { Range } = require('../src/range.js')
-const { Second } = require('../src/second.js')
-const { Segment } = require('../src/segment.js')
+import assert from 'node:assert'
+import { describe, it } from 'mocha'
+import { Rat } from '../src/rat.js'
+import { Range } from '../src/range.js'
+import { Second } from '../src/second.js'
+import { Segment } from '../src/segment.js'
 
 const MAY = 4
 


### PR DESCRIPTION
Fixes #43. Convert all CommonJS modules to ES modules. Drop support for Node.js 14. Bump major version to 4.