### PR TITLE
No leap second, 31 December 2025

### DIFF
--- a/README.md
+++ b/README.md
@@ -115,7 +115,7 @@ For your reference, at the time of writing:
 
 ### Validity for the future
 
-Leap seconds (or the lack thereof) are announced in the International Earth Rotation and Reference Systems Service (IERS)'s six-monthly Bulletin C. For example, at the time of writing, [the latest such bulletin](https://datacenter.iers.org/data/16/bulletinc-069.txt) was published on 6 January 2025 and announced that there will be no leap second at the end of June 2025. This means that `t-a-i`'s calculations are guaranteed to be correct up to, but not including, the *next* potential leap second, which in this case is at the end of December 2025. At or beyond this point, the introduction of leap seconds cannot be predicted in advance, and the correctness of `t-a-i`'s behaviour cannot be guaranteed.
+Leap seconds (or the lack thereof) are announced in the International Earth Rotation and Reference Systems Service (IERS)'s six-monthly Bulletin C. For example, at the time of writing, [the latest such bulletin](https://hpiers.obspm.fr/iers/bul/bulc/bulletinc.70) was published on 7 July 2025 and announced that there will be no leap second at the end of December 2025. This means that `t-a-i`'s calculations are guaranteed to be correct up to, but not including, the *next* potential leap second, which in this case is at the end of June 2026. At or beyond this point, the introduction of leap seconds cannot be predicted in advance, and the correctness of `t-a-i`'s behaviour cannot be guaranteed.
 
 As a result, `t-a-i`'s behaviour beyond the next-but-one (possible) leap second is considered to be undefined. Updates to the source data when new leap seconds are announced will not be considered breaking changes, and will not incur a major version bump.
 

--- a/src/tai-data.js
+++ b/src/tai-data.js
@@ -6,12 +6,12 @@ const JAN = 0
 const FEB = 1
 const MAR = 2
 const APR = 3
-// const JUN = 5
+const JUN = 5
 const JUL = 6
 const AUG = 7
 const SEP = 8
 const NOV = 10
-const DEC = 11
+// const DEC = 11
 
 // First column: Unix millisecond count when this relationship became effective
 // Second column: TAI minus UTC in TAI seconds as of the root point
@@ -64,8 +64,7 @@ export const taiData = [
 
 export const UNIX_START_MILLIS = taiData[0][0]
 
-// Because we don't know whether or not a leap second will be inserted or removed at this time,
-// the relationship between Unix time and TAI is unpredictable at or beyond this point.
-// (This is the start of a possible smear.)
+// Our limit of validity is determined by IERS Bulletin C's limit of validity.
+// https://hpiers.obspm.fr/iers/bul/bulc/BULLETINC.GUIDE.html
 // Updating this value? Don't forget to update the README too!
-export const UNIX_END_MILLIS = Date.UTC(2025, DEC, 31, 12, 0, 0, 0)
+export const UNIX_END_MILLIS = Date.UTC(2026, JUN, 28)

--- a/test/exact.spec.js
+++ b/test/exact.spec.js
@@ -8,7 +8,6 @@ const JAN = 0
 const FEB = 1
 const MAR = 2
 const APR = 3
-const JUN = 5
 const JUL = 6
 const AUG = 7
 const SEP = 8
@@ -22,18 +21,12 @@ describe('UNIX_START', () => {
 })
 
 describe('UNIX_END', () => {
-  it('is the start of a possible smear', () => {
+  it('is at the limit of validity', () => {
+    // https://hpiers.obspm.fr/iers/bul/bulc/BULLETINC.GUIDE.html
     const endDate = new Date(UNIX_END.toMillis())
 
-    if (endDate.getUTCMonth() === JUN) {
-      assert.strictEqual(endDate.getUTCDate(), 30)
-    } else if (endDate.getUTCMonth() === DEC) {
-      assert.strictEqual(endDate.getUTCDate(), 31)
-    } else {
-      throw Error('bad month')
-    }
-
-    assert.strictEqual(endDate.getUTCHours(), 12)
+    assert.strictEqual(endDate.getUTCDate(), 28)
+    assert.strictEqual(endDate.getUTCHours(), 0)
     assert.strictEqual(endDate.getUTCMinutes(), 0)
     assert.strictEqual(endDate.getUTCSeconds(), 0)
     assert.strictEqual(endDate.getUTCMilliseconds(), 0)

--- a/test/index.spec.js
+++ b/test/index.spec.js
@@ -6,7 +6,6 @@ const JAN = 0
 const FEB = 1
 const MAR = 2
 const APR = 3
-const JUN = 5
 const JUL = 6
 const AUG = 7
 const SEP = 8
@@ -20,18 +19,12 @@ describe('UNIX_START', () => {
 })
 
 describe('UNIX_END', () => {
-  it('is correct', () => {
+  it('is at the limit of validity', () => {
+    // https://hpiers.obspm.fr/iers/bul/bulc/BULLETINC.GUIDE.html
     const endDate = new Date(UNIX_END)
 
-    if (endDate.getUTCMonth() === JUN) {
-      assert.strictEqual(endDate.getUTCDate(), 30)
-    } else if (endDate.getUTCMonth() === DEC) {
-      assert.strictEqual(endDate.getUTCDate(), 31)
-    } else {
-      throw Error('bad month')
-    }
-
-    assert.strictEqual(endDate.getUTCHours(), 12)
+    assert.strictEqual(endDate.getUTCDate(), 28)
+    assert.strictEqual(endDate.getUTCHours(), 0)
     assert.strictEqual(endDate.getUTCMinutes(), 0)
     assert.strictEqual(endDate.getUTCSeconds(), 0)
     assert.strictEqual(endDate.getUTCMilliseconds(), 0)

--- a/test/nanos.spec.js
+++ b/test/nanos.spec.js
@@ -3,7 +3,6 @@ import { describe, it } from 'mocha'
 import { TaiConverter, MODELS, UNIX_START, UNIX_END } from '../src/nanos.js'
 
 const JAN = 0
-const JUN = 5
 const OCT = 9
 const DEC = 11
 
@@ -14,18 +13,12 @@ describe('UNIX_START', () => {
 })
 
 describe('UNIX_END', () => {
-  it('is correct', () => {
+  it('is at the limit of validity', () => {
+    // https://hpiers.obspm.fr/iers/bul/bulc/BULLETINC.GUIDE.html
     const endDate = new Date(UNIX_END / 1_000_000)
 
-    if (endDate.getUTCMonth() === JUN) {
-      assert.strictEqual(endDate.getUTCDate(), 30)
-    } else if (endDate.getUTCMonth() === DEC) {
-      assert.strictEqual(endDate.getUTCDate(), 31)
-    } else {
-      throw Error('bad month')
-    }
-
-    assert.strictEqual(endDate.getUTCHours(), 12)
+    assert.strictEqual(endDate.getUTCDate(), 28)
+    assert.strictEqual(endDate.getUTCHours(), 0)
     assert.strictEqual(endDate.getUTCMinutes(), 0)
     assert.strictEqual(endDate.getUTCSeconds(), 0)
     assert.strictEqual(endDate.getUTCMilliseconds(), 0)


### PR DESCRIPTION
As announced [here](hpiers.obspm.fr/iers/bul/bulc/bulletinc.70).

While investigating this I also came across [this document](https://hpiers.obspm.fr/iers/bul/bulc/BULLETINC.GUIDE.html) which gives more detail about the limits of validity of Bulletin C's announcements, which are slightly more constrained than those that `t-a-i` has been using up until now. I've been setting `UNIX_END` to be 12:00 on 30 June or 31 December, as this is the start of a possible 24-hour smear. However, IERS apparently uses 00:00 on 28 June or 28 December:

> Be careful : The limit date of validity of a bulletinc C or Leap_Second.dat is "nearly" one year :
> * The limit date of validity of the bulletin C/Leap_second.dat published at the beginning of january is 28 december
> * The limit date of validity of the bulletin C/Leap_second.dat published at the beginning of july is 28 june

*\[sic\]*

This theoretically allows for longer smears or more complex behaviour. Works for me. We'll use this for our value of `UNIX_END` going forward.