### PR TITLE
Allow BigInts for inputs

### DIFF
--- a/README.md
+++ b/README.md
@@ -276,7 +276,7 @@ are sometimes inaccessible. This affects both `unixToAtomic` and `atomicToUnix`,
 For example, suppose it's one millisecond before the end of the 24-hour smear for the most recent leap second. Let's try to convert that Unix time to TAI, using ordinary floats:
 
 ```js
-import { TaiConverter, MODELS, UNIX_START } from 't-a-i/nanos'
+import { TaiConverter, MODELS } from 't-a-i/nanos'
 
 const taiConverter = TaiConverter(MODELS.SMEAR)
 
@@ -306,7 +306,7 @@ However, because some of these numbers cannot be represented in JavaScript, the 
 If we use BigInts, these problems go away and we obtain precise results:
 
 ```js
-import { TaiConverter, MODELS, UNIX_START } from 't-a-i/nanos'
+import { TaiConverter, MODELS } from 't-a-i/nanos'
 
 const taiConverter = TaiConverter(MODELS.SMEAR)
 

--- a/src/exact.js
+++ b/src/exact.js
@@ -5,6 +5,6 @@ import { Second } from './second.js'
 export { MODELS } from './munge.js'
 export { Second }
 
-export const UNIX_START = Second.fromMillis(UNIX_START_MILLIS)
-export const UNIX_END = Second.fromMillis(UNIX_END_MILLIS)
+export const UNIX_START = Second.fromMillis(BigInt(UNIX_START_MILLIS))
+export const UNIX_END = Second.fromMillis(BigInt(UNIX_END_MILLIS))
 export const TaiConverter = model => new Converter(taiData, model)

--- a/src/millis-converter.js
+++ b/src/millis-converter.js
@@ -8,14 +8,22 @@ export class MillisConverter {
   }
 
   atomicToUnix (atomicMillis) {
-    const unix = this.converter.atomicToUnix(Second.fromMillis(atomicMillis))
+    if (!Number.isInteger(atomicMillis)) {
+      throw Error(`Not an integer: ${atomicMillis}`)
+    }
+
+    const unix = this.converter.atomicToUnix(Second.fromMillis(BigInt(atomicMillis)))
     return Number.isNaN(unix)
       ? unix
       : unix.toMillis()
   }
 
   unixToAtomic (unixMillis, options = {}) {
-    const ranges = this.converter.unixToAtomic(Second.fromMillis(unixMillis))
+    if (!Number.isInteger(unixMillis)) {
+      throw Error(`Not an integer: ${unixMillis}`)
+    }
+
+    const ranges = this.converter.unixToAtomic(Second.fromMillis(BigInt(unixMillis)))
       .map(range => [
         range.start.toMillis(),
         range.end.toMillis()

--- a/src/millis-converter.js
+++ b/src/millis-converter.js
@@ -8,26 +8,53 @@ export class MillisConverter {
   }
 
   atomicToUnix (atomicMillis) {
-    if (!Number.isInteger(atomicMillis)) {
+    const isInteger = Number.isInteger(atomicMillis)
+
+    if (isInteger) {
+      atomicMillis = BigInt(atomicMillis)
+    }
+
+    if (typeof atomicMillis !== 'bigint') {
       throw Error(`Not an integer: ${atomicMillis}`)
     }
 
-    const unix = this.converter.atomicToUnix(Second.fromMillis(BigInt(atomicMillis)))
-    return Number.isNaN(unix)
-      ? unix
-      : unix.toMillis()
+    let unix = this.converter.atomicToUnix(Second.fromMillis(atomicMillis))
+    if (Number.isNaN(unix)) {
+      return unix
+    }
+
+    unix = unix.toMillis()
+
+    if (isInteger) {
+      unix = Number(unix)
+    }
+
+    return unix
   }
 
   unixToAtomic (unixMillis, options = {}) {
-    if (!Number.isInteger(unixMillis)) {
+    const isInteger = Number.isInteger(unixMillis)
+
+    if (isInteger) {
+      unixMillis = BigInt(unixMillis)
+    }
+
+    if (typeof unixMillis !== 'bigint') {
       throw Error(`Not an integer: ${unixMillis}`)
     }
 
-    const ranges = this.converter.unixToAtomic(Second.fromMillis(BigInt(unixMillis)))
-      .map(range => [
-        range.start.toMillis(),
-        range.end.toMillis()
+    let ranges = this.converter.unixToAtomic(Second.fromMillis(unixMillis))
+    ranges = ranges.map(range => [
+      range.start.toMillis(),
+      range.end.toMillis()
+    ])
+
+    if (isInteger) {
+      ranges = ranges.map(range => [
+        Number(range[0]),
+        Number(range[1])
       ])
+    }
 
     if (options.array === true) {
       return options.range === true ? ranges : ranges.map(range => range[1])

--- a/src/munge.js
+++ b/src/munge.js
@@ -36,7 +36,7 @@ export const MODELS = {
 const NOV = 10
 const secondsPerDay = new Second(new Rat(86_400n, 1n))
 const mjdEpoch = {
-  unix: Second.fromMillis(Date.UTC(1858, NOV, 17))
+  unix: Second.fromMillis(BigInt(Date.UTC(1858, NOV, 17)))
 }
 
 // Input some raw TAI-UTC data, output the same data but altered to be more consumable for our
@@ -58,7 +58,7 @@ export const munge = (data, model) => {
     ] = datum
 
     // Convert from a millisecond count to a precise ratio of seconds
-    start.unix = Second.fromMillis(start.unixMillis)
+    start.unix = Second.fromMillis(BigInt(start.unixMillis))
 
     // Convert from a floating point number to a precise ratio
     // Offsets are given in TAI seconds to seven decimal places, e.g. `1.422_818_0`.

--- a/src/nanos-converter.js
+++ b/src/nanos-converter.js
@@ -8,18 +8,53 @@ export class NanosConverter {
   }
 
   atomicToUnix (atomicNanos) {
-    const unix = this.converter.atomicToUnix(Second.fromNanos(atomicNanos))
-    return Number.isNaN(unix)
-      ? unix
-      : unix.toNanos()
+    const isInteger = Number.isInteger(atomicNanos)
+
+    if (isInteger) {
+      atomicNanos = BigInt(atomicNanos)
+    }
+
+    if (typeof atomicNanos !== 'bigint') {
+      throw Error(`Not an integer: ${atomicNanos}`)
+    }
+
+    let unix = this.converter.atomicToUnix(Second.fromNanos(atomicNanos))
+    if (Number.isNaN(unix)) {
+      return unix
+    }
+
+    unix = unix.toNanos()
+
+    if (isInteger) {
+      unix = Number(unix)
+    }
+
+    return unix
   }
 
   unixToAtomic (unixNanos, options = {}) {
-    const ranges = this.converter.unixToAtomic(Second.fromNanos(unixNanos))
-      .map(range => [
-        range.start.toNanos(),
-        range.end.toNanos()
+    const isInteger = Number.isInteger(unixNanos)
+
+    if (isInteger) {
+      unixNanos = BigInt(unixNanos)
+    }
+
+    if (typeof unixNanos !== 'bigint') {
+      throw Error(`Not an integer: ${unixNanos}`)
+    }
+
+    let ranges = this.converter.unixToAtomic(Second.fromNanos(unixNanos))
+    ranges = ranges.map(range => [
+      range.start.toNanos(),
+      range.end.toNanos()
+    ])
+
+    if (isInteger) {
+      ranges = ranges.map(range => [
+        Number(range[0]),
+        Number(range[1])
       ])
+    }
 
     if (options.array === true) {
       return options.range === true ? ranges : ranges.map(range => range[1])

--- a/src/nanos.js
+++ b/src/nanos.js
@@ -4,8 +4,7 @@ import { Second } from './second.js'
 
 export { MODELS } from './munge.js'
 
-// TODO: need to expose BigInts for these as they are inaccurate.
-// Or are they? CHECK.
 export const UNIX_START = Number(Second.fromMillis(BigInt(UNIX_START_MILLIS)).toNanos())
 export const UNIX_END = Number(Second.fromMillis(BigInt(UNIX_END_MILLIS)).toNanos())
+
 export const TaiConverter = model => new NanosConverter(taiData, model)

--- a/src/nanos.js
+++ b/src/nanos.js
@@ -4,6 +4,6 @@ import { Second } from './second.js'
 
 export { MODELS } from './munge.js'
 
-export const UNIX_START = Second.fromMillis(UNIX_START_MILLIS).toNanos()
-export const UNIX_END = Second.fromMillis(UNIX_END_MILLIS).toNanos()
+export const UNIX_START = Second.fromMillis(BigInt(UNIX_START_MILLIS)).toNanos()
+export const UNIX_END = Second.fromMillis(BigInt(UNIX_END_MILLIS)).toNanos()
 export const TaiConverter = model => new NanosConverter(taiData, model)

--- a/src/nanos.js
+++ b/src/nanos.js
@@ -4,6 +4,8 @@ import { Second } from './second.js'
 
 export { MODELS } from './munge.js'
 
-export const UNIX_START = Second.fromMillis(BigInt(UNIX_START_MILLIS)).toNanos()
-export const UNIX_END = Second.fromMillis(BigInt(UNIX_END_MILLIS)).toNanos()
+// TODO: need to expose BigInts for these as they are inaccurate.
+// Or are they? CHECK.
+export const UNIX_START = Number(Second.fromMillis(BigInt(UNIX_START_MILLIS)).toNanos())
+export const UNIX_END = Number(Second.fromMillis(BigInt(UNIX_END_MILLIS)).toNanos())
 export const TaiConverter = model => new NanosConverter(taiData, model)

--- a/src/second.js
+++ b/src/second.js
@@ -50,6 +50,6 @@ Second.fromMillis = millis =>
   new Second(new Rat(millis, 1_000n))
 
 Second.fromNanos = nanos =>
-  return new Second(new Rat(nanos, 1_000_000_000n))
+  new Second(new Rat(nanos, 1_000_000_000n))
 
 Second.END_OF_TIME = Symbol('end of time')

--- a/src/second.js
+++ b/src/second.js
@@ -38,7 +38,7 @@ export class Second {
   }
 
   toMillis () {
-    return Number(this.rat.times(new Rat(1_000n)).trunc())
+    return this.rat.times(new Rat(1_000n)).trunc()
   }
 
   toNanos () {

--- a/src/second.js
+++ b/src/second.js
@@ -42,7 +42,7 @@ export class Second {
   }
 
   toNanos () {
-    return Number(this.rat.times(new Rat(1_000_000_000n)).trunc())
+    return this.rat.times(new Rat(1_000_000_000n)).trunc()
   }
 }
 
@@ -51,11 +51,7 @@ Second.fromMillis = millis => {
 }
 
 Second.fromNanos = nanos => {
-  if (!Number.isInteger(nanos)) {
-    throw Error(`Not an integer: ${nanos}`)
-  }
-
-  return new Second(new Rat(BigInt(nanos), 1_000_000_000n))
+  return new Second(new Rat(nanos, 1_000_000_000n))
 }
 
 Second.END_OF_TIME = Symbol('end of time')

--- a/src/second.js
+++ b/src/second.js
@@ -46,12 +46,10 @@ export class Second {
   }
 }
 
-Second.fromMillis = millis => {
-  return new Second(new Rat(millis, 1_000n))
-}
+Second.fromMillis = millis =>
+  new Second(new Rat(millis, 1_000n))
 
-Second.fromNanos = nanos => {
+Second.fromNanos = nanos =>
   return new Second(new Rat(nanos, 1_000_000_000n))
-}
 
 Second.END_OF_TIME = Symbol('end of time')

--- a/src/second.js
+++ b/src/second.js
@@ -47,11 +47,7 @@ export class Second {
 }
 
 Second.fromMillis = millis => {
-  if (!Number.isInteger(millis)) {
-    throw Error(`Not an integer: ${millis}`)
-  }
-
-  return new Second(new Rat(BigInt(millis), 1_000n))
+  return new Second(new Rat(millis, 1_000n))
 }
 
 Second.fromNanos = nanos => {

--- a/test/converter.spec.js
+++ b/test/converter.spec.js
@@ -19,10 +19,10 @@ describe('Converter', () => {
       const converter = new Converter(data, MODELS.OVERRUN)
 
       it('manages basic conversions', () => {
-        assert.deepStrictEqual(converter.unixToAtomic(Second.fromMillis(0)),
-          [new Range(Second.fromMillis(0))])
-        assert.deepStrictEqual(converter.atomicToUnix(Second.fromMillis(0)),
-          Second.fromMillis(0))
+        assert.deepStrictEqual(converter.unixToAtomic(Second.fromMillis(0n)),
+          [new Range(Second.fromMillis(0n))])
+        assert.deepStrictEqual(converter.atomicToUnix(Second.fromMillis(0n)),
+          Second.fromMillis(0n))
       })
     })
 
@@ -30,10 +30,10 @@ describe('Converter', () => {
       const converter = new Converter(data, MODELS.BREAK)
 
       it('manages basic conversions', () => {
-        assert.deepStrictEqual(converter.unixToAtomic(Second.fromMillis(0)),
-          [new Range(Second.fromMillis(0))])
-        assert.deepStrictEqual(converter.atomicToUnix(Second.fromMillis(0)),
-          Second.fromMillis(0))
+        assert.deepStrictEqual(converter.unixToAtomic(Second.fromMillis(0n)),
+          [new Range(Second.fromMillis(0n))])
+        assert.deepStrictEqual(converter.atomicToUnix(Second.fromMillis(0n)),
+          Second.fromMillis(0n))
       })
     })
 
@@ -41,22 +41,22 @@ describe('Converter', () => {
       const converter = new Converter(data, MODELS.STALL)
 
       it('fails when the atomic count is out of bounds', () => {
-        assert.deepStrictEqual(converter.atomicToUnix(Second.fromMillis(0)),
-          Second.fromMillis(0))
-        assert.strictEqual(converter.atomicToUnix(Second.fromMillis(-1)),
+        assert.deepStrictEqual(converter.atomicToUnix(Second.fromMillis(0n)),
+          Second.fromMillis(0n))
+        assert.strictEqual(converter.atomicToUnix(Second.fromMillis(-1n)),
           NaN)
       })
 
       it('fails when the Unix count is out of bounds', () => {
-        assert.deepStrictEqual(converter.unixToAtomic(Second.fromMillis(0)),
-          [new Range(Second.fromMillis(0))])
-        assert.deepStrictEqual(converter.unixToAtomic(Second.fromMillis(-1)),
+        assert.deepStrictEqual(converter.unixToAtomic(Second.fromMillis(0n)),
+          [new Range(Second.fromMillis(0n))])
+        assert.deepStrictEqual(converter.unixToAtomic(Second.fromMillis(-1n)),
           [])
       })
 
       it('manages basic conversions', () => {
-        assert.deepStrictEqual(converter.unixToAtomic(Second.fromMillis(0)), [new Range(Second.fromMillis(0))])
-        assert.deepStrictEqual(converter.atomicToUnix(Second.fromMillis(0)), Second.fromMillis(0))
+        assert.deepStrictEqual(converter.unixToAtomic(Second.fromMillis(0n)), [new Range(Second.fromMillis(0n))])
+        assert.deepStrictEqual(converter.atomicToUnix(Second.fromMillis(0n)), Second.fromMillis(0n))
       })
     })
 
@@ -64,10 +64,10 @@ describe('Converter', () => {
       const converter = new Converter(data, MODELS.SMEAR)
 
       it('manages basic conversions', () => {
-        assert.deepStrictEqual(converter.unixToAtomic(Second.fromMillis(0)),
-          [new Range(Second.fromMillis(0))])
-        assert.deepStrictEqual(converter.atomicToUnix(Second.fromMillis(0)),
-          Second.fromMillis(0))
+        assert.deepStrictEqual(converter.unixToAtomic(Second.fromMillis(0n)),
+          [new Range(Second.fromMillis(0n))])
+        assert.deepStrictEqual(converter.atomicToUnix(Second.fromMillis(0n)),
+          Second.fromMillis(0n))
       })
     })
   })
@@ -82,61 +82,61 @@ describe('Converter', () => {
       const converter = new Converter(data, MODELS.OVERRUN)
 
       it('unixToAtomic', () => {
-        assert.deepStrictEqual(converter.unixToAtomic(Second.fromMillis(0)),
+        assert.deepStrictEqual(converter.unixToAtomic(Second.fromMillis(0n)),
           [
-            new Range(Second.fromMillis(0))
+            new Range(Second.fromMillis(0n))
           ])
 
         // BIFURCATION
-        assert.deepStrictEqual(converter.unixToAtomic(Second.fromMillis(Date.UTC(1979, DEC, 31, 23, 59, 59, 999))),
+        assert.deepStrictEqual(converter.unixToAtomic(Second.fromMillis(BigInt(Date.UTC(1979, DEC, 31, 23, 59, 59, 999)))),
           [
-            new Range(Second.fromMillis(Date.UTC(1979, DEC, 31, 23, 59, 59, 999)))
+            new Range(Second.fromMillis(BigInt(Date.UTC(1979, DEC, 31, 23, 59, 59, 999))))
           ])
-        assert.deepStrictEqual(converter.unixToAtomic(Second.fromMillis(Date.UTC(1980, JAN, 1, 0, 0, 0, 0))),
+        assert.deepStrictEqual(converter.unixToAtomic(Second.fromMillis(BigInt(Date.UTC(1980, JAN, 1, 0, 0, 0, 0)))),
           [
-            new Range(Second.fromMillis(Date.UTC(1980, JAN, 1, 0, 0, 0, 0))),
-            new Range(Second.fromMillis(Date.UTC(1980, JAN, 1, 0, 0, 1, 0)))
+            new Range(Second.fromMillis(BigInt(Date.UTC(1980, JAN, 1, 0, 0, 0, 0)))),
+            new Range(Second.fromMillis(BigInt(Date.UTC(1980, JAN, 1, 0, 0, 1, 0))))
           ])
-        assert.deepStrictEqual(converter.unixToAtomic(Second.fromMillis(Date.UTC(1980, JAN, 1, 0, 0, 0, 1))),
+        assert.deepStrictEqual(converter.unixToAtomic(Second.fromMillis(BigInt(Date.UTC(1980, JAN, 1, 0, 0, 0, 1)))),
           [
-            new Range(Second.fromMillis(Date.UTC(1980, JAN, 1, 0, 0, 0, 1))),
-            new Range(Second.fromMillis(Date.UTC(1980, JAN, 1, 0, 0, 1, 1)))
+            new Range(Second.fromMillis(BigInt(Date.UTC(1980, JAN, 1, 0, 0, 0, 1)))),
+            new Range(Second.fromMillis(BigInt(Date.UTC(1980, JAN, 1, 0, 0, 1, 1))))
           ])
 
         // COLLAPSE
-        assert.deepStrictEqual(converter.unixToAtomic(Second.fromMillis(Date.UTC(1980, JAN, 1, 0, 0, 0, 999))),
+        assert.deepStrictEqual(converter.unixToAtomic(Second.fromMillis(BigInt(Date.UTC(1980, JAN, 1, 0, 0, 0, 999)))),
           [
-            new Range(Second.fromMillis(Date.UTC(1980, JAN, 1, 0, 0, 0, 999))),
-            new Range(Second.fromMillis(Date.UTC(1980, JAN, 1, 0, 0, 1, 999)))
+            new Range(Second.fromMillis(BigInt(Date.UTC(1980, JAN, 1, 0, 0, 0, 999)))),
+            new Range(Second.fromMillis(BigInt(Date.UTC(1980, JAN, 1, 0, 0, 1, 999))))
           ])
-        assert.deepStrictEqual(converter.unixToAtomic(Second.fromMillis(Date.UTC(1980, JAN, 1, 0, 0, 1, 0))),
+        assert.deepStrictEqual(converter.unixToAtomic(Second.fromMillis(BigInt(Date.UTC(1980, JAN, 1, 0, 0, 1, 0)))),
           [
-            new Range(Second.fromMillis(Date.UTC(1980, JAN, 1, 0, 0, 2, 0)))
+            new Range(Second.fromMillis(BigInt(Date.UTC(1980, JAN, 1, 0, 0, 2, 0))))
           ])
-        assert.deepStrictEqual(converter.unixToAtomic(Second.fromMillis(Date.UTC(1980, JAN, 1, 0, 0, 1, 1))),
+        assert.deepStrictEqual(converter.unixToAtomic(Second.fromMillis(BigInt(Date.UTC(1980, JAN, 1, 0, 0, 1, 1)))),
           [
-            new Range(Second.fromMillis(Date.UTC(1980, JAN, 1, 0, 0, 2, 1)))
+            new Range(Second.fromMillis(BigInt(Date.UTC(1980, JAN, 1, 0, 0, 2, 1))))
           ])
       })
 
       it('atomicToUnix', () => {
-        assert.deepStrictEqual(converter.atomicToUnix(Second.fromMillis(0)),
-          Second.fromMillis(0))
+        assert.deepStrictEqual(converter.atomicToUnix(Second.fromMillis(0n)),
+          Second.fromMillis(0n))
 
-        assert.deepStrictEqual(converter.atomicToUnix(Second.fromMillis(Date.UTC(1979, DEC, 31, 23, 59, 59, 999))),
-          Second.fromMillis(Date.UTC(1979, DEC, 31, 23, 59, 59, 999)))
-        assert.deepStrictEqual(converter.atomicToUnix(Second.fromMillis(Date.UTC(1980, JAN, 1, 0, 0, 0, 0))),
-          Second.fromMillis(Date.UTC(1980, JAN, 1, 0, 0, 0, 0)))
-        assert.deepStrictEqual(converter.atomicToUnix(Second.fromMillis(Date.UTC(1980, JAN, 1, 0, 0, 0, 1))),
-          Second.fromMillis(Date.UTC(1980, JAN, 1, 0, 0, 0, 1)))
+        assert.deepStrictEqual(converter.atomicToUnix(Second.fromMillis(BigInt(Date.UTC(1979, DEC, 31, 23, 59, 59, 999)))),
+          Second.fromMillis(BigInt(Date.UTC(1979, DEC, 31, 23, 59, 59, 999))))
+        assert.deepStrictEqual(converter.atomicToUnix(Second.fromMillis(BigInt(Date.UTC(1980, JAN, 1, 0, 0, 0, 0)))),
+          Second.fromMillis(BigInt(Date.UTC(1980, JAN, 1, 0, 0, 0, 0))))
+        assert.deepStrictEqual(converter.atomicToUnix(Second.fromMillis(BigInt(Date.UTC(1980, JAN, 1, 0, 0, 0, 1)))),
+          Second.fromMillis(BigInt(Date.UTC(1980, JAN, 1, 0, 0, 0, 1))))
 
         // BACKTRACK
-        assert.deepStrictEqual(converter.atomicToUnix(Second.fromMillis(Date.UTC(1980, JAN, 1, 0, 0, 0, 999))),
-          Second.fromMillis(Date.UTC(1980, JAN, 1, 0, 0, 0, 999)))
-        assert.deepStrictEqual(converter.atomicToUnix(Second.fromMillis(Date.UTC(1980, JAN, 1, 0, 0, 1, 0))),
-          Second.fromMillis(Date.UTC(1980, JAN, 1, 0, 0, 0, 0)))
-        assert.deepStrictEqual(converter.atomicToUnix(Second.fromMillis(Date.UTC(1980, JAN, 1, 0, 0, 1, 1))),
-          Second.fromMillis(Date.UTC(1980, JAN, 1, 0, 0, 0, 1)))
+        assert.deepStrictEqual(converter.atomicToUnix(Second.fromMillis(BigInt(Date.UTC(1980, JAN, 1, 0, 0, 0, 999)))),
+          Second.fromMillis(BigInt(Date.UTC(1980, JAN, 1, 0, 0, 0, 999))))
+        assert.deepStrictEqual(converter.atomicToUnix(Second.fromMillis(BigInt(Date.UTC(1980, JAN, 1, 0, 0, 1, 0)))),
+          Second.fromMillis(BigInt(Date.UTC(1980, JAN, 1, 0, 0, 0, 0))))
+        assert.deepStrictEqual(converter.atomicToUnix(Second.fromMillis(BigInt(Date.UTC(1980, JAN, 1, 0, 0, 1, 1)))),
+          Second.fromMillis(BigInt(Date.UTC(1980, JAN, 1, 0, 0, 0, 1))))
       })
     })
 
@@ -144,58 +144,58 @@ describe('Converter', () => {
       const converter = new Converter(data, MODELS.BREAK)
 
       it('unixToAtomic', () => {
-        assert.deepStrictEqual(converter.unixToAtomic(Second.fromMillis(0)),
+        assert.deepStrictEqual(converter.unixToAtomic(Second.fromMillis(0n)),
           [
-            new Range(Second.fromMillis(0))
+            new Range(Second.fromMillis(0n))
           ])
 
         // FORWARD JUMP
-        assert.deepStrictEqual(converter.unixToAtomic(Second.fromMillis(Date.UTC(1979, DEC, 31, 23, 59, 59, 999))),
+        assert.deepStrictEqual(converter.unixToAtomic(Second.fromMillis(BigInt(Date.UTC(1979, DEC, 31, 23, 59, 59, 999)))),
           [
-            new Range(Second.fromMillis(Date.UTC(1979, DEC, 31, 23, 59, 59, 999)))
+            new Range(Second.fromMillis(BigInt(Date.UTC(1979, DEC, 31, 23, 59, 59, 999))))
           ])
-        assert.deepStrictEqual(converter.unixToAtomic(Second.fromMillis(Date.UTC(1980, JAN, 1, 0, 0, 0, 0))),
+        assert.deepStrictEqual(converter.unixToAtomic(Second.fromMillis(BigInt(Date.UTC(1980, JAN, 1, 0, 0, 0, 0)))),
           [
-            new Range(Second.fromMillis(Date.UTC(1980, JAN, 1, 0, 0, 1, 0)))
+            new Range(Second.fromMillis(BigInt(Date.UTC(1980, JAN, 1, 0, 0, 1, 0))))
           ])
-        assert.deepStrictEqual(converter.unixToAtomic(Second.fromMillis(Date.UTC(1980, JAN, 1, 0, 0, 0, 1))),
+        assert.deepStrictEqual(converter.unixToAtomic(Second.fromMillis(BigInt(Date.UTC(1980, JAN, 1, 0, 0, 0, 1)))),
           [
-            new Range(Second.fromMillis(Date.UTC(1980, JAN, 1, 0, 0, 1, 1)))
+            new Range(Second.fromMillis(BigInt(Date.UTC(1980, JAN, 1, 0, 0, 1, 1))))
           ])
 
-        assert.deepStrictEqual(converter.unixToAtomic(Second.fromMillis(Date.UTC(1980, JAN, 1, 0, 0, 0, 999))),
+        assert.deepStrictEqual(converter.unixToAtomic(Second.fromMillis(BigInt(Date.UTC(1980, JAN, 1, 0, 0, 0, 999)))),
           [
-            new Range(Second.fromMillis(Date.UTC(1980, JAN, 1, 0, 0, 1, 999)))
+            new Range(Second.fromMillis(BigInt(Date.UTC(1980, JAN, 1, 0, 0, 1, 999))))
           ])
-        assert.deepStrictEqual(converter.unixToAtomic(Second.fromMillis(Date.UTC(1980, JAN, 1, 0, 0, 1, 0))),
+        assert.deepStrictEqual(converter.unixToAtomic(Second.fromMillis(BigInt(Date.UTC(1980, JAN, 1, 0, 0, 1, 0)))),
           [
-            new Range(Second.fromMillis(Date.UTC(1980, JAN, 1, 0, 0, 2, 0)))
+            new Range(Second.fromMillis(BigInt(Date.UTC(1980, JAN, 1, 0, 0, 2, 0))))
           ])
-        assert.deepStrictEqual(converter.unixToAtomic(Second.fromMillis(Date.UTC(1980, JAN, 1, 0, 0, 1, 1))),
+        assert.deepStrictEqual(converter.unixToAtomic(Second.fromMillis(BigInt(Date.UTC(1980, JAN, 1, 0, 0, 1, 1)))),
           [
-            new Range(Second.fromMillis(Date.UTC(1980, JAN, 1, 0, 0, 2, 1)))
+            new Range(Second.fromMillis(BigInt(Date.UTC(1980, JAN, 1, 0, 0, 2, 1))))
           ])
       })
 
       it('atomicToUnix', () => {
-        assert.deepStrictEqual(converter.atomicToUnix(Second.fromMillis(0)),
-          Second.fromMillis(0))
+        assert.deepStrictEqual(converter.atomicToUnix(Second.fromMillis(0n)),
+          Second.fromMillis(0n))
 
         // UNDEFINED UNIX TIME STARTS
-        assert.deepStrictEqual(converter.atomicToUnix(Second.fromMillis(Date.UTC(1979, DEC, 31, 23, 59, 59, 999))),
-          Second.fromMillis(Date.UTC(1979, DEC, 31, 23, 59, 59, 999)))
-        assert.strictEqual(converter.atomicToUnix(Second.fromMillis(Date.UTC(1980, JAN, 1, 0, 0, 0, 0))),
+        assert.deepStrictEqual(converter.atomicToUnix(Second.fromMillis(BigInt(Date.UTC(1979, DEC, 31, 23, 59, 59, 999)))),
+          Second.fromMillis(BigInt(Date.UTC(1979, DEC, 31, 23, 59, 59, 999))))
+        assert.strictEqual(converter.atomicToUnix(Second.fromMillis(BigInt(Date.UTC(1980, JAN, 1, 0, 0, 0, 0)))),
           NaN)
-        assert.strictEqual(converter.atomicToUnix(Second.fromMillis(Date.UTC(1980, JAN, 1, 0, 0, 0, 1))),
+        assert.strictEqual(converter.atomicToUnix(Second.fromMillis(BigInt(Date.UTC(1980, JAN, 1, 0, 0, 0, 1)))),
           NaN)
 
         // UNDEFINED UNIX TIME ENDS
-        assert.strictEqual(converter.atomicToUnix(Second.fromMillis(Date.UTC(1980, JAN, 1, 0, 0, 0, 999))),
+        assert.strictEqual(converter.atomicToUnix(Second.fromMillis(BigInt(Date.UTC(1980, JAN, 1, 0, 0, 0, 999)))),
           NaN)
-        assert.deepStrictEqual(converter.atomicToUnix(Second.fromMillis(Date.UTC(1980, JAN, 1, 0, 0, 1, 0))),
-          Second.fromMillis(Date.UTC(1980, JAN, 1, 0, 0, 0, 0)))
-        assert.deepStrictEqual(converter.atomicToUnix(Second.fromMillis(Date.UTC(1980, JAN, 1, 0, 0, 1, 1))),
-          Second.fromMillis(Date.UTC(1980, JAN, 1, 0, 0, 0, 1)))
+        assert.deepStrictEqual(converter.atomicToUnix(Second.fromMillis(BigInt(Date.UTC(1980, JAN, 1, 0, 0, 1, 0)))),
+          Second.fromMillis(BigInt(Date.UTC(1980, JAN, 1, 0, 0, 0, 0))))
+        assert.deepStrictEqual(converter.atomicToUnix(Second.fromMillis(BigInt(Date.UTC(1980, JAN, 1, 0, 0, 1, 1)))),
+          Second.fromMillis(BigInt(Date.UTC(1980, JAN, 1, 0, 0, 0, 1))))
       })
     })
 
@@ -203,48 +203,48 @@ describe('Converter', () => {
       const converter = new Converter(data, MODELS.STALL)
 
       it('unixToAtomic', () => {
-        assert.deepStrictEqual(converter.unixToAtomic(Second.fromMillis(0)),
+        assert.deepStrictEqual(converter.unixToAtomic(Second.fromMillis(0n)),
           [
-            new Range(Second.fromMillis(0))
+            new Range(Second.fromMillis(0n))
           ])
 
         // STALL POINT
-        assert.deepStrictEqual(converter.unixToAtomic(Second.fromMillis(Date.UTC(1979, DEC, 31, 23, 59, 59, 999))),
+        assert.deepStrictEqual(converter.unixToAtomic(Second.fromMillis(BigInt(Date.UTC(1979, DEC, 31, 23, 59, 59, 999)))),
           [
-            new Range(Second.fromMillis(Date.UTC(1979, DEC, 31, 23, 59, 59, 999)))
+            new Range(Second.fromMillis(BigInt(Date.UTC(1979, DEC, 31, 23, 59, 59, 999))))
           ])
-        assert.deepStrictEqual(converter.unixToAtomic(Second.fromMillis(Date.UTC(1980, JAN, 1, 0, 0, 0, 0))),
+        assert.deepStrictEqual(converter.unixToAtomic(Second.fromMillis(BigInt(Date.UTC(1980, JAN, 1, 0, 0, 0, 0)))),
           [
             new Range(
-              Second.fromMillis(Date.UTC(1980, JAN, 1, 0, 0, 0, 0)),
-              Second.fromMillis(Date.UTC(1980, JAN, 1, 0, 0, 1, 0))
+              Second.fromMillis(BigInt(Date.UTC(1980, JAN, 1, 0, 0, 0, 0))),
+              Second.fromMillis(BigInt(Date.UTC(1980, JAN, 1, 0, 0, 1, 0)))
             )
           ])
-        assert.deepStrictEqual(converter.unixToAtomic(Second.fromMillis(Date.UTC(1980, JAN, 1, 0, 0, 0, 1))),
+        assert.deepStrictEqual(converter.unixToAtomic(Second.fromMillis(BigInt(Date.UTC(1980, JAN, 1, 0, 0, 0, 1)))),
           [
-            new Range(Second.fromMillis(Date.UTC(1980, JAN, 1, 0, 0, 1, 1)))
+            new Range(Second.fromMillis(BigInt(Date.UTC(1980, JAN, 1, 0, 0, 1, 1))))
           ])
       })
 
       it('atomicToUnix', () => {
-        assert.deepStrictEqual(converter.atomicToUnix(Second.fromMillis(0)),
-          Second.fromMillis(0))
+        assert.deepStrictEqual(converter.atomicToUnix(Second.fromMillis(0n)),
+          Second.fromMillis(0n))
 
         // STALL STARTS
-        assert.deepStrictEqual(converter.atomicToUnix(Second.fromMillis(Date.UTC(1979, DEC, 31, 23, 59, 59, 999))),
-          Second.fromMillis(Date.UTC(1979, DEC, 31, 23, 59, 59, 999)))
-        assert.deepStrictEqual(converter.atomicToUnix(Second.fromMillis(Date.UTC(1980, JAN, 1, 0, 0, 0, 0))),
-          Second.fromMillis(Date.UTC(1980, JAN, 1, 0, 0, 0, 0)))
-        assert.deepStrictEqual(converter.atomicToUnix(Second.fromMillis(Date.UTC(1980, JAN, 1, 0, 0, 0, 1))),
-          Second.fromMillis(Date.UTC(1980, JAN, 1, 0, 0, 0, 0)))
+        assert.deepStrictEqual(converter.atomicToUnix(Second.fromMillis(BigInt(Date.UTC(1979, DEC, 31, 23, 59, 59, 999)))),
+          Second.fromMillis(BigInt(Date.UTC(1979, DEC, 31, 23, 59, 59, 999))))
+        assert.deepStrictEqual(converter.atomicToUnix(Second.fromMillis(BigInt(Date.UTC(1980, JAN, 1, 0, 0, 0, 0)))),
+          Second.fromMillis(BigInt(Date.UTC(1980, JAN, 1, 0, 0, 0, 0))))
+        assert.deepStrictEqual(converter.atomicToUnix(Second.fromMillis(BigInt(Date.UTC(1980, JAN, 1, 0, 0, 0, 1)))),
+          Second.fromMillis(BigInt(Date.UTC(1980, JAN, 1, 0, 0, 0, 0))))
 
         // STALL ENDS
-        assert.deepStrictEqual(converter.atomicToUnix(Second.fromMillis(Date.UTC(1980, JAN, 1, 0, 0, 0, 999))),
-          Second.fromMillis(Date.UTC(1980, JAN, 1, 0, 0, 0, 0)))
-        assert.deepStrictEqual(converter.atomicToUnix(Second.fromMillis(Date.UTC(1980, JAN, 1, 0, 0, 1, 0))),
-          Second.fromMillis(Date.UTC(1980, JAN, 1, 0, 0, 0, 0)))
-        assert.deepStrictEqual(converter.atomicToUnix(Second.fromMillis(Date.UTC(1980, JAN, 1, 0, 0, 1, 1))),
-          Second.fromMillis(Date.UTC(1980, JAN, 1, 0, 0, 0, 1)))
+        assert.deepStrictEqual(converter.atomicToUnix(Second.fromMillis(BigInt(Date.UTC(1980, JAN, 1, 0, 0, 0, 999)))),
+          Second.fromMillis(BigInt(Date.UTC(1980, JAN, 1, 0, 0, 0, 0))))
+        assert.deepStrictEqual(converter.atomicToUnix(Second.fromMillis(BigInt(Date.UTC(1980, JAN, 1, 0, 0, 1, 0)))),
+          Second.fromMillis(BigInt(Date.UTC(1980, JAN, 1, 0, 0, 0, 0))))
+        assert.deepStrictEqual(converter.atomicToUnix(Second.fromMillis(BigInt(Date.UTC(1980, JAN, 1, 0, 0, 1, 1)))),
+          Second.fromMillis(BigInt(Date.UTC(1980, JAN, 1, 0, 0, 0, 1))))
       })
     })
 
@@ -252,69 +252,69 @@ describe('Converter', () => {
       const converter = new Converter(data, MODELS.SMEAR)
 
       it('unixToAtomic', () => {
-        assert.deepStrictEqual(converter.unixToAtomic(Second.fromMillis(0)),
+        assert.deepStrictEqual(converter.unixToAtomic(Second.fromMillis(0n)),
           [
-            new Range(Second.fromMillis(0))
+            new Range(Second.fromMillis(0n))
           ])
 
         // SMEAR STARTS, ATOMIC TIME "RUNS A LITTLE FASTER" THAN UNIX (actually Unix is slower)
-        assert.deepStrictEqual(converter.unixToAtomic(Second.fromMillis(Date.UTC(1979, DEC, 31, 11, 59, 59, 999))),
+        assert.deepStrictEqual(converter.unixToAtomic(Second.fromMillis(BigInt(Date.UTC(1979, DEC, 31, 11, 59, 59, 999)))),
           [
-            new Range(Second.fromMillis(Date.UTC(1979, DEC, 31, 11, 59, 59, 999)))
+            new Range(Second.fromMillis(BigInt(Date.UTC(1979, DEC, 31, 11, 59, 59, 999))))
           ])
-        assert.deepStrictEqual(converter.unixToAtomic(Second.fromMillis(Date.UTC(1979, DEC, 31, 12, 0, 0, 0))),
+        assert.deepStrictEqual(converter.unixToAtomic(Second.fromMillis(BigInt(Date.UTC(1979, DEC, 31, 12, 0, 0, 0)))),
           [
-            new Range(Second.fromMillis(Date.UTC(1979, DEC, 31, 12, 0, 0, 0)))
+            new Range(Second.fromMillis(BigInt(Date.UTC(1979, DEC, 31, 12, 0, 0, 0))))
           ])
-        assert.deepStrictEqual(converter.unixToAtomic(Second.fromMillis(Date.UTC(1979, DEC, 31, 12, 0, 0, 1))),
+        assert.deepStrictEqual(converter.unixToAtomic(Second.fromMillis(BigInt(Date.UTC(1979, DEC, 31, 12, 0, 0, 1)))),
           [
-            new Range(Second.fromMillis(Date.UTC(1979, DEC, 31, 12, 0, 0, 1)).plusS(new Second(new Rat(1n, 86_400_000n))))
+            new Range(Second.fromMillis(BigInt(Date.UTC(1979, DEC, 31, 12, 0, 0, 1))).plusS(new Second(new Rat(1n, 86_400_000n))))
           ])
 
         // SMEAR MIDPOINT
-        assert.deepStrictEqual(converter.unixToAtomic(Second.fromMillis(Date.UTC(1980, JAN, 1, 0, 0, 0, 0))),
+        assert.deepStrictEqual(converter.unixToAtomic(Second.fromMillis(BigInt(Date.UTC(1980, JAN, 1, 0, 0, 0, 0)))),
           [
-            new Range(Second.fromMillis(Date.UTC(1980, JAN, 1, 0, 0, 0, 500)))
+            new Range(Second.fromMillis(BigInt(Date.UTC(1980, JAN, 1, 0, 0, 0, 500))))
           ])
 
         // SMEAR ENDS, ATOMIC IS A FULL SECOND AHEAD (actually Unix is a full second behind)
-        assert.deepStrictEqual(converter.unixToAtomic(Second.fromMillis(Date.UTC(1980, JAN, 1, 11, 59, 59, 999))),
+        assert.deepStrictEqual(converter.unixToAtomic(Second.fromMillis(BigInt(Date.UTC(1980, JAN, 1, 11, 59, 59, 999)))),
           [
-            new Range(Second.fromMillis(Date.UTC(1980, JAN, 1, 11, 59, 59, 999)).plusS(new Second(new Rat(86_399_999n, 86_400_000n))))
+            new Range(Second.fromMillis(BigInt(Date.UTC(1980, JAN, 1, 11, 59, 59, 999))).plusS(new Second(new Rat(86_399_999n, 86_400_000n))))
           ])
-        assert.deepStrictEqual(converter.unixToAtomic(Second.fromMillis(Date.UTC(1980, JAN, 1, 12, 0, 0, 0))),
+        assert.deepStrictEqual(converter.unixToAtomic(Second.fromMillis(BigInt(Date.UTC(1980, JAN, 1, 12, 0, 0, 0)))),
           [
-            new Range(Second.fromMillis(Date.UTC(1980, JAN, 1, 12, 0, 1, 0)))
+            new Range(Second.fromMillis(BigInt(Date.UTC(1980, JAN, 1, 12, 0, 1, 0))))
           ])
-        assert.deepStrictEqual(converter.unixToAtomic(Second.fromMillis(Date.UTC(1980, JAN, 1, 12, 0, 0, 1))),
+        assert.deepStrictEqual(converter.unixToAtomic(Second.fromMillis(BigInt(Date.UTC(1980, JAN, 1, 12, 0, 0, 1)))),
           [
-            new Range(Second.fromMillis(Date.UTC(1980, JAN, 1, 12, 0, 1, 1)))
+            new Range(Second.fromMillis(BigInt(Date.UTC(1980, JAN, 1, 12, 0, 1, 1))))
           ])
       })
 
       it('atomicToUnix', () => {
-        assert.deepStrictEqual(converter.atomicToUnix(Second.fromMillis(0)),
-          Second.fromMillis(0))
+        assert.deepStrictEqual(converter.atomicToUnix(Second.fromMillis(0n)),
+          Second.fromMillis(0n))
 
         // SMEAR STARTS, UNIX TIME RUNS A LITTLE SLOWER THAN ATOMIC
-        assert.deepStrictEqual(converter.atomicToUnix(Second.fromMillis(Date.UTC(1979, DEC, 31, 11, 59, 59, 999))),
-          Second.fromMillis(Date.UTC(1979, DEC, 31, 11, 59, 59, 999)))
-        assert.deepStrictEqual(converter.atomicToUnix(Second.fromMillis(Date.UTC(1979, DEC, 31, 12, 0, 0, 0))),
-          Second.fromMillis(Date.UTC(1979, DEC, 31, 12, 0, 0, 0)))
-        assert.deepStrictEqual(converter.atomicToUnix(Second.fromMillis(Date.UTC(1979, DEC, 31, 12, 0, 0, 1))),
-          Second.fromMillis(Date.UTC(1979, DEC, 31, 12, 0, 0, 1)).minusS(new Second(new Rat(1n, 86_401_000n))))
+        assert.deepStrictEqual(converter.atomicToUnix(Second.fromMillis(BigInt(Date.UTC(1979, DEC, 31, 11, 59, 59, 999)))),
+          Second.fromMillis(BigInt(Date.UTC(1979, DEC, 31, 11, 59, 59, 999))))
+        assert.deepStrictEqual(converter.atomicToUnix(Second.fromMillis(BigInt(Date.UTC(1979, DEC, 31, 12, 0, 0, 0)))),
+          Second.fromMillis(BigInt(Date.UTC(1979, DEC, 31, 12, 0, 0, 0))))
+        assert.deepStrictEqual(converter.atomicToUnix(Second.fromMillis(BigInt(Date.UTC(1979, DEC, 31, 12, 0, 0, 1)))),
+          Second.fromMillis(BigInt(Date.UTC(1979, DEC, 31, 12, 0, 0, 1))).minusS(new Second(new Rat(1n, 86_401_000n))))
 
         // SMEAR MIDPOINT
-        assert.deepStrictEqual(converter.atomicToUnix(Second.fromMillis(Date.UTC(1980, JAN, 1, 0, 0, 0, 500))),
-          Second.fromMillis(Date.UTC(1980, JAN, 1, 0, 0, 0, 0)))
+        assert.deepStrictEqual(converter.atomicToUnix(Second.fromMillis(BigInt(Date.UTC(1980, JAN, 1, 0, 0, 0, 500)))),
+          Second.fromMillis(BigInt(Date.UTC(1980, JAN, 1, 0, 0, 0, 0))))
 
         // SMEAR ENDS, UNIX HAS DROPPED A FULL SECOND BEHIND
-        assert.deepStrictEqual(converter.atomicToUnix(Second.fromMillis(Date.UTC(1980, JAN, 1, 12, 0, 0, 999))),
-          Second.fromMillis(Date.UTC(1980, JAN, 1, 12, 0, 0, 999)).minusS(new Second(new Rat(86_400_999n, 86_401_000n))))
-        assert.deepStrictEqual(converter.atomicToUnix(Second.fromMillis(Date.UTC(1980, JAN, 1, 12, 0, 1, 0))),
-          Second.fromMillis(Date.UTC(1980, JAN, 1, 12, 0, 0, 0)))
-        assert.deepStrictEqual(converter.atomicToUnix(Second.fromMillis(Date.UTC(1980, JAN, 1, 12, 0, 1, 1))),
-          Second.fromMillis(Date.UTC(1980, JAN, 1, 12, 0, 0, 1)))
+        assert.deepStrictEqual(converter.atomicToUnix(Second.fromMillis(BigInt(Date.UTC(1980, JAN, 1, 12, 0, 0, 999)))),
+          Second.fromMillis(BigInt(Date.UTC(1980, JAN, 1, 12, 0, 0, 999))).minusS(new Second(new Rat(86_400_999n, 86_401_000n))))
+        assert.deepStrictEqual(converter.atomicToUnix(Second.fromMillis(BigInt(Date.UTC(1980, JAN, 1, 12, 0, 1, 0)))),
+          Second.fromMillis(BigInt(Date.UTC(1980, JAN, 1, 12, 0, 0, 0))))
+        assert.deepStrictEqual(converter.atomicToUnix(Second.fromMillis(BigInt(Date.UTC(1980, JAN, 1, 12, 0, 1, 1)))),
+          Second.fromMillis(BigInt(Date.UTC(1980, JAN, 1, 12, 0, 0, 1))))
       })
     })
   })
@@ -329,45 +329,45 @@ describe('Converter', () => {
       const converter = new Converter(data, MODELS.OVERRUN)
 
       it('unixToAtomic', () => {
-        assert.deepStrictEqual(converter.unixToAtomic(Second.fromMillis(0)),
+        assert.deepStrictEqual(converter.unixToAtomic(Second.fromMillis(0n)),
           [
-            new Range(Second.fromMillis(0))
+            new Range(Second.fromMillis(0n))
           ])
 
         // START OF MISSING TIME
-        assert.deepStrictEqual(converter.unixToAtomic(Second.fromMillis(Date.UTC(1979, DEC, 31, 23, 59, 58, 999))),
+        assert.deepStrictEqual(converter.unixToAtomic(Second.fromMillis(BigInt(Date.UTC(1979, DEC, 31, 23, 59, 58, 999)))),
           [
-            new Range(Second.fromMillis(Date.UTC(1979, DEC, 31, 23, 59, 58, 999)))
+            new Range(Second.fromMillis(BigInt(Date.UTC(1979, DEC, 31, 23, 59, 58, 999))))
           ])
-        assert.deepStrictEqual(converter.unixToAtomic(Second.fromMillis(Date.UTC(1979, DEC, 31, 23, 59, 59, 0))),
+        assert.deepStrictEqual(converter.unixToAtomic(Second.fromMillis(BigInt(Date.UTC(1979, DEC, 31, 23, 59, 59, 0)))),
           [])
-        assert.deepStrictEqual(converter.unixToAtomic(Second.fromMillis(Date.UTC(1979, DEC, 31, 23, 59, 59, 1))),
+        assert.deepStrictEqual(converter.unixToAtomic(Second.fromMillis(BigInt(Date.UTC(1979, DEC, 31, 23, 59, 59, 1)))),
           [])
 
         // END OF MISSING TIME
-        assert.deepStrictEqual(converter.unixToAtomic(Second.fromMillis(Date.UTC(1979, DEC, 31, 23, 59, 59, 999))),
+        assert.deepStrictEqual(converter.unixToAtomic(Second.fromMillis(BigInt(Date.UTC(1979, DEC, 31, 23, 59, 59, 999)))),
           [])
-        assert.deepStrictEqual(converter.unixToAtomic(Second.fromMillis(Date.UTC(1980, JAN, 1, 0, 0, 0, 0))),
+        assert.deepStrictEqual(converter.unixToAtomic(Second.fromMillis(BigInt(Date.UTC(1980, JAN, 1, 0, 0, 0, 0)))),
           [
-            new Range(Second.fromMillis(Date.UTC(1979, DEC, 31, 23, 59, 59, 0)))
+            new Range(Second.fromMillis(BigInt(Date.UTC(1979, DEC, 31, 23, 59, 59, 0))))
           ])
-        assert.deepStrictEqual(converter.unixToAtomic(Second.fromMillis(Date.UTC(1980, JAN, 1, 0, 0, 0, 1))),
+        assert.deepStrictEqual(converter.unixToAtomic(Second.fromMillis(BigInt(Date.UTC(1980, JAN, 1, 0, 0, 0, 1)))),
           [
-            new Range(Second.fromMillis(Date.UTC(1979, DEC, 31, 23, 59, 59, 1)))
+            new Range(Second.fromMillis(BigInt(Date.UTC(1979, DEC, 31, 23, 59, 59, 1))))
           ])
       })
 
       it('atomicToUnix', () => {
-        assert.deepStrictEqual(converter.atomicToUnix(Second.fromMillis(0)),
-          Second.fromMillis(0))
+        assert.deepStrictEqual(converter.atomicToUnix(Second.fromMillis(0n)),
+          Second.fromMillis(0n))
 
         // JUMP AHEAD
-        assert.deepStrictEqual(converter.atomicToUnix(Second.fromMillis(Date.UTC(1979, DEC, 31, 23, 59, 58, 999))),
-          Second.fromMillis(Date.UTC(1979, DEC, 31, 23, 59, 58, 999)))
-        assert.deepStrictEqual(converter.atomicToUnix(Second.fromMillis(Date.UTC(1979, DEC, 31, 23, 59, 59, 0))),
-          Second.fromMillis(Date.UTC(1980, JAN, 1, 0, 0, 0, 0)))
-        assert.deepStrictEqual(converter.atomicToUnix(Second.fromMillis(Date.UTC(1979, DEC, 31, 23, 59, 59, 1))),
-          Second.fromMillis(Date.UTC(1980, JAN, 1, 0, 0, 0, 1)))
+        assert.deepStrictEqual(converter.atomicToUnix(Second.fromMillis(BigInt(Date.UTC(1979, DEC, 31, 23, 59, 58, 999)))),
+          Second.fromMillis(BigInt(Date.UTC(1979, DEC, 31, 23, 59, 58, 999))))
+        assert.deepStrictEqual(converter.atomicToUnix(Second.fromMillis(BigInt(Date.UTC(1979, DEC, 31, 23, 59, 59, 0)))),
+          Second.fromMillis(BigInt(Date.UTC(1980, JAN, 1, 0, 0, 0, 0))))
+        assert.deepStrictEqual(converter.atomicToUnix(Second.fromMillis(BigInt(Date.UTC(1979, DEC, 31, 23, 59, 59, 1)))),
+          Second.fromMillis(BigInt(Date.UTC(1980, JAN, 1, 0, 0, 0, 1))))
       })
     })
 
@@ -375,45 +375,45 @@ describe('Converter', () => {
       const converter = new Converter(data, MODELS.BREAK)
 
       it('unixToAtomic', () => {
-        assert.deepStrictEqual(converter.unixToAtomic(Second.fromMillis(0)),
+        assert.deepStrictEqual(converter.unixToAtomic(Second.fromMillis(0n)),
           [
-            new Range(Second.fromMillis(0))
+            new Range(Second.fromMillis(0n))
           ])
 
         // START OF MISSING TIME
-        assert.deepStrictEqual(converter.unixToAtomic(Second.fromMillis(Date.UTC(1979, DEC, 31, 23, 59, 58, 999))),
+        assert.deepStrictEqual(converter.unixToAtomic(Second.fromMillis(BigInt(Date.UTC(1979, DEC, 31, 23, 59, 58, 999)))),
           [
-            new Range(Second.fromMillis(Date.UTC(1979, DEC, 31, 23, 59, 58, 999)))
+            new Range(Second.fromMillis(BigInt(Date.UTC(1979, DEC, 31, 23, 59, 58, 999))))
           ])
-        assert.deepStrictEqual(converter.unixToAtomic(Second.fromMillis(Date.UTC(1979, DEC, 31, 23, 59, 59, 0))),
+        assert.deepStrictEqual(converter.unixToAtomic(Second.fromMillis(BigInt(Date.UTC(1979, DEC, 31, 23, 59, 59, 0)))),
           [])
-        assert.deepStrictEqual(converter.unixToAtomic(Second.fromMillis(Date.UTC(1979, DEC, 31, 23, 59, 59, 1))),
+        assert.deepStrictEqual(converter.unixToAtomic(Second.fromMillis(BigInt(Date.UTC(1979, DEC, 31, 23, 59, 59, 1)))),
           [])
 
         // END OF MISSING TIME
-        assert.deepStrictEqual(converter.unixToAtomic(Second.fromMillis(Date.UTC(1979, DEC, 31, 23, 59, 59, 999))),
+        assert.deepStrictEqual(converter.unixToAtomic(Second.fromMillis(BigInt(Date.UTC(1979, DEC, 31, 23, 59, 59, 999)))),
           [])
-        assert.deepStrictEqual(converter.unixToAtomic(Second.fromMillis(Date.UTC(1980, JAN, 1, 0, 0, 0, 0))),
+        assert.deepStrictEqual(converter.unixToAtomic(Second.fromMillis(BigInt(Date.UTC(1980, JAN, 1, 0, 0, 0, 0)))),
           [
-            new Range(Second.fromMillis(Date.UTC(1979, DEC, 31, 23, 59, 59, 0)))
+            new Range(Second.fromMillis(BigInt(Date.UTC(1979, DEC, 31, 23, 59, 59, 0))))
           ])
-        assert.deepStrictEqual(converter.unixToAtomic(Second.fromMillis(Date.UTC(1980, JAN, 1, 0, 0, 0, 1))),
+        assert.deepStrictEqual(converter.unixToAtomic(Second.fromMillis(BigInt(Date.UTC(1980, JAN, 1, 0, 0, 0, 1)))),
           [
-            new Range(Second.fromMillis(Date.UTC(1979, DEC, 31, 23, 59, 59, 1)))
+            new Range(Second.fromMillis(BigInt(Date.UTC(1979, DEC, 31, 23, 59, 59, 1))))
           ])
       })
 
       it('atomicToUnix', () => {
-        assert.deepStrictEqual(converter.atomicToUnix(Second.fromMillis(0)),
-          Second.fromMillis(0))
+        assert.deepStrictEqual(converter.atomicToUnix(Second.fromMillis(0n)),
+          Second.fromMillis(0n))
 
         // JUMP AHEAD
-        assert.deepStrictEqual(converter.atomicToUnix(Second.fromMillis(Date.UTC(1979, DEC, 31, 23, 59, 58, 999))),
-          Second.fromMillis(Date.UTC(1979, DEC, 31, 23, 59, 58, 999)))
-        assert.deepStrictEqual(converter.atomicToUnix(Second.fromMillis(Date.UTC(1979, DEC, 31, 23, 59, 59, 0))),
-          Second.fromMillis(Date.UTC(1980, JAN, 1, 0, 0, 0, 0)))
-        assert.deepStrictEqual(converter.atomicToUnix(Second.fromMillis(Date.UTC(1979, DEC, 31, 23, 59, 59, 1))),
-          Second.fromMillis(Date.UTC(1980, JAN, 1, 0, 0, 0, 1)))
+        assert.deepStrictEqual(converter.atomicToUnix(Second.fromMillis(BigInt(Date.UTC(1979, DEC, 31, 23, 59, 58, 999)))),
+          Second.fromMillis(BigInt(Date.UTC(1979, DEC, 31, 23, 59, 58, 999))))
+        assert.deepStrictEqual(converter.atomicToUnix(Second.fromMillis(BigInt(Date.UTC(1979, DEC, 31, 23, 59, 59, 0)))),
+          Second.fromMillis(BigInt(Date.UTC(1980, JAN, 1, 0, 0, 0, 0))))
+        assert.deepStrictEqual(converter.atomicToUnix(Second.fromMillis(BigInt(Date.UTC(1979, DEC, 31, 23, 59, 59, 1)))),
+          Second.fromMillis(BigInt(Date.UTC(1980, JAN, 1, 0, 0, 0, 1))))
       })
     })
 
@@ -421,45 +421,45 @@ describe('Converter', () => {
       const converter = new Converter(data, MODELS.STALL)
 
       it('unixToAtomic', () => {
-        assert.deepStrictEqual(converter.unixToAtomic(Second.fromMillis(0)),
+        assert.deepStrictEqual(converter.unixToAtomic(Second.fromMillis(0n)),
           [
-            new Range(Second.fromMillis(0))
+            new Range(Second.fromMillis(0n))
           ])
 
         // START OF MISSING TIME
-        assert.deepStrictEqual(converter.unixToAtomic(Second.fromMillis(Date.UTC(1979, DEC, 31, 23, 59, 58, 999))),
+        assert.deepStrictEqual(converter.unixToAtomic(Second.fromMillis(BigInt(Date.UTC(1979, DEC, 31, 23, 59, 58, 999)))),
           [
-            new Range(Second.fromMillis(Date.UTC(1979, DEC, 31, 23, 59, 58, 999)))
+            new Range(Second.fromMillis(BigInt(Date.UTC(1979, DEC, 31, 23, 59, 58, 999))))
           ])
-        assert.deepStrictEqual(converter.unixToAtomic(Second.fromMillis(Date.UTC(1979, DEC, 31, 23, 59, 59, 0))),
+        assert.deepStrictEqual(converter.unixToAtomic(Second.fromMillis(BigInt(Date.UTC(1979, DEC, 31, 23, 59, 59, 0)))),
           [])
-        assert.deepStrictEqual(converter.unixToAtomic(Second.fromMillis(Date.UTC(1979, DEC, 31, 23, 59, 59, 1))),
+        assert.deepStrictEqual(converter.unixToAtomic(Second.fromMillis(BigInt(Date.UTC(1979, DEC, 31, 23, 59, 59, 1)))),
           [])
 
         // END OF MISSING TIME
-        assert.deepStrictEqual(converter.unixToAtomic(Second.fromMillis(Date.UTC(1979, DEC, 31, 23, 59, 59, 999))),
+        assert.deepStrictEqual(converter.unixToAtomic(Second.fromMillis(BigInt(Date.UTC(1979, DEC, 31, 23, 59, 59, 999)))),
           [])
-        assert.deepStrictEqual(converter.unixToAtomic(Second.fromMillis(Date.UTC(1980, JAN, 1, 0, 0, 0, 0))),
+        assert.deepStrictEqual(converter.unixToAtomic(Second.fromMillis(BigInt(Date.UTC(1980, JAN, 1, 0, 0, 0, 0)))),
           [
-            new Range(Second.fromMillis(Date.UTC(1979, DEC, 31, 23, 59, 59, 0)))
+            new Range(Second.fromMillis(BigInt(Date.UTC(1979, DEC, 31, 23, 59, 59, 0))))
           ])
-        assert.deepStrictEqual(converter.unixToAtomic(Second.fromMillis(Date.UTC(1980, JAN, 1, 0, 0, 0, 1))),
+        assert.deepStrictEqual(converter.unixToAtomic(Second.fromMillis(BigInt(Date.UTC(1980, JAN, 1, 0, 0, 0, 1)))),
           [
-            new Range(Second.fromMillis(Date.UTC(1979, DEC, 31, 23, 59, 59, 1)))
+            new Range(Second.fromMillis(BigInt(Date.UTC(1979, DEC, 31, 23, 59, 59, 1))))
           ])
       })
 
       it('atomicToUnix', () => {
-        assert.deepStrictEqual(converter.atomicToUnix(Second.fromMillis(0)),
-          Second.fromMillis(0))
+        assert.deepStrictEqual(converter.atomicToUnix(Second.fromMillis(0n)),
+          Second.fromMillis(0n))
 
         // JUMP AHEAD
-        assert.deepStrictEqual(converter.atomicToUnix(Second.fromMillis(Date.UTC(1979, DEC, 31, 23, 59, 58, 999))),
-          Second.fromMillis(Date.UTC(1979, DEC, 31, 23, 59, 58, 999)))
-        assert.deepStrictEqual(converter.atomicToUnix(Second.fromMillis(Date.UTC(1979, DEC, 31, 23, 59, 59, 0))),
-          Second.fromMillis(Date.UTC(1980, JAN, 1, 0, 0, 0, 0)))
-        assert.deepStrictEqual(converter.atomicToUnix(Second.fromMillis(Date.UTC(1979, DEC, 31, 23, 59, 59, 1))),
-          Second.fromMillis(Date.UTC(1980, JAN, 1, 0, 0, 0, 1)))
+        assert.deepStrictEqual(converter.atomicToUnix(Second.fromMillis(BigInt(Date.UTC(1979, DEC, 31, 23, 59, 58, 999)))),
+          Second.fromMillis(BigInt(Date.UTC(1979, DEC, 31, 23, 59, 58, 999))))
+        assert.deepStrictEqual(converter.atomicToUnix(Second.fromMillis(BigInt(Date.UTC(1979, DEC, 31, 23, 59, 59, 0)))),
+          Second.fromMillis(BigInt(Date.UTC(1980, JAN, 1, 0, 0, 0, 0))))
+        assert.deepStrictEqual(converter.atomicToUnix(Second.fromMillis(BigInt(Date.UTC(1979, DEC, 31, 23, 59, 59, 1)))),
+          Second.fromMillis(BigInt(Date.UTC(1980, JAN, 1, 0, 0, 0, 1))))
       })
     })
 
@@ -467,69 +467,69 @@ describe('Converter', () => {
       const converter = new Converter(data, MODELS.SMEAR)
 
       it('unixToAtomic', () => {
-        assert.deepStrictEqual(converter.unixToAtomic(Second.fromMillis(0)),
+        assert.deepStrictEqual(converter.unixToAtomic(Second.fromMillis(0n)),
           [
-            new Range(Second.fromMillis(0))
+            new Range(Second.fromMillis(0n))
           ])
 
         // SMEAR STARTS, ATOMIC "RUNS A LITTLE SLOWER" THAN UNIX (actually Unix runs faster)
-        assert.deepStrictEqual(converter.unixToAtomic(Second.fromMillis(Date.UTC(1979, DEC, 31, 11, 59, 59, 999))),
+        assert.deepStrictEqual(converter.unixToAtomic(Second.fromMillis(BigInt(Date.UTC(1979, DEC, 31, 11, 59, 59, 999)))),
           [
-            new Range(Second.fromMillis(Date.UTC(1979, DEC, 31, 11, 59, 59, 999)))
+            new Range(Second.fromMillis(BigInt(Date.UTC(1979, DEC, 31, 11, 59, 59, 999))))
           ])
-        assert.deepStrictEqual(converter.unixToAtomic(Second.fromMillis(Date.UTC(1979, DEC, 31, 12, 0, 0, 0))),
+        assert.deepStrictEqual(converter.unixToAtomic(Second.fromMillis(BigInt(Date.UTC(1979, DEC, 31, 12, 0, 0, 0)))),
           [
-            new Range(Second.fromMillis(Date.UTC(1979, DEC, 31, 12, 0, 0, 0)))
+            new Range(Second.fromMillis(BigInt(Date.UTC(1979, DEC, 31, 12, 0, 0, 0))))
           ])
-        assert.deepStrictEqual(converter.unixToAtomic(Second.fromMillis(Date.UTC(1979, DEC, 31, 12, 0, 0, 1))),
+        assert.deepStrictEqual(converter.unixToAtomic(Second.fromMillis(BigInt(Date.UTC(1979, DEC, 31, 12, 0, 0, 1)))),
           [
-            new Range(Second.fromMillis(Date.UTC(1979, DEC, 31, 12, 0, 0, 1)).minusS(new Second(new Rat(1n, 86_400_000n))))
+            new Range(Second.fromMillis(BigInt(Date.UTC(1979, DEC, 31, 12, 0, 0, 1))).minusS(new Second(new Rat(1n, 86_400_000n))))
           ])
 
         // SMEAR MIDPOINT
-        assert.deepStrictEqual(converter.unixToAtomic(Second.fromMillis(Date.UTC(1980, JAN, 1, 0, 0, 0, 0))),
+        assert.deepStrictEqual(converter.unixToAtomic(Second.fromMillis(BigInt(Date.UTC(1980, JAN, 1, 0, 0, 0, 0)))),
           [
-            new Range(Second.fromMillis(Date.UTC(1979, DEC, 31, 23, 59, 59, 500)))
+            new Range(Second.fromMillis(BigInt(Date.UTC(1979, DEC, 31, 23, 59, 59, 500))))
           ])
 
         // SMEAR ENDS, ATOMIC IS A FULL SECOND BEHIND (actually Unix is a full second ahead)
-        assert.deepStrictEqual(converter.unixToAtomic(Second.fromMillis(Date.UTC(1980, JAN, 1, 11, 59, 59, 999))),
+        assert.deepStrictEqual(converter.unixToAtomic(Second.fromMillis(BigInt(Date.UTC(1980, JAN, 1, 11, 59, 59, 999)))),
           [
-            new Range(Second.fromMillis(Date.UTC(1980, JAN, 1, 11, 59, 59, 999)).minusS(new Second(new Rat(86_399_999n, 86_400_000n))))
+            new Range(Second.fromMillis(BigInt(Date.UTC(1980, JAN, 1, 11, 59, 59, 999))).minusS(new Second(new Rat(86_399_999n, 86_400_000n))))
           ])
-        assert.deepStrictEqual(converter.unixToAtomic(Second.fromMillis(Date.UTC(1980, JAN, 1, 12, 0, 0, 0))),
+        assert.deepStrictEqual(converter.unixToAtomic(Second.fromMillis(BigInt(Date.UTC(1980, JAN, 1, 12, 0, 0, 0)))),
           [
-            new Range(Second.fromMillis(Date.UTC(1980, JAN, 1, 11, 59, 59, 0)))
+            new Range(Second.fromMillis(BigInt(Date.UTC(1980, JAN, 1, 11, 59, 59, 0))))
           ])
-        assert.deepStrictEqual(converter.unixToAtomic(Second.fromMillis(Date.UTC(1980, JAN, 1, 12, 0, 0, 1))),
+        assert.deepStrictEqual(converter.unixToAtomic(Second.fromMillis(BigInt(Date.UTC(1980, JAN, 1, 12, 0, 0, 1)))),
           [
-            new Range(Second.fromMillis(Date.UTC(1980, JAN, 1, 11, 59, 59, 1)))
+            new Range(Second.fromMillis(BigInt(Date.UTC(1980, JAN, 1, 11, 59, 59, 1))))
           ])
       })
 
       it('atomicToUnix', () => {
-        assert.deepStrictEqual(converter.atomicToUnix(Second.fromMillis(0)),
-          Second.fromMillis(0))
+        assert.deepStrictEqual(converter.atomicToUnix(Second.fromMillis(0n)),
+          Second.fromMillis(0n))
 
         // SMEAR STARTS, UNIX TIME RUNS A LITTLE FASTER THAN ATOMIC
-        assert.deepStrictEqual(converter.atomicToUnix(Second.fromMillis(Date.UTC(1979, DEC, 31, 11, 59, 59, 999))),
-          Second.fromMillis(Date.UTC(1979, DEC, 31, 11, 59, 59, 999)))
-        assert.deepStrictEqual(converter.atomicToUnix(Second.fromMillis(Date.UTC(1979, DEC, 31, 12, 0, 0, 0))),
-          Second.fromMillis(Date.UTC(1979, DEC, 31, 12, 0, 0, 0)))
-        assert.deepStrictEqual(converter.atomicToUnix(Second.fromMillis(Date.UTC(1979, DEC, 31, 12, 0, 0, 1))),
-          Second.fromMillis(Date.UTC(1979, DEC, 31, 12, 0, 0, 1)).plusS(new Second(new Rat(1n, 86_399_000n))))
+        assert.deepStrictEqual(converter.atomicToUnix(Second.fromMillis(BigInt(Date.UTC(1979, DEC, 31, 11, 59, 59, 999)))),
+          Second.fromMillis(BigInt(Date.UTC(1979, DEC, 31, 11, 59, 59, 999))))
+        assert.deepStrictEqual(converter.atomicToUnix(Second.fromMillis(BigInt(Date.UTC(1979, DEC, 31, 12, 0, 0, 0)))),
+          Second.fromMillis(BigInt(Date.UTC(1979, DEC, 31, 12, 0, 0, 0))))
+        assert.deepStrictEqual(converter.atomicToUnix(Second.fromMillis(BigInt(Date.UTC(1979, DEC, 31, 12, 0, 0, 1)))),
+          Second.fromMillis(BigInt(Date.UTC(1979, DEC, 31, 12, 0, 0, 1))).plusS(new Second(new Rat(1n, 86_399_000n))))
 
         // SMEAR MIDPOINT
-        assert.deepStrictEqual(converter.atomicToUnix(Second.fromMillis(Date.UTC(1979, DEC, 31, 23, 59, 59, 500))),
-          Second.fromMillis(Date.UTC(1980, JAN, 1, 0, 0, 0, 0)))
+        assert.deepStrictEqual(converter.atomicToUnix(Second.fromMillis(BigInt(Date.UTC(1979, DEC, 31, 23, 59, 59, 500)))),
+          Second.fromMillis(BigInt(Date.UTC(1980, JAN, 1, 0, 0, 0, 0))))
 
         // SMEAR ENDS, UNIX HAS RUN A FULL SECOND FASTER THAN ATOMIC
-        assert.deepStrictEqual(converter.atomicToUnix(Second.fromMillis(Date.UTC(1980, JAN, 1, 11, 59, 58, 999))),
-          Second.fromMillis(Date.UTC(1980, JAN, 1, 11, 59, 58, 999)).plusS(new Second(new Rat(86_398_999n, 86_399_000n))))
-        assert.deepStrictEqual(converter.atomicToUnix(Second.fromMillis(Date.UTC(1980, JAN, 1, 11, 59, 59, 0))),
-          Second.fromMillis(Date.UTC(1980, JAN, 1, 12, 0, 0, 0)))
-        assert.deepStrictEqual(converter.atomicToUnix(Second.fromMillis(Date.UTC(1980, JAN, 1, 11, 59, 59, 1))),
-          Second.fromMillis(Date.UTC(1980, JAN, 1, 12, 0, 0, 1)))
+        assert.deepStrictEqual(converter.atomicToUnix(Second.fromMillis(BigInt(Date.UTC(1980, JAN, 1, 11, 59, 58, 999)))),
+          Second.fromMillis(BigInt(Date.UTC(1980, JAN, 1, 11, 59, 58, 999))).plusS(new Second(new Rat(86_398_999n, 86_399_000n))))
+        assert.deepStrictEqual(converter.atomicToUnix(Second.fromMillis(BigInt(Date.UTC(1980, JAN, 1, 11, 59, 59, 0)))),
+          Second.fromMillis(BigInt(Date.UTC(1980, JAN, 1, 12, 0, 0, 0))))
+        assert.deepStrictEqual(converter.atomicToUnix(Second.fromMillis(BigInt(Date.UTC(1980, JAN, 1, 11, 59, 59, 1)))),
+          Second.fromMillis(BigInt(Date.UTC(1980, JAN, 1, 12, 0, 0, 1))))
       })
     })
   })
@@ -542,12 +542,12 @@ describe('Converter', () => {
         ]
         const converter = new Converter(data, MODELS.OVERRUN)
 
-        assert.deepStrictEqual(converter.unixToAtomic(Second.fromMillis(1)),
+        assert.deepStrictEqual(converter.unixToAtomic(Second.fromMillis(1n)),
           [
             new Range(new Second(new Rat(900n, 1_000_000n)))
           ])
         assert.deepStrictEqual(converter.atomicToUnix(new Second(new Rat(900n, 1_000_000n))),
-          Second.fromMillis(1))
+          Second.fromMillis(1n))
       })
 
       it('at the end of the ray', () => {
@@ -557,12 +557,12 @@ describe('Converter', () => {
         ]
         const converter = new Converter(data, MODELS.OVERRUN)
 
-        assert.deepStrictEqual(converter.unixToAtomic(Second.fromMillis(-1)),
+        assert.deepStrictEqual(converter.unixToAtomic(Second.fromMillis(-1n)),
           [
             new Range(new Second(new Rat(-900n, 1_000_000n)))
           ])
         assert.deepStrictEqual(converter.atomicToUnix(new Second(new Rat(-900n, 1_000_000n))),
-          Second.fromMillis(-1))
+          Second.fromMillis(-1n))
       })
     })
   })
@@ -579,45 +579,45 @@ describe('Converter', () => {
         const converter = new Converter(data, MODELS.BREAK)
 
         it('unixToAtomic', () => {
-          assert.deepStrictEqual(converter.unixToAtomic(Second.fromMillis(0)),
+          assert.deepStrictEqual(converter.unixToAtomic(Second.fromMillis(0n)),
             [
-              new Range(Second.fromMillis(0))
+              new Range(Second.fromMillis(0n))
             ])
 
           // STALL POINT
-          assert.deepStrictEqual(converter.unixToAtomic(Second.fromMillis(999)),
+          assert.deepStrictEqual(converter.unixToAtomic(Second.fromMillis(999n)),
             [
-              new Range(Second.fromMillis(999))
+              new Range(Second.fromMillis(999n))
             ])
-          assert.deepStrictEqual(converter.unixToAtomic(Second.fromMillis(1000)),
+          assert.deepStrictEqual(converter.unixToAtomic(Second.fromMillis(1000n)),
             [
-              new Range(Second.fromMillis(3000))
+              new Range(Second.fromMillis(3000n))
             ])
-          assert.deepStrictEqual(converter.unixToAtomic(Second.fromMillis(1001)),
+          assert.deepStrictEqual(converter.unixToAtomic(Second.fromMillis(1001n)),
             [
-              new Range(Second.fromMillis(3001))
+              new Range(Second.fromMillis(3001n))
             ])
         })
 
         it('atomicToUnix', () => {
-          assert.deepStrictEqual(converter.atomicToUnix(Second.fromMillis(0)),
-            Second.fromMillis(0))
+          assert.deepStrictEqual(converter.atomicToUnix(Second.fromMillis(0n)),
+            Second.fromMillis(0n))
 
           // STALL STARTS
-          assert.deepStrictEqual(converter.atomicToUnix(Second.fromMillis(999)),
-            Second.fromMillis(999))
-          assert.strictEqual(converter.atomicToUnix(Second.fromMillis(1000)),
+          assert.deepStrictEqual(converter.atomicToUnix(Second.fromMillis(999n)),
+            Second.fromMillis(999n))
+          assert.strictEqual(converter.atomicToUnix(Second.fromMillis(1000n)),
             NaN)
-          assert.strictEqual(converter.atomicToUnix(Second.fromMillis(1001)),
+          assert.strictEqual(converter.atomicToUnix(Second.fromMillis(1001n)),
             NaN)
 
           // STALL ENDS
-          assert.strictEqual(converter.atomicToUnix(Second.fromMillis(2999)),
+          assert.strictEqual(converter.atomicToUnix(Second.fromMillis(2999n)),
             NaN)
-          assert.deepStrictEqual(converter.atomicToUnix(Second.fromMillis(3000)),
-            Second.fromMillis(1000))
-          assert.deepStrictEqual(converter.atomicToUnix(Second.fromMillis(3001)),
-            Second.fromMillis(1001))
+          assert.deepStrictEqual(converter.atomicToUnix(Second.fromMillis(3000n)),
+            Second.fromMillis(1000n))
+          assert.deepStrictEqual(converter.atomicToUnix(Second.fromMillis(3001n)),
+            Second.fromMillis(1001n))
         })
       })
 
@@ -625,45 +625,45 @@ describe('Converter', () => {
         const converter = new Converter(data, MODELS.STALL)
 
         it('unixToAtomic', () => {
-          assert.deepStrictEqual(converter.unixToAtomic(Second.fromMillis(0)),
+          assert.deepStrictEqual(converter.unixToAtomic(Second.fromMillis(0n)),
             [
-              new Range(Second.fromMillis(0))
+              new Range(Second.fromMillis(0n))
             ])
 
           // STALL POINT
-          assert.deepStrictEqual(converter.unixToAtomic(Second.fromMillis(999)),
+          assert.deepStrictEqual(converter.unixToAtomic(Second.fromMillis(999n)),
             [
-              new Range(Second.fromMillis(999))
+              new Range(Second.fromMillis(999n))
             ])
-          assert.deepStrictEqual(converter.unixToAtomic(Second.fromMillis(1000)),
+          assert.deepStrictEqual(converter.unixToAtomic(Second.fromMillis(1000n)),
             [
-              new Range(Second.fromMillis(1000), Second.fromMillis(3000))
+              new Range(Second.fromMillis(1000n), Second.fromMillis(3000n))
             ])
-          assert.deepStrictEqual(converter.unixToAtomic(Second.fromMillis(1001)),
+          assert.deepStrictEqual(converter.unixToAtomic(Second.fromMillis(1001n)),
             [
-              new Range(Second.fromMillis(3001))
+              new Range(Second.fromMillis(3001n))
             ])
         })
 
         it('atomicToUnix', () => {
-          assert.deepStrictEqual(converter.atomicToUnix(Second.fromMillis(0)),
-            Second.fromMillis(0))
+          assert.deepStrictEqual(converter.atomicToUnix(Second.fromMillis(0n)),
+            Second.fromMillis(0n))
 
           // STALL STARTS
-          assert.deepStrictEqual(converter.atomicToUnix(Second.fromMillis(999)),
-            Second.fromMillis(999))
-          assert.deepStrictEqual(converter.atomicToUnix(Second.fromMillis(1000)),
-            Second.fromMillis(1000))
-          assert.deepStrictEqual(converter.atomicToUnix(Second.fromMillis(1001)),
-            Second.fromMillis(1000))
+          assert.deepStrictEqual(converter.atomicToUnix(Second.fromMillis(999n)),
+            Second.fromMillis(999n))
+          assert.deepStrictEqual(converter.atomicToUnix(Second.fromMillis(1000n)),
+            Second.fromMillis(1000n))
+          assert.deepStrictEqual(converter.atomicToUnix(Second.fromMillis(1001n)),
+            Second.fromMillis(1000n))
 
           // STALL ENDS
-          assert.deepStrictEqual(converter.atomicToUnix(Second.fromMillis(2999)),
-            Second.fromMillis(1000))
-          assert.deepStrictEqual(converter.atomicToUnix(Second.fromMillis(3000)),
-            Second.fromMillis(1000))
-          assert.deepStrictEqual(converter.atomicToUnix(Second.fromMillis(3001)),
-            Second.fromMillis(1001))
+          assert.deepStrictEqual(converter.atomicToUnix(Second.fromMillis(2999n)),
+            Second.fromMillis(1000n))
+          assert.deepStrictEqual(converter.atomicToUnix(Second.fromMillis(3000n)),
+            Second.fromMillis(1000n))
+          assert.deepStrictEqual(converter.atomicToUnix(Second.fromMillis(3001n)),
+            Second.fromMillis(1001n))
         })
       })
     })

--- a/test/exact.spec.js
+++ b/test/exact.spec.js
@@ -8,6 +8,7 @@ const JAN = 0
 const FEB = 1
 const MAR = 2
 const APR = 3
+const JUN = 5
 const JUL = 6
 const AUG = 7
 const SEP = 8
@@ -25,6 +26,7 @@ describe('UNIX_END', () => {
     // https://hpiers.obspm.fr/iers/bul/bulc/BULLETINC.GUIDE.html
     const endDate = new Date(Number(UNIX_END.toMillis()))
 
+    assert([JUN, DEC].includes(endDate.getUTCMonth()))
     assert.strictEqual(endDate.getUTCDate(), 28)
     assert.strictEqual(endDate.getUTCHours(), 0)
     assert.strictEqual(endDate.getUTCMinutes(), 0)

--- a/test/exact.spec.js
+++ b/test/exact.spec.js
@@ -23,7 +23,7 @@ describe('UNIX_START', () => {
 describe('UNIX_END', () => {
   it('is at the limit of validity', () => {
     // https://hpiers.obspm.fr/iers/bul/bulc/BULLETINC.GUIDE.html
-    const endDate = new Date(UNIX_END.toMillis())
+    const endDate = new Date(Number(UNIX_END.toMillis()))
 
     assert.strictEqual(endDate.getUTCDate(), 28)
     assert.strictEqual(endDate.getUTCHours(), 0)

--- a/test/exact.spec.js
+++ b/test/exact.spec.js
@@ -16,7 +16,7 @@ const DEC = 11
 
 describe('UNIX_START', () => {
   it('is correct', () => {
-    assert.deepStrictEqual(UNIX_START, Second.fromMillis(Date.UTC(1961, JAN, 1)))
+    assert.deepStrictEqual(UNIX_START, Second.fromMillis(BigInt(Date.UTC(1961, JAN, 1))))
   })
 })
 
@@ -40,51 +40,51 @@ describe('TaiConverter', () => {
     describe('unixToAtomic', () => {
       it('starts TAI at 1961-01-01 00:00:01.422_818', () => {
         // 00:00:01.422_818 is in range, but rounds down to 00:00:01.422 which is not
-        assert.deepStrictEqual(taiConverter.unixToAtomic(Second.fromMillis(Date.UTC(1961, JAN, 1, 0, 0, 0, 0))),
+        assert.deepStrictEqual(taiConverter.unixToAtomic(Second.fromMillis(BigInt(Date.UTC(1961, JAN, 1, 0, 0, 0, 0)))),
           [
-            new Range(Second.fromMillis(Date.UTC(1961, JAN, 1, 0, 0, 1, 422)).plusS(new Second(new Rat(818_000_000n, 1_000_000_000_000n))))
+            new Range(Second.fromMillis(BigInt(Date.UTC(1961, JAN, 1, 0, 0, 1, 422))).plusS(new Second(new Rat(818_000_000n, 1_000_000_000_000n))))
           ])
       })
 
       it('advances 15 TAI picoseconds per Unix millisecond', () => {
-        assert.deepStrictEqual(taiConverter.unixToAtomic(Second.fromMillis(Date.UTC(1961, JAN, 1, 0, 0, 0, 1))),
+        assert.deepStrictEqual(taiConverter.unixToAtomic(Second.fromMillis(BigInt(Date.UTC(1961, JAN, 1, 0, 0, 0, 1)))),
           [
-            new Range(Second.fromMillis(Date.UTC(1961, JAN, 1, 0, 0, 1, 423)).plusS(new Second(new Rat(818_000_015n, 1_000_000_000_000n))))
+            new Range(Second.fromMillis(BigInt(Date.UTC(1961, JAN, 1, 0, 0, 1, 423))).plusS(new Second(new Rat(818_000_015n, 1_000_000_000_000n))))
           ])
-        assert.deepStrictEqual(taiConverter.unixToAtomic(Second.fromMillis(Date.UTC(1961, JAN, 1, 0, 0, 0, 2))),
+        assert.deepStrictEqual(taiConverter.unixToAtomic(Second.fromMillis(BigInt(Date.UTC(1961, JAN, 1, 0, 0, 0, 2)))),
           [
-            new Range(Second.fromMillis(Date.UTC(1961, JAN, 1, 0, 0, 1, 424)).plusS(new Second(new Rat(818_000_030n, 1_000_000_000_000n))))
+            new Range(Second.fromMillis(BigInt(Date.UTC(1961, JAN, 1, 0, 0, 1, 424))).plusS(new Second(new Rat(818_000_030n, 1_000_000_000_000n))))
           ])
-        assert.deepStrictEqual(taiConverter.unixToAtomic(Second.fromMillis(Date.UTC(1961, JAN, 1, 0, 0, 0, 3))),
+        assert.deepStrictEqual(taiConverter.unixToAtomic(Second.fromMillis(BigInt(Date.UTC(1961, JAN, 1, 0, 0, 0, 3)))),
           [
-            new Range(Second.fromMillis(Date.UTC(1961, JAN, 1, 0, 0, 1, 425)).plusS(new Second(new Rat(818_000_045n, 1_000_000_000_000n))))
+            new Range(Second.fromMillis(BigInt(Date.UTC(1961, JAN, 1, 0, 0, 1, 425))).plusS(new Second(new Rat(818_000_045n, 1_000_000_000_000n))))
           ])
       })
 
       it('advances 0.001_296 TAI seconds per Unix day', () => {
-        assert.deepStrictEqual(taiConverter.unixToAtomic(Second.fromMillis(Date.UTC(1961, JAN, 2, 0, 0, 0, 0))),
+        assert.deepStrictEqual(taiConverter.unixToAtomic(Second.fromMillis(BigInt(Date.UTC(1961, JAN, 2, 0, 0, 0, 0)))),
           [
-            new Range(Second.fromMillis(Date.UTC(1961, JAN, 2, 0, 0, 1, 424)).plusS(new Second(new Rat(114n, 1_000_000n))))
+            new Range(Second.fromMillis(BigInt(Date.UTC(1961, JAN, 2, 0, 0, 1, 424))).plusS(new Second(new Rat(114n, 1_000_000n))))
           ])
       })
 
       it('makes certain TAI millisecond counts inaccessible', () => {
-        assert.deepStrictEqual(taiConverter.unixToAtomic(Second.fromMillis(-283_984_666_668)),
+        assert.deepStrictEqual(taiConverter.unixToAtomic(Second.fromMillis(-283_984_666_668n)),
           [
             new Range(new Second(new Rat(-283_984_665_245_000_000_020n, 1_000_000_000_000n)))
           ])
-        assert.deepStrictEqual(taiConverter.unixToAtomic(Second.fromMillis(-283_984_666_667)),
+        assert.deepStrictEqual(taiConverter.unixToAtomic(Second.fromMillis(-283_984_666_667n)),
           [
             new Range(new Second(new Rat(-283_984_665_244_000_000_005n, 1_000_000_000_000n)))
           ])
 
         // it's not possible to get a result of -283_984_665_244_XXX_XXX_XXXn
 
-        assert.deepStrictEqual(taiConverter.unixToAtomic(Second.fromMillis(-283_984_666_666)),
+        assert.deepStrictEqual(taiConverter.unixToAtomic(Second.fromMillis(-283_984_666_666n)),
           [
             new Range(new Second(new Rat(-283_984_665_242_999_999_990n, 1_000_000_000_000n)))
           ])
-        assert.deepStrictEqual(taiConverter.unixToAtomic(Second.fromMillis(-283_984_666_665)),
+        assert.deepStrictEqual(taiConverter.unixToAtomic(Second.fromMillis(-283_984_666_665n)),
           [
             new Range(new Second(new Rat(-283_984_665_241_999_999_975n, 1_000_000_000_000n)))
           ])
@@ -93,84 +93,84 @@ describe('TaiConverter', () => {
 
     describe('atomicToUnix', () => {
       it('The NEW earliest instant in TAI', () => {
-        assert.strictEqual(taiConverter.atomicToUnix(Second.fromMillis(Date.UTC(1961, JAN, 1, 0, 0, 1, 422))),
+        assert.strictEqual(taiConverter.atomicToUnix(Second.fromMillis(BigInt(Date.UTC(1961, JAN, 1, 0, 0, 1, 422)))),
           NaN)
 
         // Actual start of TAI: 1961-01-01 00:00:01.422_818
-        assert.deepStrictEqual(taiConverter.atomicToUnix(Second.fromMillis(Date.UTC(1961, JAN, 1, 0, 0, 1, 422)).plusS(new Second(new Rat(818n, 1_000_000n)))),
-          Second.fromMillis(Date.UTC(1961, JAN, 1, 0, 0, 0, 0)))
+        assert.deepStrictEqual(taiConverter.atomicToUnix(Second.fromMillis(BigInt(Date.UTC(1961, JAN, 1, 0, 0, 1, 422))).plusS(new Second(new Rat(818n, 1_000_000n)))),
+          Second.fromMillis(BigInt(Date.UTC(1961, JAN, 1, 0, 0, 0, 0))))
       })
 
       it('start of 1972', () => {
         // After this point in time, conversions become far simpler and always integer numbers of milliseconds
-        assert.deepStrictEqual(taiConverter.atomicToUnix(Second.fromMillis(Date.UTC(1972, JAN, 1, 0, 0, 10, 0))),
-          Second.fromMillis(Date.UTC(1972, JAN, 1, 0, 0, 0, 0)))
-        assert.deepStrictEqual(taiConverter.atomicToUnix(Second.fromMillis(Date.UTC(1972, JAN, 1, 0, 0, 10, 1))),
-          Second.fromMillis(Date.UTC(1972, JAN, 1, 0, 0, 0, 1)))
+        assert.deepStrictEqual(taiConverter.atomicToUnix(Second.fromMillis(BigInt(Date.UTC(1972, JAN, 1, 0, 0, 10, 0)))),
+          Second.fromMillis(BigInt(Date.UTC(1972, JAN, 1, 0, 0, 0, 0))))
+        assert.deepStrictEqual(taiConverter.atomicToUnix(Second.fromMillis(BigInt(Date.UTC(1972, JAN, 1, 0, 0, 10, 1)))),
+          Second.fromMillis(BigInt(Date.UTC(1972, JAN, 1, 0, 0, 0, 1))))
       })
 
       it('typical', () => {
         // A typical leap second from the past, note backtracking
-        assert.deepStrictEqual(taiConverter.atomicToUnix(Second.fromMillis(Date.UTC(1999, JAN, 1, 0, 0, 31, 999))),
-          Second.fromMillis(Date.UTC(1999, JAN, 1, 0, 0, 0, 999)))
-        assert.deepStrictEqual(taiConverter.atomicToUnix(Second.fromMillis(Date.UTC(1999, JAN, 1, 0, 0, 32, 0))),
-          Second.fromMillis(Date.UTC(1999, JAN, 1, 0, 0, 0, 0)))
-        assert.deepStrictEqual(taiConverter.atomicToUnix(Second.fromMillis(Date.UTC(1999, JAN, 1, 0, 0, 32, 1))),
-          Second.fromMillis(Date.UTC(1999, JAN, 1, 0, 0, 0, 1)))
+        assert.deepStrictEqual(taiConverter.atomicToUnix(Second.fromMillis(BigInt(Date.UTC(1999, JAN, 1, 0, 0, 31, 999)))),
+          Second.fromMillis(BigInt(Date.UTC(1999, JAN, 1, 0, 0, 0, 999))))
+        assert.deepStrictEqual(taiConverter.atomicToUnix(Second.fromMillis(BigInt(Date.UTC(1999, JAN, 1, 0, 0, 32, 0)))),
+          Second.fromMillis(BigInt(Date.UTC(1999, JAN, 1, 0, 0, 0, 0))))
+        assert.deepStrictEqual(taiConverter.atomicToUnix(Second.fromMillis(BigInt(Date.UTC(1999, JAN, 1, 0, 0, 32, 1)))),
+          Second.fromMillis(BigInt(Date.UTC(1999, JAN, 1, 0, 0, 0, 1))))
       })
     })
 
     describe('TAI->Unix conversions', () => {
       it('now-ish', () => {
-        assert.deepStrictEqual(taiConverter.atomicToUnix(Second.fromMillis(Date.UTC(2016, OCT, 27, 20, 5, 50, 678))),
-          Second.fromMillis(Date.UTC(2016, OCT, 27, 20, 5, 14, 678)))
+        assert.deepStrictEqual(taiConverter.atomicToUnix(Second.fromMillis(BigInt(Date.UTC(2016, OCT, 27, 20, 5, 50, 678)))),
+          Second.fromMillis(BigInt(Date.UTC(2016, OCT, 27, 20, 5, 14, 678))))
       })
     })
 
     describe('Unix->TAI conversions', () => {
       it('The NEW earliest instant in TAI', () => {
-        assert.deepStrictEqual(taiConverter.unixToAtomic(Second.fromMillis(Date.UTC(1960, DEC, 31, 23, 59, 59, 999))),
+        assert.deepStrictEqual(taiConverter.unixToAtomic(Second.fromMillis(BigInt(Date.UTC(1960, DEC, 31, 23, 59, 59, 999)))),
           [])
       })
 
       it('icky', () => {
         // Fun fact! There is about 105 leap milliseconds here!
-        assert.deepStrictEqual(taiConverter.unixToAtomic(Second.fromMillis(Date.UTC(1972, JAN, 1, 0, 0, 0, 0))),
+        assert.deepStrictEqual(taiConverter.unixToAtomic(Second.fromMillis(BigInt(Date.UTC(1972, JAN, 1, 0, 0, 0, 0)))),
           [
-            new Range(Second.fromMillis(Date.UTC(1972, JAN, 1, 0, 0, 9, 892)).plusS(new Second(new Rat(242n, 1_000_000n)))),
-            new Range(Second.fromMillis(Date.UTC(1972, JAN, 1, 0, 0, 10, 0)))
+            new Range(Second.fromMillis(BigInt(Date.UTC(1972, JAN, 1, 0, 0, 9, 892))).plusS(new Second(new Rat(242n, 1_000_000n)))),
+            new Range(Second.fromMillis(BigInt(Date.UTC(1972, JAN, 1, 0, 0, 10, 0))))
           ])
       })
 
       it('typical', () => {
         // A typical leap second from the past, note repetition
-        assert.deepStrictEqual(taiConverter.unixToAtomic(Second.fromMillis(Date.UTC(1998, DEC, 31, 23, 59, 59, 999))),
+        assert.deepStrictEqual(taiConverter.unixToAtomic(Second.fromMillis(BigInt(Date.UTC(1998, DEC, 31, 23, 59, 59, 999)))),
           [
-            new Range(Second.fromMillis(Date.UTC(1999, JAN, 1, 0, 0, 30, 999)))
+            new Range(Second.fromMillis(BigInt(Date.UTC(1999, JAN, 1, 0, 0, 30, 999))))
           ])
-        assert.deepStrictEqual(taiConverter.unixToAtomic(Second.fromMillis(Date.UTC(1999, JAN, 1, 0, 0, 0, 0))),
+        assert.deepStrictEqual(taiConverter.unixToAtomic(Second.fromMillis(BigInt(Date.UTC(1999, JAN, 1, 0, 0, 0, 0)))),
           [
-            new Range(Second.fromMillis(Date.UTC(1999, JAN, 1, 0, 0, 31, 0))),
-            new Range(Second.fromMillis(Date.UTC(1999, JAN, 1, 0, 0, 32, 0)))
+            new Range(Second.fromMillis(BigInt(Date.UTC(1999, JAN, 1, 0, 0, 31, 0)))),
+            new Range(Second.fromMillis(BigInt(Date.UTC(1999, JAN, 1, 0, 0, 32, 0))))
           ])
-        assert.deepStrictEqual(taiConverter.unixToAtomic(Second.fromMillis(Date.UTC(1999, JAN, 1, 0, 0, 0, 1))),
+        assert.deepStrictEqual(taiConverter.unixToAtomic(Second.fromMillis(BigInt(Date.UTC(1999, JAN, 1, 0, 0, 0, 1)))),
           [
-            new Range(Second.fromMillis(Date.UTC(1999, JAN, 1, 0, 0, 31, 1))),
-            new Range(Second.fromMillis(Date.UTC(1999, JAN, 1, 0, 0, 32, 1)))
+            new Range(Second.fromMillis(BigInt(Date.UTC(1999, JAN, 1, 0, 0, 31, 1)))),
+            new Range(Second.fromMillis(BigInt(Date.UTC(1999, JAN, 1, 0, 0, 32, 1))))
           ])
 
-        assert.deepStrictEqual(taiConverter.unixToAtomic(Second.fromMillis(Date.UTC(1999, JAN, 1, 0, 0, 0, 999))),
+        assert.deepStrictEqual(taiConverter.unixToAtomic(Second.fromMillis(BigInt(Date.UTC(1999, JAN, 1, 0, 0, 0, 999)))),
           [
-            new Range(Second.fromMillis(Date.UTC(1999, JAN, 1, 0, 0, 31, 999))),
-            new Range(Second.fromMillis(Date.UTC(1999, JAN, 1, 0, 0, 32, 999)))
+            new Range(Second.fromMillis(BigInt(Date.UTC(1999, JAN, 1, 0, 0, 31, 999)))),
+            new Range(Second.fromMillis(BigInt(Date.UTC(1999, JAN, 1, 0, 0, 32, 999))))
           ])
-        assert.deepStrictEqual(taiConverter.unixToAtomic(Second.fromMillis(Date.UTC(1999, JAN, 1, 0, 0, 1, 0))),
+        assert.deepStrictEqual(taiConverter.unixToAtomic(Second.fromMillis(BigInt(Date.UTC(1999, JAN, 1, 0, 0, 1, 0)))),
           [
-            new Range(Second.fromMillis(Date.UTC(1999, JAN, 1, 0, 0, 33, 0)))
+            new Range(Second.fromMillis(BigInt(Date.UTC(1999, JAN, 1, 0, 0, 33, 0))))
           ])
-        assert.deepStrictEqual(taiConverter.unixToAtomic(Second.fromMillis(Date.UTC(1999, JAN, 1, 0, 0, 1, 1))),
+        assert.deepStrictEqual(taiConverter.unixToAtomic(Second.fromMillis(BigInt(Date.UTC(1999, JAN, 1, 0, 0, 1, 1)))),
           [
-            new Range(Second.fromMillis(Date.UTC(1999, JAN, 1, 0, 0, 33, 1)))
+            new Range(Second.fromMillis(BigInt(Date.UTC(1999, JAN, 1, 0, 0, 33, 1))))
           ])
       })
     })
@@ -180,15 +180,15 @@ describe('TaiConverter', () => {
 
       // Prior ray
       // TAI picosecond count rounds to -252_460_798_155 which is not in range
-      assert.deepStrictEqual(taiConverter.unixToAtomic(Second.fromMillis(Date.UTC(1961, DEC, 31, 23, 59, 59, 999))),
+      assert.deepStrictEqual(taiConverter.unixToAtomic(Second.fromMillis(BigInt(Date.UTC(1961, DEC, 31, 23, 59, 59, 999)))),
         [
           new Range(new Second(new Rat(-252_460_798_155_142_000_015n, 1_000_000_000_000n)))
         ])
-      assert.deepStrictEqual(taiConverter.unixToAtomic(Second.fromMillis(Date.UTC(1962, JAN, 1, 0, 0, 0, 0))),
+      assert.deepStrictEqual(taiConverter.unixToAtomic(Second.fromMillis(BigInt(Date.UTC(1962, JAN, 1, 0, 0, 0, 0)))),
         [
           new Range(new Second(new Rat(-252_460_798_154_142_000_000n, 1_000_000_000_000n)))
         ])
-      assert.deepStrictEqual(taiConverter.unixToAtomic(Second.fromMillis(Date.UTC(1962, JAN, 1, 0, 0, 0, 1))),
+      assert.deepStrictEqual(taiConverter.unixToAtomic(Second.fromMillis(BigInt(Date.UTC(1962, JAN, 1, 0, 0, 0, 1)))),
         [
           new Range(new Second(new Rat(-252_460_798_153_141_999_987n, 1_000_000_000_000n)))
         ])
@@ -197,7 +197,7 @@ describe('TaiConverter', () => {
     it('inserted tenth', () => {
       // Oh look, an inserted leap tenth of a second!
       // The period between 1965-09-01 00:00:00 and 00:00:00.100 UTC happened twice!
-      assert.deepStrictEqual(taiConverter.unixToAtomic(Second.fromMillis(Date.UTC(1965, SEP, 1, 0, 0, 0, 50))),
+      assert.deepStrictEqual(taiConverter.unixToAtomic(Second.fromMillis(BigInt(Date.UTC(1965, SEP, 1, 0, 0, 0, 50)))),
         [
           new Range(new Second(new Rat(-136_771_195_894_941_999_250n, 1_000_000_000_000n))),
           new Range(new Second(new Rat(-136_771_195_794_941_999_250n, 1_000_000_000_000n)))
@@ -208,24 +208,24 @@ describe('TaiConverter', () => {
       // Hey, what! A removed leap twentieth of a second???
       // Well, technically, that's 1/20th of a TAI second, which is SLIGHTLY LESS than 1/20th of a UTC second
       // Which means that 23:59:59.950 UTC *does* actually exist...
-      assert.deepStrictEqual(taiConverter.unixToAtomic(Second.fromMillis(Date.UTC(1961, JUL, 31, 23, 59, 59, 949))),
+      assert.deepStrictEqual(taiConverter.unixToAtomic(Second.fromMillis(BigInt(Date.UTC(1961, JUL, 31, 23, 59, 59, 949)))),
         [
           new Range(new Second(new Rat(-265_679_998_353_430_000_765n, 1_000_000_000_000n)))
         ])
-      assert.deepStrictEqual(taiConverter.unixToAtomic(Second.fromMillis(Date.UTC(1961, JUL, 31, 23, 59, 59, 950))),
+      assert.deepStrictEqual(taiConverter.unixToAtomic(Second.fromMillis(BigInt(Date.UTC(1961, JUL, 31, 23, 59, 59, 950)))),
         [
           new Range(new Second(new Rat(-265_679_998_352_430_000_750n, 1_000_000_000_000n)))
         ])
-      assert.deepStrictEqual(taiConverter.unixToAtomic(Second.fromMillis(Date.UTC(1961, JUL, 31, 23, 59, 59, 951))),
+      assert.deepStrictEqual(taiConverter.unixToAtomic(Second.fromMillis(BigInt(Date.UTC(1961, JUL, 31, 23, 59, 59, 951)))),
         [])
 
-      assert.deepStrictEqual(taiConverter.unixToAtomic(Second.fromMillis(Date.UTC(1961, JUL, 31, 23, 59, 59, 999))),
+      assert.deepStrictEqual(taiConverter.unixToAtomic(Second.fromMillis(BigInt(Date.UTC(1961, JUL, 31, 23, 59, 59, 999)))),
         [])
-      assert.deepStrictEqual(taiConverter.unixToAtomic(Second.fromMillis(Date.UTC(1961, AUG, 1, 0, 0, 0, 0))),
+      assert.deepStrictEqual(taiConverter.unixToAtomic(Second.fromMillis(BigInt(Date.UTC(1961, AUG, 1, 0, 0, 0, 0)))),
         [
           new Range(new Second(new Rat(-265_679_998_352_430_000_000n, 1_000_000_000_000n)))
         ])
-      assert.deepStrictEqual(taiConverter.unixToAtomic(Second.fromMillis(Date.UTC(1961, AUG, 1, 0, 0, 0, 1))),
+      assert.deepStrictEqual(taiConverter.unixToAtomic(Second.fromMillis(BigInt(Date.UTC(1961, AUG, 1, 0, 0, 0, 1)))),
         [
           new Range(new Second(new Rat(-265_679_998_351_429_999_985n, 1_000_000_000_000n)))
         ])
@@ -234,158 +234,158 @@ describe('TaiConverter', () => {
     it('boundaries', () => {
       // Let's check out some boundaries where the relationship between TAI and UTC changed
       // 1 January 1962: Perfect continuity (although the drift rate changed)
-      assert.strictEqual(taiConverter.unixToAtomic(Second.fromMillis(Date.UTC(1961, DEC, 31, 23, 59, 59, 999))).length,
+      assert.strictEqual(taiConverter.unixToAtomic(Second.fromMillis(BigInt(Date.UTC(1961, DEC, 31, 23, 59, 59, 999)))).length,
         1)
-      assert.strictEqual(taiConverter.unixToAtomic(Second.fromMillis(Date.UTC(1962, JAN, 1, 0, 0, 0, 0))).length,
+      assert.strictEqual(taiConverter.unixToAtomic(Second.fromMillis(BigInt(Date.UTC(1962, JAN, 1, 0, 0, 0, 0)))).length,
         1)
-      assert.strictEqual(taiConverter.unixToAtomic(Second.fromMillis(Date.UTC(1962, JAN, 1, 0, 0, 0, 1))).length,
+      assert.strictEqual(taiConverter.unixToAtomic(Second.fromMillis(BigInt(Date.UTC(1962, JAN, 1, 0, 0, 0, 1)))).length,
         1)
 
       // 1 January 1964: Perfect continuity (drift rate changes)
-      assert.strictEqual(taiConverter.unixToAtomic(Second.fromMillis(Date.UTC(1963, DEC, 31, 23, 59, 59, 999))).length,
+      assert.strictEqual(taiConverter.unixToAtomic(Second.fromMillis(BigInt(Date.UTC(1963, DEC, 31, 23, 59, 59, 999)))).length,
         1)
-      assert.strictEqual(taiConverter.unixToAtomic(Second.fromMillis(Date.UTC(1964, JAN, 1, 0, 0, 0, 0))).length,
+      assert.strictEqual(taiConverter.unixToAtomic(Second.fromMillis(BigInt(Date.UTC(1964, JAN, 1, 0, 0, 0, 0)))).length,
         1)
-      assert.strictEqual(taiConverter.unixToAtomic(Second.fromMillis(Date.UTC(1964, JAN, 1, 0, 0, 0, 1))).length,
+      assert.strictEqual(taiConverter.unixToAtomic(Second.fromMillis(BigInt(Date.UTC(1964, JAN, 1, 0, 0, 0, 1)))).length,
         1)
 
       // 1 April 1964: 0.1 TAI seconds inserted
-      assert.strictEqual(taiConverter.unixToAtomic(Second.fromMillis(Date.UTC(1964, MAR, 31, 23, 59, 59, 999))).length,
+      assert.strictEqual(taiConverter.unixToAtomic(Second.fromMillis(BigInt(Date.UTC(1964, MAR, 31, 23, 59, 59, 999)))).length,
         1)
-      assert.strictEqual(taiConverter.unixToAtomic(Second.fromMillis(Date.UTC(1964, APR, 1, 0, 0, 0, 0))).length,
+      assert.strictEqual(taiConverter.unixToAtomic(Second.fromMillis(BigInt(Date.UTC(1964, APR, 1, 0, 0, 0, 0)))).length,
         2)
-      assert.strictEqual(taiConverter.unixToAtomic(Second.fromMillis(Date.UTC(1964, APR, 1, 0, 0, 0, 99))).length,
+      assert.strictEqual(taiConverter.unixToAtomic(Second.fromMillis(BigInt(Date.UTC(1964, APR, 1, 0, 0, 0, 99)))).length,
         2)
-      assert.strictEqual(taiConverter.unixToAtomic(Second.fromMillis(Date.UTC(1964, APR, 1, 0, 0, 0, 100))).length,
+      assert.strictEqual(taiConverter.unixToAtomic(Second.fromMillis(BigInt(Date.UTC(1964, APR, 1, 0, 0, 0, 100)))).length,
         1)
 
       // etc. (various occasions when 0.1 TAI seconds were inserted)
-      assert.strictEqual(taiConverter.unixToAtomic(Second.fromMillis(Date.UTC(1964, SEP, 1, 0, 0, 0, 99))).length,
+      assert.strictEqual(taiConverter.unixToAtomic(Second.fromMillis(BigInt(Date.UTC(1964, SEP, 1, 0, 0, 0, 99)))).length,
         2)
-      assert.strictEqual(taiConverter.unixToAtomic(Second.fromMillis(Date.UTC(1965, JAN, 1, 0, 0, 0, 99))).length,
+      assert.strictEqual(taiConverter.unixToAtomic(Second.fromMillis(BigInt(Date.UTC(1965, JAN, 1, 0, 0, 0, 99)))).length,
         2)
-      assert.strictEqual(taiConverter.unixToAtomic(Second.fromMillis(Date.UTC(1965, MAR, 1, 0, 0, 0, 99))).length,
+      assert.strictEqual(taiConverter.unixToAtomic(Second.fromMillis(BigInt(Date.UTC(1965, MAR, 1, 0, 0, 0, 99)))).length,
         2)
-      assert.strictEqual(taiConverter.unixToAtomic(Second.fromMillis(Date.UTC(1965, JUL, 1, 0, 0, 0, 99))).length,
+      assert.strictEqual(taiConverter.unixToAtomic(Second.fromMillis(BigInt(Date.UTC(1965, JUL, 1, 0, 0, 0, 99)))).length,
         2)
-      assert.strictEqual(taiConverter.unixToAtomic(Second.fromMillis(Date.UTC(1965, SEP, 1, 0, 0, 0, 99))).length,
+      assert.strictEqual(taiConverter.unixToAtomic(Second.fromMillis(BigInt(Date.UTC(1965, SEP, 1, 0, 0, 0, 99)))).length,
         2)
 
       // 1 January 1966: Perfect continuity (drift rate changes)
-      assert.strictEqual(taiConverter.unixToAtomic(Second.fromMillis(Date.UTC(1965, DEC, 31, 23, 59, 59, 999))).length,
+      assert.strictEqual(taiConverter.unixToAtomic(Second.fromMillis(BigInt(Date.UTC(1965, DEC, 31, 23, 59, 59, 999)))).length,
         1)
-      assert.strictEqual(taiConverter.unixToAtomic(Second.fromMillis(Date.UTC(1966, JAN, 1, 0, 0, 0, 0))).length,
+      assert.strictEqual(taiConverter.unixToAtomic(Second.fromMillis(BigInt(Date.UTC(1966, JAN, 1, 0, 0, 0, 0)))).length,
         1)
-      assert.strictEqual(taiConverter.unixToAtomic(Second.fromMillis(Date.UTC(1966, JAN, 1, 0, 0, 0, 1))).length,
+      assert.strictEqual(taiConverter.unixToAtomic(Second.fromMillis(BigInt(Date.UTC(1966, JAN, 1, 0, 0, 0, 1)))).length,
         1)
 
       // 1 February 1968: 0.1 TAI seconds removed
-      assert.strictEqual(taiConverter.unixToAtomic(Second.fromMillis(Date.UTC(1968, JAN, 31, 23, 59, 59, 899))).length,
+      assert.strictEqual(taiConverter.unixToAtomic(Second.fromMillis(BigInt(Date.UTC(1968, JAN, 31, 23, 59, 59, 899)))).length,
         1)
-      assert.deepStrictEqual(taiConverter.unixToAtomic(Second.fromMillis(Date.UTC(1968, JAN, 31, 23, 59, 59, 900))),
+      assert.deepStrictEqual(taiConverter.unixToAtomic(Second.fromMillis(BigInt(Date.UTC(1968, JAN, 31, 23, 59, 59, 900)))),
         [
           new Range(new Second(new Rat(-60_479_993_814_318_003n, 1_000_000_000n)))
         ])
 
-      assert.strictEqual(taiConverter.unixToAtomic(Second.fromMillis(Date.UTC(1968, JAN, 31, 23, 59, 59, 901))).length,
+      assert.strictEqual(taiConverter.unixToAtomic(Second.fromMillis(BigInt(Date.UTC(1968, JAN, 31, 23, 59, 59, 901)))).length,
         0)
-      assert.strictEqual(taiConverter.unixToAtomic(Second.fromMillis(Date.UTC(1968, JAN, 31, 23, 59, 59, 999))).length,
+      assert.strictEqual(taiConverter.unixToAtomic(Second.fromMillis(BigInt(Date.UTC(1968, JAN, 31, 23, 59, 59, 999)))).length,
         0)
-      assert.strictEqual(taiConverter.unixToAtomic(Second.fromMillis(Date.UTC(1968, FEB, 1, 0, 0, 0, 0))).length,
+      assert.strictEqual(taiConverter.unixToAtomic(Second.fromMillis(BigInt(Date.UTC(1968, FEB, 1, 0, 0, 0, 0)))).length,
         1)
 
       // 1 January 1972: 0.107_758 TAI seconds inserted
-      assert.strictEqual(taiConverter.unixToAtomic(Second.fromMillis(Date.UTC(1971, DEC, 31, 23, 59, 59, 999))).length,
+      assert.strictEqual(taiConverter.unixToAtomic(Second.fromMillis(BigInt(Date.UTC(1971, DEC, 31, 23, 59, 59, 999)))).length,
         1)
-      assert.strictEqual(taiConverter.unixToAtomic(Second.fromMillis(Date.UTC(1972, JAN, 1, 0, 0, 0, 0))).length,
+      assert.strictEqual(taiConverter.unixToAtomic(Second.fromMillis(BigInt(Date.UTC(1972, JAN, 1, 0, 0, 0, 0)))).length,
         2)
-      assert.strictEqual(taiConverter.unixToAtomic(Second.fromMillis(Date.UTC(1972, JAN, 1, 0, 0, 0, 107))).length,
+      assert.strictEqual(taiConverter.unixToAtomic(Second.fromMillis(BigInt(Date.UTC(1972, JAN, 1, 0, 0, 0, 107)))).length,
         2)
-      assert.strictEqual(taiConverter.unixToAtomic(Second.fromMillis(Date.UTC(1972, JAN, 1, 0, 0, 0, 108))).length,
+      assert.strictEqual(taiConverter.unixToAtomic(Second.fromMillis(BigInt(Date.UTC(1972, JAN, 1, 0, 0, 0, 108)))).length,
         1)
 
       // Removed time
-      assert.strictEqual(taiConverter.unixToAtomic(Second.fromMillis(-265_680_000_051)).length,
+      assert.strictEqual(taiConverter.unixToAtomic(Second.fromMillis(-265_680_000_051n)).length,
         1)
-      assert.strictEqual(taiConverter.unixToAtomic(Second.fromMillis(-265_680_000_050)).length,
+      assert.strictEqual(taiConverter.unixToAtomic(Second.fromMillis(-265_680_000_050n)).length,
         1)
-      assert.strictEqual(taiConverter.unixToAtomic(Second.fromMillis(-265_680_000_049)).length,
+      assert.strictEqual(taiConverter.unixToAtomic(Second.fromMillis(-265_680_000_049n)).length,
         0)
-      assert.strictEqual(taiConverter.unixToAtomic(Second.fromMillis(-265_680_000_048)).length,
+      assert.strictEqual(taiConverter.unixToAtomic(Second.fromMillis(-265_680_000_048n)).length,
         0)
 
-      assert.strictEqual(taiConverter.unixToAtomic(Second.fromMillis(-252_460_800_000)).length,
+      assert.strictEqual(taiConverter.unixToAtomic(Second.fromMillis(-252_460_800_000n)).length,
         1)
-      assert.strictEqual(taiConverter.unixToAtomic(Second.fromMillis(-194_659_199_900)).length,
+      assert.strictEqual(taiConverter.unixToAtomic(Second.fromMillis(-194_659_199_900n)).length,
         1)
-      assert.strictEqual(taiConverter.unixToAtomic(Second.fromMillis(-189_388_800_000)).length,
+      assert.strictEqual(taiConverter.unixToAtomic(Second.fromMillis(-189_388_800_000n)).length,
         1)
-      assert.strictEqual(taiConverter.unixToAtomic(Second.fromMillis(-181_526_399_900)).length,
+      assert.strictEqual(taiConverter.unixToAtomic(Second.fromMillis(-181_526_399_900n)).length,
         1)
-      assert.strictEqual(taiConverter.unixToAtomic(Second.fromMillis(-168_307_199_900)).length,
+      assert.strictEqual(taiConverter.unixToAtomic(Second.fromMillis(-168_307_199_900n)).length,
         1)
-      assert.strictEqual(taiConverter.unixToAtomic(Second.fromMillis(-157_766_399_900)).length,
+      assert.strictEqual(taiConverter.unixToAtomic(Second.fromMillis(-157_766_399_900n)).length,
         1)
-      assert.strictEqual(taiConverter.unixToAtomic(Second.fromMillis(-152_668_799_900)).length,
+      assert.strictEqual(taiConverter.unixToAtomic(Second.fromMillis(-152_668_799_900n)).length,
         1)
-      assert.strictEqual(taiConverter.unixToAtomic(Second.fromMillis(-142_127_999_900)).length,
+      assert.strictEqual(taiConverter.unixToAtomic(Second.fromMillis(-142_127_999_900n)).length,
         1)
-      assert.strictEqual(taiConverter.unixToAtomic(Second.fromMillis(-136_771_199_900)).length,
+      assert.strictEqual(taiConverter.unixToAtomic(Second.fromMillis(-136_771_199_900n)).length,
         1)
-      assert.strictEqual(taiConverter.unixToAtomic(Second.fromMillis(-126_230_400_000)).length,
+      assert.strictEqual(taiConverter.unixToAtomic(Second.fromMillis(-126_230_400_000n)).length,
         1)
 
       // Removed time
-      assert.strictEqual(taiConverter.unixToAtomic(Second.fromMillis(-60_480_000_101)).length,
+      assert.strictEqual(taiConverter.unixToAtomic(Second.fromMillis(-60_480_000_101n)).length,
         1)
-      assert.strictEqual(taiConverter.unixToAtomic(Second.fromMillis(-60_480_000_100)).length,
+      assert.strictEqual(taiConverter.unixToAtomic(Second.fromMillis(-60_480_000_100n)).length,
         1)
-      assert.strictEqual(taiConverter.unixToAtomic(Second.fromMillis(-60_480_000_099)).length,
+      assert.strictEqual(taiConverter.unixToAtomic(Second.fromMillis(-60_480_000_099n)).length,
         0)
-      assert.strictEqual(taiConverter.unixToAtomic(Second.fromMillis(-60_480_000_098)).length,
+      assert.strictEqual(taiConverter.unixToAtomic(Second.fromMillis(-60_480_000_098n)).length,
         0)
 
-      assert.strictEqual(taiConverter.unixToAtomic(Second.fromMillis(63_072_000_106)).length,
+      assert.strictEqual(taiConverter.unixToAtomic(Second.fromMillis(63_072_000_106n)).length,
         2)
-      assert.strictEqual(taiConverter.unixToAtomic(Second.fromMillis(63_072_000_107)).length,
+      assert.strictEqual(taiConverter.unixToAtomic(Second.fromMillis(63_072_000_107n)).length,
         2)
-      assert.strictEqual(taiConverter.unixToAtomic(Second.fromMillis(63_072_000_108)).length,
+      assert.strictEqual(taiConverter.unixToAtomic(Second.fromMillis(63_072_000_108n)).length,
         1)
-      assert.strictEqual(taiConverter.unixToAtomic(Second.fromMillis(63_072_000_109)).length,
+      assert.strictEqual(taiConverter.unixToAtomic(Second.fromMillis(63_072_000_109n)).length,
         1)
     })
 
     describe('TAI raw data conversion unit tests based on magic numbers', () => {
       it('taiConverter.unixToAtomic', () => {
         const pairs = [
-          [63_072_010_000, 63_072_020_000],
-          [78_796_811_000, 78_796_822_000],
-          [94_694_412_000, 94_694_424_000],
-          [126_230_413_000, 126_230_426_000],
-          [157_766_414_000, 157_766_428_000],
-          [189_302_415_000, 189_302_430_000],
-          [220_924_816_000, 220_924_832_000],
-          [252_460_817_000, 252_460_834_000],
-          [283_996_818_000, 283_996_836_000],
-          [315_532_819_000, 315_532_838_000],
-          [362_793_620_000, 362_793_640_000],
-          [394_329_621_000, 394_329_642_000],
-          [425_865_622_000, 425_865_644_000],
-          [489_024_023_000, 489_024_046_000],
-          [567_993_624_000, 567_993_648_000],
-          [631_152_025_000, 631_152_050_000],
-          [662_688_026_000, 662_688_052_000],
-          [709_948_827_000, 709_948_854_000],
-          [741_484_828_000, 741_484_856_000],
-          [773_020_829_000, 773_020_858_000],
-          [820_454_430_000, 820_454_460_000],
-          [867_715_231_000, 867_715_262_000],
-          [915_148_832_000, 915_148_864_000],
-          [1_136_073_633_000, 1_136_073_666_000],
-          [1_230_768_034_000, 1_230_768_068_000],
-          [1_341_100_835_000, 1_341_100_870_000],
-          [1_435_708_836_000, 1_435_708_872_000],
-          [1_483_228_837_000, 1_483_228_874_000]
+          [63_072_010_000n, 63_072_020_000n],
+          [78_796_811_000n, 78_796_822_000n],
+          [94_694_412_000n, 94_694_424_000n],
+          [126_230_413_000n, 126_230_426_000n],
+          [157_766_414_000n, 157_766_428_000n],
+          [189_302_415_000n, 189_302_430_000n],
+          [220_924_816_000n, 220_924_832_000n],
+          [252_460_817_000n, 252_460_834_000n],
+          [283_996_818_000n, 283_996_836_000n],
+          [315_532_819_000n, 315_532_838_000n],
+          [362_793_620_000n, 362_793_640_000n],
+          [394_329_621_000n, 394_329_642_000n],
+          [425_865_622_000n, 425_865_644_000n],
+          [489_024_023_000n, 489_024_046_000n],
+          [567_993_624_000n, 567_993_648_000n],
+          [631_152_025_000n, 631_152_050_000n],
+          [662_688_026_000n, 662_688_052_000n],
+          [709_948_827_000n, 709_948_854_000n],
+          [741_484_828_000n, 741_484_856_000n],
+          [773_020_829_000n, 773_020_858_000n],
+          [820_454_430_000n, 820_454_460_000n],
+          [867_715_231_000n, 867_715_262_000n],
+          [915_148_832_000n, 915_148_864_000n],
+          [1_136_073_633_000n, 1_136_073_666_000n],
+          [1_230_768_034_000n, 1_230_768_068_000n],
+          [1_341_100_835_000n, 1_341_100_870_000n],
+          [1_435_708_836_000n, 1_435_708_872_000n],
+          [1_483_228_837_000n, 1_483_228_874_000n]
         ]
 
         pairs.forEach(([unixMillis, atomicMillis]) => {
@@ -397,64 +397,64 @@ describe('TaiConverter', () => {
       })
 
       it('taiConverter.atomicToUnix', () => {
-        assert.strictEqual(taiConverter.atomicToUnix(Second.fromMillis(-283_996_800_000)),
+        assert.strictEqual(taiConverter.atomicToUnix(Second.fromMillis(-283_996_800_000n)),
           NaN)
-        assert.deepStrictEqual(taiConverter.atomicToUnix(Second.fromMillis(63_072_010_000)),
-          Second.fromMillis(63_072_000_000))
-        assert.deepStrictEqual(taiConverter.atomicToUnix(Second.fromMillis(78_796_811_000)),
-          Second.fromMillis(78_796_800_000))
-        assert.deepStrictEqual(taiConverter.atomicToUnix(Second.fromMillis(94_694_412_000)),
-          Second.fromMillis(94_694_400_000))
-        assert.deepStrictEqual(taiConverter.atomicToUnix(Second.fromMillis(126_230_413_000)),
-          Second.fromMillis(126_230_400_000))
-        assert.deepStrictEqual(taiConverter.atomicToUnix(Second.fromMillis(157_766_414_000)),
-          Second.fromMillis(157_766_400_000))
-        assert.deepStrictEqual(taiConverter.atomicToUnix(Second.fromMillis(189_302_415_000)),
-          Second.fromMillis(189_302_400_000))
-        assert.deepStrictEqual(taiConverter.atomicToUnix(Second.fromMillis(220_924_816_000)),
-          Second.fromMillis(220_924_800_000))
-        assert.deepStrictEqual(taiConverter.atomicToUnix(Second.fromMillis(252_460_817_000)),
-          Second.fromMillis(252_460_800_000))
-        assert.deepStrictEqual(taiConverter.atomicToUnix(Second.fromMillis(283_996_818_000)),
-          Second.fromMillis(283_996_800_000))
-        assert.deepStrictEqual(taiConverter.atomicToUnix(Second.fromMillis(315_532_819_000)),
-          Second.fromMillis(315_532_800_000))
-        assert.deepStrictEqual(taiConverter.atomicToUnix(Second.fromMillis(362_793_620_000)),
-          Second.fromMillis(362_793_600_000))
-        assert.deepStrictEqual(taiConverter.atomicToUnix(Second.fromMillis(394_329_621_000)),
-          Second.fromMillis(394_329_600_000))
-        assert.deepStrictEqual(taiConverter.atomicToUnix(Second.fromMillis(425_865_622_000)),
-          Second.fromMillis(425_865_600_000))
-        assert.deepStrictEqual(taiConverter.atomicToUnix(Second.fromMillis(489_024_023_000)),
-          Second.fromMillis(489_024_000_000))
-        assert.deepStrictEqual(taiConverter.atomicToUnix(Second.fromMillis(567_993_624_000)),
-          Second.fromMillis(567_993_600_000))
-        assert.deepStrictEqual(taiConverter.atomicToUnix(Second.fromMillis(631_152_025_000)),
-          Second.fromMillis(631_152_000_000))
-        assert.deepStrictEqual(taiConverter.atomicToUnix(Second.fromMillis(662_688_026_000)),
-          Second.fromMillis(662_688_000_000))
-        assert.deepStrictEqual(taiConverter.atomicToUnix(Second.fromMillis(709_948_827_000)),
-          Second.fromMillis(709_948_800_000))
-        assert.deepStrictEqual(taiConverter.atomicToUnix(Second.fromMillis(741_484_828_000)),
-          Second.fromMillis(741_484_800_000))
-        assert.deepStrictEqual(taiConverter.atomicToUnix(Second.fromMillis(773_020_829_000)),
-          Second.fromMillis(773_020_800_000))
-        assert.deepStrictEqual(taiConverter.atomicToUnix(Second.fromMillis(820_454_430_000)),
-          Second.fromMillis(820_454_400_000))
-        assert.deepStrictEqual(taiConverter.atomicToUnix(Second.fromMillis(867_715_231_000)),
-          Second.fromMillis(867_715_200_000))
-        assert.deepStrictEqual(taiConverter.atomicToUnix(Second.fromMillis(915_148_832_000)),
-          Second.fromMillis(915_148_800_000))
-        assert.deepStrictEqual(taiConverter.atomicToUnix(Second.fromMillis(1_136_073_633_000)),
-          Second.fromMillis(1_136_073_600_000))
-        assert.deepStrictEqual(taiConverter.atomicToUnix(Second.fromMillis(1_230_768_034_000)),
-          Second.fromMillis(1_230_768_000_000))
-        assert.deepStrictEqual(taiConverter.atomicToUnix(Second.fromMillis(1_341_100_835_000)),
-          Second.fromMillis(1_341_100_800_000))
-        assert.deepStrictEqual(taiConverter.atomicToUnix(Second.fromMillis(1_435_708_836_000)),
-          Second.fromMillis(1_435_708_800_000))
-        assert.deepStrictEqual(taiConverter.atomicToUnix(Second.fromMillis(1_483_228_837_000)),
-          Second.fromMillis(1_483_228_800_000))
+        assert.deepStrictEqual(taiConverter.atomicToUnix(Second.fromMillis(63_072_010_000n)),
+          Second.fromMillis(63_072_000_000n))
+        assert.deepStrictEqual(taiConverter.atomicToUnix(Second.fromMillis(78_796_811_000n)),
+          Second.fromMillis(78_796_800_000n))
+        assert.deepStrictEqual(taiConverter.atomicToUnix(Second.fromMillis(94_694_412_000n)),
+          Second.fromMillis(94_694_400_000n))
+        assert.deepStrictEqual(taiConverter.atomicToUnix(Second.fromMillis(126_230_413_000n)),
+          Second.fromMillis(126_230_400_000n))
+        assert.deepStrictEqual(taiConverter.atomicToUnix(Second.fromMillis(157_766_414_000n)),
+          Second.fromMillis(157_766_400_000n))
+        assert.deepStrictEqual(taiConverter.atomicToUnix(Second.fromMillis(189_302_415_000n)),
+          Second.fromMillis(189_302_400_000n))
+        assert.deepStrictEqual(taiConverter.atomicToUnix(Second.fromMillis(220_924_816_000n)),
+          Second.fromMillis(220_924_800_000n))
+        assert.deepStrictEqual(taiConverter.atomicToUnix(Second.fromMillis(252_460_817_000n)),
+          Second.fromMillis(252_460_800_000n))
+        assert.deepStrictEqual(taiConverter.atomicToUnix(Second.fromMillis(283_996_818_000n)),
+          Second.fromMillis(283_996_800_000n))
+        assert.deepStrictEqual(taiConverter.atomicToUnix(Second.fromMillis(315_532_819_000n)),
+          Second.fromMillis(315_532_800_000n))
+        assert.deepStrictEqual(taiConverter.atomicToUnix(Second.fromMillis(362_793_620_000n)),
+          Second.fromMillis(362_793_600_000n))
+        assert.deepStrictEqual(taiConverter.atomicToUnix(Second.fromMillis(394_329_621_000n)),
+          Second.fromMillis(394_329_600_000n))
+        assert.deepStrictEqual(taiConverter.atomicToUnix(Second.fromMillis(425_865_622_000n)),
+          Second.fromMillis(425_865_600_000n))
+        assert.deepStrictEqual(taiConverter.atomicToUnix(Second.fromMillis(489_024_023_000n)),
+          Second.fromMillis(489_024_000_000n))
+        assert.deepStrictEqual(taiConverter.atomicToUnix(Second.fromMillis(567_993_624_000n)),
+          Second.fromMillis(567_993_600_000n))
+        assert.deepStrictEqual(taiConverter.atomicToUnix(Second.fromMillis(631_152_025_000n)),
+          Second.fromMillis(631_152_000_000n))
+        assert.deepStrictEqual(taiConverter.atomicToUnix(Second.fromMillis(662_688_026_000n)),
+          Second.fromMillis(662_688_000_000n))
+        assert.deepStrictEqual(taiConverter.atomicToUnix(Second.fromMillis(709_948_827_000n)),
+          Second.fromMillis(709_948_800_000n))
+        assert.deepStrictEqual(taiConverter.atomicToUnix(Second.fromMillis(741_484_828_000n)),
+          Second.fromMillis(741_484_800_000n))
+        assert.deepStrictEqual(taiConverter.atomicToUnix(Second.fromMillis(773_020_829_000n)),
+          Second.fromMillis(773_020_800_000n))
+        assert.deepStrictEqual(taiConverter.atomicToUnix(Second.fromMillis(820_454_430_000n)),
+          Second.fromMillis(820_454_400_000n))
+        assert.deepStrictEqual(taiConverter.atomicToUnix(Second.fromMillis(867_715_231_000n)),
+          Second.fromMillis(867_715_200_000n))
+        assert.deepStrictEqual(taiConverter.atomicToUnix(Second.fromMillis(915_148_832_000n)),
+          Second.fromMillis(915_148_800_000n))
+        assert.deepStrictEqual(taiConverter.atomicToUnix(Second.fromMillis(1_136_073_633_000n)),
+          Second.fromMillis(1_136_073_600_000n))
+        assert.deepStrictEqual(taiConverter.atomicToUnix(Second.fromMillis(1_230_768_034_000n)),
+          Second.fromMillis(1_230_768_000_000n))
+        assert.deepStrictEqual(taiConverter.atomicToUnix(Second.fromMillis(1_341_100_835_000n)),
+          Second.fromMillis(1_341_100_800_000n))
+        assert.deepStrictEqual(taiConverter.atomicToUnix(Second.fromMillis(1_435_708_836_000n)),
+          Second.fromMillis(1_435_708_800_000n))
+        assert.deepStrictEqual(taiConverter.atomicToUnix(Second.fromMillis(1_483_228_837_000n)),
+          Second.fromMillis(1_483_228_800_000n))
       })
     })
   })
@@ -465,85 +465,85 @@ describe('TaiConverter', () => {
     describe('atomicToUnix', () => {
       it('The NEW earliest instant in TAI', () => {
         // Actual start of TAI: 1961-01-01 00:00:01.422_818
-        assert.deepStrictEqual(taiConverter.atomicToUnix(Second.fromMillis(Date.UTC(1961, JAN, 1, 0, 0, 1, 422)).plusS(new Second(new Rat(818n, 1_000_000n)))),
-          Second.fromMillis(Date.UTC(1961, JAN, 1, 0, 0, 0, 0)))
+        assert.deepStrictEqual(taiConverter.atomicToUnix(Second.fromMillis(BigInt(Date.UTC(1961, JAN, 1, 0, 0, 1, 422))).plusS(new Second(new Rat(818n, 1_000_000n)))),
+          Second.fromMillis(BigInt(Date.UTC(1961, JAN, 1, 0, 0, 0, 0))))
       })
 
       it('handles the start of 1972', () => {
-        assert.deepStrictEqual(taiConverter.atomicToUnix(Second.fromMillis(Date.UTC(1972, JAN, 1, 0, 0, 10, 0))),
-          Second.fromMillis(Date.UTC(1972, JAN, 1, 0, 0, 0, 0)))
+        assert.deepStrictEqual(taiConverter.atomicToUnix(Second.fromMillis(BigInt(Date.UTC(1972, JAN, 1, 0, 0, 10, 0)))),
+          Second.fromMillis(BigInt(Date.UTC(1972, JAN, 1, 0, 0, 0, 0))))
       })
 
       it('0.107_758 seconds added, start of 1972', () => {
         // stall begins at 1972-01-01 00:00:09.892_242 TAI
-        assert.deepStrictEqual(taiConverter.atomicToUnix(Second.fromMillis(Date.UTC(1972, JAN, 1, 0, 0, 9, 892)).plusS(new Second(new Rat(242n, 1_000_000n)))),
-          Second.fromMillis(Date.UTC(1972, JAN, 1, 0, 0, 0, 0)))
-        assert.deepStrictEqual(taiConverter.atomicToUnix(Second.fromMillis(Date.UTC(1972, JAN, 1, 0, 0, 9, 893))),
-          Second.fromMillis(Date.UTC(1972, JAN, 1, 0, 0, 0, 0)))
+        assert.deepStrictEqual(taiConverter.atomicToUnix(Second.fromMillis(BigInt(Date.UTC(1972, JAN, 1, 0, 0, 9, 892))).plusS(new Second(new Rat(242n, 1_000_000n)))),
+          Second.fromMillis(BigInt(Date.UTC(1972, JAN, 1, 0, 0, 0, 0))))
+        assert.deepStrictEqual(taiConverter.atomicToUnix(Second.fromMillis(BigInt(Date.UTC(1972, JAN, 1, 0, 0, 9, 893)))),
+          Second.fromMillis(BigInt(Date.UTC(1972, JAN, 1, 0, 0, 0, 0))))
 
         // Leap time over
         // After this point in time, conversions become far simpler and always integer numbers of milliseconds
-        assert.deepStrictEqual(taiConverter.atomicToUnix(Second.fromMillis(Date.UTC(1972, JAN, 1, 0, 0, 9, 999))),
-          Second.fromMillis(Date.UTC(1972, JAN, 1, 0, 0, 0, 0)))
-        assert.deepStrictEqual(taiConverter.atomicToUnix(Second.fromMillis(Date.UTC(1972, JAN, 1, 0, 0, 10, 0))),
-          Second.fromMillis(Date.UTC(1972, JAN, 1, 0, 0, 0, 0)))
-        assert.deepStrictEqual(taiConverter.atomicToUnix(Second.fromMillis(Date.UTC(1972, JAN, 1, 0, 0, 10, 1))),
-          Second.fromMillis(Date.UTC(1972, JAN, 1, 0, 0, 0, 1)))
+        assert.deepStrictEqual(taiConverter.atomicToUnix(Second.fromMillis(BigInt(Date.UTC(1972, JAN, 1, 0, 0, 9, 999)))),
+          Second.fromMillis(BigInt(Date.UTC(1972, JAN, 1, 0, 0, 0, 0))))
+        assert.deepStrictEqual(taiConverter.atomicToUnix(Second.fromMillis(BigInt(Date.UTC(1972, JAN, 1, 0, 0, 10, 0)))),
+          Second.fromMillis(BigInt(Date.UTC(1972, JAN, 1, 0, 0, 0, 0))))
+        assert.deepStrictEqual(taiConverter.atomicToUnix(Second.fromMillis(BigInt(Date.UTC(1972, JAN, 1, 0, 0, 10, 1)))),
+          Second.fromMillis(BigInt(Date.UTC(1972, JAN, 1, 0, 0, 0, 1))))
       })
 
       it('typical', () => {
         // A typical leap second from the past, note stall
-        assert.deepStrictEqual(taiConverter.atomicToUnix(Second.fromMillis(Date.UTC(1999, JAN, 1, 0, 0, 30, 999))),
-          Second.fromMillis(Date.UTC(1998, DEC, 31, 23, 59, 59, 999)))
-        assert.deepStrictEqual(taiConverter.atomicToUnix(Second.fromMillis(Date.UTC(1999, JAN, 1, 0, 0, 31, 0))),
-          Second.fromMillis(Date.UTC(1999, JAN, 1, 0, 0, 0, 0)))
-        assert.deepStrictEqual(taiConverter.atomicToUnix(Second.fromMillis(Date.UTC(1999, JAN, 1, 0, 0, 31, 1))),
-          Second.fromMillis(Date.UTC(1999, JAN, 1, 0, 0, 0, 0)))
+        assert.deepStrictEqual(taiConverter.atomicToUnix(Second.fromMillis(BigInt(Date.UTC(1999, JAN, 1, 0, 0, 30, 999)))),
+          Second.fromMillis(BigInt(Date.UTC(1998, DEC, 31, 23, 59, 59, 999))))
+        assert.deepStrictEqual(taiConverter.atomicToUnix(Second.fromMillis(BigInt(Date.UTC(1999, JAN, 1, 0, 0, 31, 0)))),
+          Second.fromMillis(BigInt(Date.UTC(1999, JAN, 1, 0, 0, 0, 0))))
+        assert.deepStrictEqual(taiConverter.atomicToUnix(Second.fromMillis(BigInt(Date.UTC(1999, JAN, 1, 0, 0, 31, 1)))),
+          Second.fromMillis(BigInt(Date.UTC(1999, JAN, 1, 0, 0, 0, 0))))
 
-        assert.deepStrictEqual(taiConverter.atomicToUnix(Second.fromMillis(Date.UTC(1999, JAN, 1, 0, 0, 31, 999))),
-          Second.fromMillis(Date.UTC(1999, JAN, 1, 0, 0, 0, 0)))
-        assert.deepStrictEqual(taiConverter.atomicToUnix(Second.fromMillis(Date.UTC(1999, JAN, 1, 0, 0, 32, 0))),
-          Second.fromMillis(Date.UTC(1999, JAN, 1, 0, 0, 0, 0)))
-        assert.deepStrictEqual(taiConverter.atomicToUnix(Second.fromMillis(Date.UTC(1999, JAN, 1, 0, 0, 32, 1))),
-          Second.fromMillis(Date.UTC(1999, JAN, 1, 0, 0, 0, 1)))
+        assert.deepStrictEqual(taiConverter.atomicToUnix(Second.fromMillis(BigInt(Date.UTC(1999, JAN, 1, 0, 0, 31, 999)))),
+          Second.fromMillis(BigInt(Date.UTC(1999, JAN, 1, 0, 0, 0, 0))))
+        assert.deepStrictEqual(taiConverter.atomicToUnix(Second.fromMillis(BigInt(Date.UTC(1999, JAN, 1, 0, 0, 32, 0)))),
+          Second.fromMillis(BigInt(Date.UTC(1999, JAN, 1, 0, 0, 0, 0))))
+        assert.deepStrictEqual(taiConverter.atomicToUnix(Second.fromMillis(BigInt(Date.UTC(1999, JAN, 1, 0, 0, 32, 1)))),
+          Second.fromMillis(BigInt(Date.UTC(1999, JAN, 1, 0, 0, 0, 1))))
       })
     })
 
     describe('Unix->TAI conversions', () => {
       it('typical', () => {
         // A typical leap second from the past, note stall
-        assert.deepStrictEqual(taiConverter.unixToAtomic(Second.fromMillis(Date.UTC(1998, DEC, 31, 23, 59, 59, 999))),
+        assert.deepStrictEqual(taiConverter.unixToAtomic(Second.fromMillis(BigInt(Date.UTC(1998, DEC, 31, 23, 59, 59, 999)))),
           [
-            new Range(Second.fromMillis(Date.UTC(1999, JAN, 1, 0, 0, 30, 999)))
+            new Range(Second.fromMillis(BigInt(Date.UTC(1999, JAN, 1, 0, 0, 30, 999))))
           ])
-        assert.deepStrictEqual(taiConverter.unixToAtomic(Second.fromMillis(Date.UTC(1999, JAN, 1, 0, 0, 0, 0))),
+        assert.deepStrictEqual(taiConverter.unixToAtomic(Second.fromMillis(BigInt(Date.UTC(1999, JAN, 1, 0, 0, 0, 0)))),
           [
             new Range(
-              Second.fromMillis(Date.UTC(1999, JAN, 1, 0, 0, 31, 0)),
-              Second.fromMillis(Date.UTC(1999, JAN, 1, 0, 0, 32, 0))
+              Second.fromMillis(BigInt(Date.UTC(1999, JAN, 1, 0, 0, 31, 0))),
+              Second.fromMillis(BigInt(Date.UTC(1999, JAN, 1, 0, 0, 32, 0)))
             )
           ])
-        assert.deepStrictEqual(taiConverter.unixToAtomic(Second.fromMillis(Date.UTC(1999, JAN, 1, 0, 0, 0, 1))),
+        assert.deepStrictEqual(taiConverter.unixToAtomic(Second.fromMillis(BigInt(Date.UTC(1999, JAN, 1, 0, 0, 0, 1)))),
           [
-            new Range(Second.fromMillis(Date.UTC(1999, JAN, 1, 0, 0, 32, 1)))
+            new Range(Second.fromMillis(BigInt(Date.UTC(1999, JAN, 1, 0, 0, 32, 1))))
           ])
       })
 
       it('Now-ish', () => {
-        assert.deepStrictEqual(taiConverter.unixToAtomic(Second.fromMillis(Date.UTC(2016, OCT, 27, 20, 5, 14, 678))),
+        assert.deepStrictEqual(taiConverter.unixToAtomic(Second.fromMillis(BigInt(Date.UTC(2016, OCT, 27, 20, 5, 14, 678)))),
           [
-            new Range(Second.fromMillis(Date.UTC(2016, OCT, 27, 20, 5, 50, 678)))
+            new Range(Second.fromMillis(BigInt(Date.UTC(2016, OCT, 27, 20, 5, 50, 678))))
           ])
       })
     })
 
     it('Crazy pre-1972 nonsense', () => {
       // Exact picosecond ratios
-      assert.deepStrictEqual(taiConverter.unixToAtomic(Second.fromMillis(Date.UTC(1962, JAN, 1, 0, 0, 0, 0))),
+      assert.deepStrictEqual(taiConverter.unixToAtomic(Second.fromMillis(BigInt(Date.UTC(1962, JAN, 1, 0, 0, 0, 0)))),
         [
           new Range(new Second(new Rat(-252_460_798_154_142_000_000n, 1_000_000_000_000n)))
         ])
-      assert.deepStrictEqual(taiConverter.unixToAtomic(Second.fromMillis(Date.UTC(1962, JAN, 1, 0, 0, 0, 1))),
+      assert.deepStrictEqual(taiConverter.unixToAtomic(Second.fromMillis(BigInt(Date.UTC(1962, JAN, 1, 0, 0, 0, 1)))),
         [
           new Range(new Second(new Rat(-252_460_798_153_141_999_987n, 1_000_000_000_000n)))
         ])
@@ -552,34 +552,34 @@ describe('TaiConverter', () => {
     describe('TAI raw data conversion unit tests based on magic numbers', () => {
       it('taiConverter.unixToAtomic', () => {
         const pairs = [
-          [63_072_010_000, 63_072_020_000],
-          [78_796_811_000, 78_796_822_000],
-          [94_694_412_000, 94_694_424_000],
-          [126_230_413_000, 126_230_426_000],
-          [157_766_414_000, 157_766_428_000],
-          [189_302_415_000, 189_302_430_000],
-          [220_924_816_000, 220_924_832_000],
-          [252_460_817_000, 252_460_834_000],
-          [283_996_818_000, 283_996_836_000],
-          [315_532_819_000, 315_532_838_000],
-          [362_793_620_000, 362_793_640_000],
-          [394_329_621_000, 394_329_642_000],
-          [425_865_622_000, 425_865_644_000],
-          [489_024_023_000, 489_024_046_000],
-          [567_993_624_000, 567_993_648_000],
-          [631_152_025_000, 631_152_050_000],
-          [662_688_026_000, 662_688_052_000],
-          [709_948_827_000, 709_948_854_000],
-          [741_484_828_000, 741_484_856_000],
-          [773_020_829_000, 773_020_858_000],
-          [820_454_430_000, 820_454_460_000],
-          [867_715_231_000, 867_715_262_000],
-          [915_148_832_000, 915_148_864_000],
-          [1_136_073_633_000, 1_136_073_666_000],
-          [1_230_768_034_000, 1_230_768_068_000],
-          [1_341_100_835_000, 1_341_100_870_000],
-          [1_435_708_836_000, 1_435_708_872_000],
-          [1_483_228_837_000, 1_483_228_874_000]
+          [63_072_010_000n, 63_072_020_000n],
+          [78_796_811_000n, 78_796_822_000n],
+          [94_694_412_000n, 94_694_424_000n],
+          [126_230_413_000n, 126_230_426_000n],
+          [157_766_414_000n, 157_766_428_000n],
+          [189_302_415_000n, 189_302_430_000n],
+          [220_924_816_000n, 220_924_832_000n],
+          [252_460_817_000n, 252_460_834_000n],
+          [283_996_818_000n, 283_996_836_000n],
+          [315_532_819_000n, 315_532_838_000n],
+          [362_793_620_000n, 362_793_640_000n],
+          [394_329_621_000n, 394_329_642_000n],
+          [425_865_622_000n, 425_865_644_000n],
+          [489_024_023_000n, 489_024_046_000n],
+          [567_993_624_000n, 567_993_648_000n],
+          [631_152_025_000n, 631_152_050_000n],
+          [662_688_026_000n, 662_688_052_000n],
+          [709_948_827_000n, 709_948_854_000n],
+          [741_484_828_000n, 741_484_856_000n],
+          [773_020_829_000n, 773_020_858_000n],
+          [820_454_430_000n, 820_454_460_000n],
+          [867_715_231_000n, 867_715_262_000n],
+          [915_148_832_000n, 915_148_864_000n],
+          [1_136_073_633_000n, 1_136_073_666_000n],
+          [1_230_768_034_000n, 1_230_768_068_000n],
+          [1_341_100_835_000n, 1_341_100_870_000n],
+          [1_435_708_836_000n, 1_435_708_872_000n],
+          [1_483_228_837_000n, 1_483_228_874_000n]
         ]
 
         pairs.forEach(([unixMillis, atomicMillis]) => {
@@ -591,64 +591,64 @@ describe('TaiConverter', () => {
       })
 
       it('taiConverter.atomicToUnix', () => {
-        assert.strictEqual(taiConverter.atomicToUnix(Second.fromMillis(-283_996_800_000)),
+        assert.strictEqual(taiConverter.atomicToUnix(Second.fromMillis(-283_996_800_000n)),
           NaN)
-        assert.deepStrictEqual(taiConverter.atomicToUnix(Second.fromMillis(63_072_010_000)),
-          Second.fromMillis(63_072_000_000))
-        assert.deepStrictEqual(taiConverter.atomicToUnix(Second.fromMillis(78_796_811_000)),
-          Second.fromMillis(78_796_800_000))
-        assert.deepStrictEqual(taiConverter.atomicToUnix(Second.fromMillis(94_694_412_000)),
-          Second.fromMillis(94_694_400_000))
-        assert.deepStrictEqual(taiConverter.atomicToUnix(Second.fromMillis(126_230_413_000)),
-          Second.fromMillis(126_230_400_000))
-        assert.deepStrictEqual(taiConverter.atomicToUnix(Second.fromMillis(157_766_414_000)),
-          Second.fromMillis(157_766_400_000))
-        assert.deepStrictEqual(taiConverter.atomicToUnix(Second.fromMillis(189_302_415_000)),
-          Second.fromMillis(189_302_400_000))
-        assert.deepStrictEqual(taiConverter.atomicToUnix(Second.fromMillis(220_924_816_000)),
-          Second.fromMillis(220_924_800_000))
-        assert.deepStrictEqual(taiConverter.atomicToUnix(Second.fromMillis(252_460_817_000)),
-          Second.fromMillis(252_460_800_000))
-        assert.deepStrictEqual(taiConverter.atomicToUnix(Second.fromMillis(283_996_818_000)),
-          Second.fromMillis(283_996_800_000))
-        assert.deepStrictEqual(taiConverter.atomicToUnix(Second.fromMillis(315_532_819_000)),
-          Second.fromMillis(315_532_800_000))
-        assert.deepStrictEqual(taiConverter.atomicToUnix(Second.fromMillis(362_793_620_000)),
-          Second.fromMillis(362_793_600_000))
-        assert.deepStrictEqual(taiConverter.atomicToUnix(Second.fromMillis(394_329_621_000)),
-          Second.fromMillis(394_329_600_000))
-        assert.deepStrictEqual(taiConverter.atomicToUnix(Second.fromMillis(425_865_622_000)),
-          Second.fromMillis(425_865_600_000))
-        assert.deepStrictEqual(taiConverter.atomicToUnix(Second.fromMillis(489_024_023_000)),
-          Second.fromMillis(489_024_000_000))
-        assert.deepStrictEqual(taiConverter.atomicToUnix(Second.fromMillis(567_993_624_000)),
-          Second.fromMillis(567_993_600_000))
-        assert.deepStrictEqual(taiConverter.atomicToUnix(Second.fromMillis(631_152_025_000)),
-          Second.fromMillis(631_152_000_000))
-        assert.deepStrictEqual(taiConverter.atomicToUnix(Second.fromMillis(662_688_026_000)),
-          Second.fromMillis(662_688_000_000))
-        assert.deepStrictEqual(taiConverter.atomicToUnix(Second.fromMillis(709_948_827_000)),
-          Second.fromMillis(709_948_800_000))
-        assert.deepStrictEqual(taiConverter.atomicToUnix(Second.fromMillis(741_484_828_000)),
-          Second.fromMillis(741_484_800_000))
-        assert.deepStrictEqual(taiConverter.atomicToUnix(Second.fromMillis(773_020_829_000)),
-          Second.fromMillis(773_020_800_000))
-        assert.deepStrictEqual(taiConverter.atomicToUnix(Second.fromMillis(820_454_430_000)),
-          Second.fromMillis(820_454_400_000))
-        assert.deepStrictEqual(taiConverter.atomicToUnix(Second.fromMillis(867_715_231_000)),
-          Second.fromMillis(867_715_200_000))
-        assert.deepStrictEqual(taiConverter.atomicToUnix(Second.fromMillis(915_148_832_000)),
-          Second.fromMillis(915_148_800_000))
-        assert.deepStrictEqual(taiConverter.atomicToUnix(Second.fromMillis(1_136_073_633_000)),
-          Second.fromMillis(1_136_073_600_000))
-        assert.deepStrictEqual(taiConverter.atomicToUnix(Second.fromMillis(1_230_768_034_000)),
-          Second.fromMillis(1_230_768_000_000))
-        assert.deepStrictEqual(taiConverter.atomicToUnix(Second.fromMillis(1_341_100_835_000)),
-          Second.fromMillis(1_341_100_800_000))
-        assert.deepStrictEqual(taiConverter.atomicToUnix(Second.fromMillis(1_435_708_836_000)),
-          Second.fromMillis(1_435_708_800_000))
-        assert.deepStrictEqual(taiConverter.atomicToUnix(Second.fromMillis(1_483_228_837_000)),
-          Second.fromMillis(1_483_228_800_000))
+        assert.deepStrictEqual(taiConverter.atomicToUnix(Second.fromMillis(63_072_010_000n)),
+          Second.fromMillis(63_072_000_000n))
+        assert.deepStrictEqual(taiConverter.atomicToUnix(Second.fromMillis(78_796_811_000n)),
+          Second.fromMillis(78_796_800_000n))
+        assert.deepStrictEqual(taiConverter.atomicToUnix(Second.fromMillis(94_694_412_000n)),
+          Second.fromMillis(94_694_400_000n))
+        assert.deepStrictEqual(taiConverter.atomicToUnix(Second.fromMillis(126_230_413_000n)),
+          Second.fromMillis(126_230_400_000n))
+        assert.deepStrictEqual(taiConverter.atomicToUnix(Second.fromMillis(157_766_414_000n)),
+          Second.fromMillis(157_766_400_000n))
+        assert.deepStrictEqual(taiConverter.atomicToUnix(Second.fromMillis(189_302_415_000n)),
+          Second.fromMillis(189_302_400_000n))
+        assert.deepStrictEqual(taiConverter.atomicToUnix(Second.fromMillis(220_924_816_000n)),
+          Second.fromMillis(220_924_800_000n))
+        assert.deepStrictEqual(taiConverter.atomicToUnix(Second.fromMillis(252_460_817_000n)),
+          Second.fromMillis(252_460_800_000n))
+        assert.deepStrictEqual(taiConverter.atomicToUnix(Second.fromMillis(283_996_818_000n)),
+          Second.fromMillis(283_996_800_000n))
+        assert.deepStrictEqual(taiConverter.atomicToUnix(Second.fromMillis(315_532_819_000n)),
+          Second.fromMillis(315_532_800_000n))
+        assert.deepStrictEqual(taiConverter.atomicToUnix(Second.fromMillis(362_793_620_000n)),
+          Second.fromMillis(362_793_600_000n))
+        assert.deepStrictEqual(taiConverter.atomicToUnix(Second.fromMillis(394_329_621_000n)),
+          Second.fromMillis(394_329_600_000n))
+        assert.deepStrictEqual(taiConverter.atomicToUnix(Second.fromMillis(425_865_622_000n)),
+          Second.fromMillis(425_865_600_000n))
+        assert.deepStrictEqual(taiConverter.atomicToUnix(Second.fromMillis(489_024_023_000n)),
+          Second.fromMillis(489_024_000_000n))
+        assert.deepStrictEqual(taiConverter.atomicToUnix(Second.fromMillis(567_993_624_000n)),
+          Second.fromMillis(567_993_600_000n))
+        assert.deepStrictEqual(taiConverter.atomicToUnix(Second.fromMillis(631_152_025_000n)),
+          Second.fromMillis(631_152_000_000n))
+        assert.deepStrictEqual(taiConverter.atomicToUnix(Second.fromMillis(662_688_026_000n)),
+          Second.fromMillis(662_688_000_000n))
+        assert.deepStrictEqual(taiConverter.atomicToUnix(Second.fromMillis(709_948_827_000n)),
+          Second.fromMillis(709_948_800_000n))
+        assert.deepStrictEqual(taiConverter.atomicToUnix(Second.fromMillis(741_484_828_000n)),
+          Second.fromMillis(741_484_800_000n))
+        assert.deepStrictEqual(taiConverter.atomicToUnix(Second.fromMillis(773_020_829_000n)),
+          Second.fromMillis(773_020_800_000n))
+        assert.deepStrictEqual(taiConverter.atomicToUnix(Second.fromMillis(820_454_430_000n)),
+          Second.fromMillis(820_454_400_000n))
+        assert.deepStrictEqual(taiConverter.atomicToUnix(Second.fromMillis(867_715_231_000n)),
+          Second.fromMillis(867_715_200_000n))
+        assert.deepStrictEqual(taiConverter.atomicToUnix(Second.fromMillis(915_148_832_000n)),
+          Second.fromMillis(915_148_800_000n))
+        assert.deepStrictEqual(taiConverter.atomicToUnix(Second.fromMillis(1_136_073_633_000n)),
+          Second.fromMillis(1_136_073_600_000n))
+        assert.deepStrictEqual(taiConverter.atomicToUnix(Second.fromMillis(1_230_768_034_000n)),
+          Second.fromMillis(1_230_768_000_000n))
+        assert.deepStrictEqual(taiConverter.atomicToUnix(Second.fromMillis(1_341_100_835_000n)),
+          Second.fromMillis(1_341_100_800_000n))
+        assert.deepStrictEqual(taiConverter.atomicToUnix(Second.fromMillis(1_435_708_836_000n)),
+          Second.fromMillis(1_435_708_800_000n))
+        assert.deepStrictEqual(taiConverter.atomicToUnix(Second.fromMillis(1_483_228_837_000n)),
+          Second.fromMillis(1_483_228_800_000n))
       })
     })
 
@@ -656,34 +656,34 @@ describe('TaiConverter', () => {
       describe('unixToAtomic and back', () => {
         const unixMillises = [
           // Pre 1972, round trips DO NOT work due to rounding behaviour
-          63_072_010_000,
-          78_796_811_000,
-          94_694_412_000,
-          126_230_413_000,
-          157_766_414_000,
-          189_302_415_000,
-          220_924_816_000,
-          252_460_817_000,
-          283_996_818_000,
-          315_532_819_000,
-          362_793_620_000,
-          394_329_621_000,
-          425_865_622_000,
-          489_024_023_000,
-          567_993_624_000,
-          631_152_025_000,
-          662_688_026_000,
-          709_948_827_000,
-          741_484_828_000,
-          773_020_829_000,
-          820_454_430_000,
-          867_715_231_000,
-          915_148_832_000,
-          1_136_073_633_000,
-          1_230_768_034_000,
-          1_341_100_835_000,
-          1_435_708_836_000,
-          1_483_228_837_000
+          63_072_010_000n,
+          78_796_811_000n,
+          94_694_412_000n,
+          126_230_413_000n,
+          157_766_414_000n,
+          189_302_415_000n,
+          220_924_816_000n,
+          252_460_817_000n,
+          283_996_818_000n,
+          315_532_819_000n,
+          362_793_620_000n,
+          394_329_621_000n,
+          425_865_622_000n,
+          489_024_023_000n,
+          567_993_624_000n,
+          631_152_025_000n,
+          662_688_026_000n,
+          709_948_827_000n,
+          741_484_828_000n,
+          773_020_829_000n,
+          820_454_430_000n,
+          867_715_231_000n,
+          915_148_832_000n,
+          1_136_073_633_000n,
+          1_230_768_034_000n,
+          1_341_100_835_000n,
+          1_435_708_836_000n,
+          1_483_228_837_000n
         ]
         unixMillises.forEach(unixMillis => {
           it(String(unixMillis), () => {
@@ -697,7 +697,7 @@ describe('TaiConverter', () => {
 
       describe('atomicToUnix and back', () => {
         it(String(63_072_010_000), () => {
-          const atomic = Second.fromMillis(63_072_010_000)
+          const atomic = Second.fromMillis(63_072_010_000n)
           assert.deepStrictEqual(taiConverter.unixToAtomic(taiConverter.atomicToUnix(atomic)),
             [
               new Range(atomic.minusS(new Second(new Rat(107_758n, 1_000_000n))), atomic)
@@ -706,40 +706,40 @@ describe('TaiConverter', () => {
 
         const atomicMillises = [
           // Pre 1972, round trips DO NOT work due to rounding behaviour
-          78_796_811_000,
-          94_694_412_000,
-          126_230_413_000,
-          157_766_414_000,
-          189_302_415_000,
-          220_924_816_000,
-          252_460_817_000,
-          283_996_818_000,
-          315_532_819_000,
-          362_793_620_000,
-          394_329_621_000,
-          425_865_622_000,
-          489_024_023_000,
-          567_993_624_000,
-          631_152_025_000,
-          662_688_026_000,
-          709_948_827_000,
-          741_484_828_000,
-          773_020_829_000,
-          820_454_430_000,
-          867_715_231_000,
-          915_148_832_000,
-          1_136_073_633_000,
-          1_230_768_034_000,
-          1_341_100_835_000,
-          1_435_708_836_000,
-          1_483_228_837_000
+          78_796_811_000n,
+          94_694_412_000n,
+          126_230_413_000n,
+          157_766_414_000n,
+          189_302_415_000n,
+          220_924_816_000n,
+          252_460_817_000n,
+          283_996_818_000n,
+          315_532_819_000n,
+          362_793_620_000n,
+          394_329_621_000n,
+          425_865_622_000n,
+          489_024_023_000n,
+          567_993_624_000n,
+          631_152_025_000n,
+          662_688_026_000n,
+          709_948_827_000n,
+          741_484_828_000n,
+          773_020_829_000n,
+          820_454_430_000n,
+          867_715_231_000n,
+          915_148_832_000n,
+          1_136_073_633_000n,
+          1_230_768_034_000n,
+          1_341_100_835_000n,
+          1_435_708_836_000n,
+          1_483_228_837_000n
         ]
         atomicMillises.forEach(atomicMillis => {
           it(String(atomicMillis), () => {
             const atomic = Second.fromMillis(atomicMillis)
             assert.deepStrictEqual(taiConverter.unixToAtomic(taiConverter.atomicToUnix(atomic)),
               [
-                new Range(atomic.minusS(Second.fromMillis(1_000)), atomic)
+                new Range(atomic.minusS(Second.fromMillis(1_000n)), atomic)
               ])
           })
         })
@@ -750,49 +750,49 @@ describe('TaiConverter', () => {
   describe('smearing', () => {
     const taiConverter = TaiConverter(MODELS.SMEAR)
     it('smears', () => {
-      assert.deepStrictEqual(taiConverter.unixToAtomic(Second.fromMillis(Date.UTC(2016, DEC, 31, 0, 0, 0, 0))),
+      assert.deepStrictEqual(taiConverter.unixToAtomic(Second.fromMillis(BigInt(Date.UTC(2016, DEC, 31, 0, 0, 0, 0)))),
         [
-          new Range(Second.fromMillis(Date.UTC(2016, DEC, 31, 0, 0, 36, 0)))
+          new Range(Second.fromMillis(BigInt(Date.UTC(2016, DEC, 31, 0, 0, 36, 0))))
         ])
 
       // SMEAR BEGINS
-      assert.deepStrictEqual(taiConverter.unixToAtomic(Second.fromMillis(Date.UTC(2016, DEC, 31, 11, 59, 59, 999))),
+      assert.deepStrictEqual(taiConverter.unixToAtomic(Second.fromMillis(BigInt(Date.UTC(2016, DEC, 31, 11, 59, 59, 999)))),
         [
-          new Range(Second.fromMillis(Date.UTC(2016, DEC, 31, 12, 0, 35, 999)))
+          new Range(Second.fromMillis(BigInt(Date.UTC(2016, DEC, 31, 12, 0, 35, 999))))
         ])
-      assert.deepStrictEqual(taiConverter.unixToAtomic(Second.fromMillis(Date.UTC(2016, DEC, 31, 12, 0, 0, 0))),
+      assert.deepStrictEqual(taiConverter.unixToAtomic(Second.fromMillis(BigInt(Date.UTC(2016, DEC, 31, 12, 0, 0, 0)))),
         [
-          new Range(Second.fromMillis(Date.UTC(2016, DEC, 31, 12, 0, 36, 0)))
+          new Range(Second.fromMillis(BigInt(Date.UTC(2016, DEC, 31, 12, 0, 36, 0))))
         ])
-      assert.deepStrictEqual(taiConverter.unixToAtomic(Second.fromMillis(Date.UTC(2016, DEC, 31, 12, 0, 0, 1))),
+      assert.deepStrictEqual(taiConverter.unixToAtomic(Second.fromMillis(BigInt(Date.UTC(2016, DEC, 31, 12, 0, 0, 1)))),
         [
-          new Range(Second.fromMillis(Date.UTC(2016, DEC, 31, 12, 0, 36, 1)).plusS(new Second(new Rat(1n, 86_400_000n))))
+          new Range(Second.fromMillis(BigInt(Date.UTC(2016, DEC, 31, 12, 0, 36, 1))).plusS(new Second(new Rat(1n, 86_400_000n))))
         ])
 
       // After 86_400 Unix milliseconds, exactly 86_401 TAI milliseconds have passed
-      assert.deepStrictEqual(taiConverter.unixToAtomic(Second.fromMillis(Date.UTC(2016, DEC, 31, 12, 1, 26, 400))),
+      assert.deepStrictEqual(taiConverter.unixToAtomic(Second.fromMillis(BigInt(Date.UTC(2016, DEC, 31, 12, 1, 26, 400)))),
         [
-          new Range(Second.fromMillis(Date.UTC(2016, DEC, 31, 12, 2, 2, 401)))
+          new Range(Second.fromMillis(BigInt(Date.UTC(2016, DEC, 31, 12, 2, 2, 401))))
         ])
 
       // After 12 Unix hours, 12 TAI hours and 500 milliseconds
-      assert.deepStrictEqual(taiConverter.unixToAtomic(Second.fromMillis(Date.UTC(2017, JAN, 1, 0, 0, 0, 0))),
+      assert.deepStrictEqual(taiConverter.unixToAtomic(Second.fromMillis(BigInt(Date.UTC(2017, JAN, 1, 0, 0, 0, 0)))),
         [
-          new Range(Second.fromMillis(Date.UTC(2017, JAN, 1, 0, 0, 36, 500)))
+          new Range(Second.fromMillis(BigInt(Date.UTC(2017, JAN, 1, 0, 0, 36, 500))))
         ])
 
       // SMEAR ENDS. After 24 Unix hours, 24 TAI hours and 1 second
-      assert.deepStrictEqual(taiConverter.unixToAtomic(Second.fromMillis(Date.UTC(2017, JAN, 1, 11, 59, 59, 999))),
+      assert.deepStrictEqual(taiConverter.unixToAtomic(Second.fromMillis(BigInt(Date.UTC(2017, JAN, 1, 11, 59, 59, 999)))),
         [
-          new Range(Second.fromMillis(Date.UTC(2017, JAN, 1, 12, 0, 35, 999)).plusS(new Second(new Rat(86_399_999n, 86_400_000n))))
+          new Range(Second.fromMillis(BigInt(Date.UTC(2017, JAN, 1, 12, 0, 35, 999))).plusS(new Second(new Rat(86_399_999n, 86_400_000n))))
         ])
-      assert.deepStrictEqual(taiConverter.unixToAtomic(Second.fromMillis(Date.UTC(2017, JAN, 1, 12, 0, 0, 0))),
+      assert.deepStrictEqual(taiConverter.unixToAtomic(Second.fromMillis(BigInt(Date.UTC(2017, JAN, 1, 12, 0, 0, 0)))),
         [
-          new Range(Second.fromMillis(Date.UTC(2017, JAN, 1, 12, 0, 37, 0)))
+          new Range(Second.fromMillis(BigInt(Date.UTC(2017, JAN, 1, 12, 0, 37, 0))))
         ])
-      assert.deepStrictEqual(taiConverter.unixToAtomic(Second.fromMillis(Date.UTC(2017, JAN, 1, 12, 0, 0, 1))),
+      assert.deepStrictEqual(taiConverter.unixToAtomic(Second.fromMillis(BigInt(Date.UTC(2017, JAN, 1, 12, 0, 0, 1)))),
         [
-          new Range(Second.fromMillis(Date.UTC(2017, JAN, 1, 12, 0, 37, 1)))
+          new Range(Second.fromMillis(BigInt(Date.UTC(2017, JAN, 1, 12, 0, 37, 1))))
         ])
     })
   })

--- a/test/millis-converter.spec.js
+++ b/test/millis-converter.spec.js
@@ -26,8 +26,12 @@ describe('MillisConverter', () => {
           [0])
         assert.strictEqual(millisConverter.unixToAtomic(0),
           0)
+        assert.strictEqual(millisConverter.unixToAtomic(0n),
+          0n)
         assert.strictEqual(millisConverter.atomicToUnix(0),
           0)
+        assert.strictEqual(millisConverter.atomicToUnix(0n),
+          0n)
       })
     })
 
@@ -937,6 +941,16 @@ describe('MillisConverter', () => {
           assert.strictEqual(millisConverter.unixToAtomic(2_000), 4_500)
         })
 
+        it('unixToAtomic (BigInts)', () => {
+          assert.strictEqual(millisConverter.unixToAtomic(0n), 0n)
+          assert.strictEqual(millisConverter.unixToAtomic(499n), 499n)
+          assert.strictEqual(millisConverter.unixToAtomic(500n), 3_000n)
+          assert.strictEqual(millisConverter.unixToAtomic(999n), 3_499n)
+          assert.strictEqual(millisConverter.unixToAtomic(1_000n), 3_500n)
+          assert.strictEqual(millisConverter.unixToAtomic(1_999n), 4_499n)
+          assert.strictEqual(millisConverter.unixToAtomic(2_000n), 4_500n)
+        })
+
         it('atomicToUnix', () => {
           assert.strictEqual(millisConverter.atomicToUnix(0), 0)
           assert.strictEqual(millisConverter.atomicToUnix(499), 499)
@@ -952,6 +966,23 @@ describe('MillisConverter', () => {
           assert.strictEqual(millisConverter.atomicToUnix(3_001), 501)
           assert.strictEqual(millisConverter.atomicToUnix(4_499), 1_999)
           assert.strictEqual(millisConverter.atomicToUnix(4_500), 2_000)
+        })
+
+        it('atomicToUnix (BigInts)', () => {
+          assert.strictEqual(millisConverter.atomicToUnix(0n), 0n)
+          assert.strictEqual(millisConverter.atomicToUnix(499n), 499n)
+          assert.strictEqual(millisConverter.atomicToUnix(500n), 500n)
+          assert.strictEqual(millisConverter.atomicToUnix(999n), 999n)
+          assert.strictEqual(millisConverter.atomicToUnix(1_000n), 1_000n)
+          assert.strictEqual(millisConverter.atomicToUnix(1_001n), 1_001n)
+          assert.strictEqual(millisConverter.atomicToUnix(1_999n), 1_999n)
+          assert.strictEqual(millisConverter.atomicToUnix(2_000n), 1_000n)
+          assert.strictEqual(millisConverter.atomicToUnix(2_001n), 1_001n)
+          assert.strictEqual(millisConverter.atomicToUnix(2_999n), 1_999n)
+          assert.strictEqual(millisConverter.atomicToUnix(3_000n), 500n)
+          assert.strictEqual(millisConverter.atomicToUnix(3_001n), 501n)
+          assert.strictEqual(millisConverter.atomicToUnix(4_499n), 1_999n)
+          assert.strictEqual(millisConverter.atomicToUnix(4_500n), 2_000n)
         })
       })
 

--- a/test/munge.spec.js
+++ b/test/munge.spec.js
@@ -44,7 +44,7 @@ describe('munge', () => {
       assert.deepStrictEqual(munge([
         [Date.UTC(1970, JAN, 1), 0]
       ], MODELS.OVERRUN), [new Segment(
-        { atomic: Second.fromMillis(0), unix: Second.fromMillis(0) }
+        { atomic: Second.fromMillis(0n), unix: Second.fromMillis(0n) }
       )])
     })
 
@@ -52,7 +52,7 @@ describe('munge', () => {
       assert.deepStrictEqual(munge([
         [7, -4]
       ], MODELS.OVERRUN), [new Segment(
-        { atomic: Second.fromMillis(-3_993), unix: Second.fromMillis(7) }
+        { atomic: Second.fromMillis(-3_993n), unix: Second.fromMillis(7n) }
       )])
     })
 
@@ -81,7 +81,7 @@ describe('munge', () => {
       assert.deepStrictEqual(munge([
         [Date.UTC(1970, JAN, 1), 0, 40_587, 8.640_0]
       ], MODELS.OVERRUN), [new Segment(
-        { atomic: Second.fromMillis(0), unix: Second.fromMillis(0) },
+        { atomic: Second.fromMillis(0n), unix: Second.fromMillis(0n) },
         { atomic: Second.END_OF_TIME },
         { unixPerAtomic: new Rat(10_000n, 10_001n) }
       )])
@@ -90,14 +90,14 @@ describe('munge', () => {
       assert.deepStrictEqual(munge([
         [Date.UTC(1970, JAN, 1), 0, 40_587, 0]
       ], MODELS.OVERRUN), [new Segment(
-        { atomic: Second.fromMillis(0), unix: Second.fromMillis(0) }
+        { atomic: Second.fromMillis(0n), unix: Second.fromMillis(0n) }
       )])
 
       // TAI runs way slower than UTC
       assert.deepStrictEqual(munge([
         [Date.UTC(1970, JAN, 1), 0, 40_587, -8.640_0]
       ], MODELS.OVERRUN), [new Segment(
-        { atomic: Second.fromMillis(0), unix: Second.fromMillis(0) },
+        { atomic: Second.fromMillis(0n), unix: Second.fromMillis(0n) },
         { atomic: Second.END_OF_TIME },
         { unixPerAtomic: new Rat(10_000n, 9_999n) }
       )])
@@ -107,7 +107,7 @@ describe('munge', () => {
       assert.deepStrictEqual(munge([
         [Date.UTC(1970, JAN, 1), 0, 40_587, -86_400 + 8.640_0]
       ], MODELS.OVERRUN), [new Segment(
-        { atomic: Second.fromMillis(0), unix: Second.fromMillis(0) },
+        { atomic: Second.fromMillis(0n), unix: Second.fromMillis(0n) },
         { atomic: Second.END_OF_TIME },
         { unixPerAtomic: new Rat(10_000n) }
       )])
@@ -251,7 +251,7 @@ describe('munge', () => {
         assert.deepStrictEqual(munge([
           [Date.UTC(1970, JAN, 1, 0, 0, 0, 1), -0.000_1]
         ], MODELS.OVERRUN), [new Segment(
-          { atomic: new Second(new Rat(900n, 1_000_000n)), unix: Second.fromMillis(1) } // ray start intentionally doesn't include TAI epoch
+          { atomic: new Second(new Rat(900n, 1_000_000n)), unix: Second.fromMillis(1n) } // ray start intentionally doesn't include TAI epoch
         )])
       })
 
@@ -261,10 +261,10 @@ describe('munge', () => {
           [Date.UTC(1969, DEC, 31, 23, 59, 59, 999), 0.000_1],
           [Date.UTC(1970, JAN, 1, 0, 0, 0, 1), -0.001_1]
         ], MODELS.OVERRUN), [new Segment(
-          { atomic: new Second(new Rat(-900n, 1_000_000n)), unix: Second.fromMillis(-1) },
+          { atomic: new Second(new Rat(-900n, 1_000_000n)), unix: Second.fromMillis(-1n) },
           { atomic: new Second(new Rat(-100n, 1_000_000n)) }
         ), new Segment(
-          { atomic: new Second(new Rat(-100n, 1_000_000n)), unix: Second.fromMillis(1) }
+          { atomic: new Second(new Rat(-100n, 1_000_000n)), unix: Second.fromMillis(1n) }
         )])
       })
     })
@@ -275,7 +275,7 @@ describe('munge', () => {
       assert.deepStrictEqual(munge([
         [Date.UTC(1970, JAN, 1), 0]
       ], MODELS.BREAK), [new Segment(
-        { atomic: Second.fromMillis(0), unix: Second.fromMillis(0) }
+        { atomic: Second.fromMillis(0n), unix: Second.fromMillis(0n) }
       )])
     })
 
@@ -313,7 +313,7 @@ describe('munge', () => {
       assert.deepStrictEqual(munge([
         [Date.UTC(1970, JAN, 1), 0]
       ], MODELS.STALL), [new Segment(
-        { atomic: Second.fromMillis(0), unix: Second.fromMillis(0) }
+        { atomic: Second.fromMillis(0n), unix: Second.fromMillis(0n) }
       )])
     })
 
@@ -321,7 +321,7 @@ describe('munge', () => {
       assert.deepStrictEqual(munge([
         [7, -4]
       ], MODELS.STALL), [new Segment(
-        { atomic: Second.fromMillis(-3_993), unix: Second.fromMillis(7) }
+        { atomic: Second.fromMillis(-3_993n), unix: Second.fromMillis(7n) }
       )])
     })
 
@@ -355,7 +355,7 @@ describe('munge', () => {
       assert.deepStrictEqual(munge([
         [Date.UTC(1970, JAN, 1), 0, 40_587, 8.640_0]
       ], MODELS.STALL), [new Segment(
-        { atomic: Second.fromMillis(0), unix: Second.fromMillis(0) },
+        { atomic: Second.fromMillis(0n), unix: Second.fromMillis(0n) },
         { atomic: Second.END_OF_TIME },
         { unixPerAtomic: new Rat(10_000n, 10_001n) }
       )])
@@ -364,14 +364,14 @@ describe('munge', () => {
       assert.deepStrictEqual(munge([
         [Date.UTC(1970, JAN, 1), 0, 40_587, 0]
       ], MODELS.STALL), [new Segment(
-        { atomic: Second.fromMillis(0), unix: Second.fromMillis(0) }
+        { atomic: Second.fromMillis(0n), unix: Second.fromMillis(0n) }
       )])
 
       // TAI runs way slower than UTC
       assert.deepStrictEqual(munge([
         [Date.UTC(1970, JAN, 1), 0, 40_587, -8.640_0]
       ], MODELS.STALL), [new Segment(
-        { atomic: Second.fromMillis(0), unix: Second.fromMillis(0) },
+        { atomic: Second.fromMillis(0n), unix: Second.fromMillis(0n) },
         { atomic: Second.END_OF_TIME },
         { unixPerAtomic: new Rat(10_000n, 9_999n) }
       )])
@@ -381,7 +381,7 @@ describe('munge', () => {
       assert.deepStrictEqual(munge([
         [Date.UTC(1970, JAN, 1), 0, 40_587, -86_400 + 8.640_0]
       ], MODELS.STALL), [new Segment(
-        { atomic: Second.fromMillis(0), unix: Second.fromMillis(0) },
+        { atomic: Second.fromMillis(0n), unix: Second.fromMillis(0n) },
         { atomic: Second.END_OF_TIME },
         { unixPerAtomic: new Rat(10_000n) }
       )])
@@ -603,7 +603,7 @@ describe('munge', () => {
       assert.deepStrictEqual(munge([
         [Date.UTC(1970, JAN, 1), 0]
       ], MODELS.SMEAR), [new Segment(
-        { atomic: Second.fromMillis(0), unix: Second.fromMillis(0) }
+        { atomic: Second.fromMillis(0n), unix: Second.fromMillis(0n) }
       )])
     })
 
@@ -612,7 +612,7 @@ describe('munge', () => {
         [0, 0],
         [86_400_000, 1] // inserted leap second after one day
       ], MODELS.SMEAR), [new Segment(
-        { atomic: Second.fromMillis(0), unix: Second.fromMillis(0) },
+        { atomic: Second.fromMillis(0n), unix: Second.fromMillis(0n) },
         { atomic: new Second(new Rat(43_200n, 1n)) } // midday
       ), new Segment(
         { atomic: new Second(new Rat(43_200n, 1n)), unix: new Second(new Rat(43_200n, 1n)) }, // midday
@@ -628,7 +628,7 @@ describe('munge', () => {
         [0, 0],
         [86_400_000, -1] // removed leap second after one day
       ], MODELS.SMEAR), [new Segment(
-        { atomic: Second.fromMillis(0), unix: Second.fromMillis(0) },
+        { atomic: Second.fromMillis(0n), unix: Second.fromMillis(0n) },
         { atomic: new Second(new Rat(43_200n, 1n)) } // midday
       ), new Segment(
         { atomic: new Second(new Rat(43_200n, 1n)), unix: new Second(new Rat(43_200n, 1n)) }, // midday

--- a/test/nanos.spec.js
+++ b/test/nanos.spec.js
@@ -1,7 +1,6 @@
 import assert from 'node:assert'
 import { describe, it } from 'mocha'
 import { TaiConverter, MODELS, UNIX_START, UNIX_END } from '../src/nanos.js'
-import { UNIX_START_MILLIS, UNIX_END_MILLIS } from '../src/tai-data.js'
 
 const JAN = 0
 const JUN = 5

--- a/test/second.spec.js
+++ b/test/second.spec.js
@@ -46,7 +46,7 @@ describe('Second', () => {
   })
 
   it('fromMillis', () => {
-    assert.deepStrictEqual(Second.fromMillis(123), new Second(new Rat(123n, 1_000n)))
+    assert.deepStrictEqual(Second.fromMillis(123n), new Second(new Rat(123n, 1_000n)))
     assert.throws(() => Second.fromMillis(Infinity))
   })
 

--- a/test/second.spec.js
+++ b/test/second.spec.js
@@ -55,11 +55,11 @@ describe('Second', () => {
   })
 
   it('fromNanos', () => {
-    assert.deepStrictEqual(Second.fromNanos(123), new Second(new Rat(123n, 1_000_000_000n)))
+    assert.deepStrictEqual(Second.fromNanos(123n), new Second(new Rat(123n, 1_000_000_000n)))
     assert.throws(() => Second.fromNanos(Infinity))
   })
 
   it('toNanos', () => {
-    assert.strictEqual(new Second(new Rat(123n, 1_000_000_000n)).toNanos(), 123)
+    assert.strictEqual(new Second(new Rat(123n, 1_000_000_000n)).toNanos(), 123n)
   })
 })

--- a/test/second.spec.js
+++ b/test/second.spec.js
@@ -51,7 +51,7 @@ describe('Second', () => {
   })
 
   it('toMillis', () => {
-    assert.strictEqual(new Second(new Rat(123n, 1_000n)).toMillis(), 123)
+    assert.strictEqual(new Second(new Rat(123n, 1_000n)).toMillis(), 123n)
   })
 
   it('fromNanos', () => {

--- a/test/segment.spec.js
+++ b/test/segment.spec.js
@@ -13,162 +13,162 @@ describe('Segment', () => {
       { atomic: new Rat(0n) }
     ), /TAI start must be a `Second`/)
     assert.throws(() => new Segment(
-      { atomic: Second.fromMillis(0), unix: new Rat(0n) }
+      { atomic: Second.fromMillis(0n), unix: new Rat(0n) }
     ), /Unix start must be a `Second`/)
     assert.throws(() => new Segment(
-      { atomic: Second.fromMillis(0), unix: Second.fromMillis(0) },
+      { atomic: Second.fromMillis(0n), unix: Second.fromMillis(0n) },
       { atomic: new Rat(1n) }
     ), /TAI end must be a `Second` or `Second.END_OF_TIME`/)
     assert.throws(() => new Segment(
-      { atomic: Second.fromMillis(0), unix: Second.fromMillis(0) },
-      { atomic: Second.fromMillis(1_000) },
+      { atomic: Second.fromMillis(0n), unix: Second.fromMillis(0n) },
+      { atomic: Second.fromMillis(1_000n) },
       { unixPerAtomic: new Second(new Rat(1n, 1n)) }
     ), /slope must be a `Rat`/)
   })
 
   it('disallows rays which run backwards', () => {
     assert.throws(() => new Segment(
-      { atomic: Second.fromMillis(0), unix: Second.fromMillis(0) },
+      { atomic: Second.fromMillis(0n), unix: Second.fromMillis(0n) },
       { atomic: new Second(new Rat(-1n, 1_000_000_000_000n)) }
     ), /segment length must be positive/)
   })
 
   it('disallows zero-length rays which run backwards', () => {
     assert.throws(() => new Segment(
-      { atomic: Second.fromMillis(0), unix: Second.fromMillis(0) },
-      { atomic: Second.fromMillis(0) }
+      { atomic: Second.fromMillis(0n), unix: Second.fromMillis(0n) },
+      { atomic: Second.fromMillis(0n) }
     ), /segment length must be positive/)
   })
 
   describe('basic infinite ray', () => {
     const segment = new Segment(
-      { atomic: Second.fromMillis(0), unix: Second.fromMillis(0) }
+      { atomic: Second.fromMillis(0n), unix: Second.fromMillis(0n) }
     )
 
     it('zero point', () => {
-      assert.strictEqual(segment.unixOnSegment(Second.fromMillis(0)),
+      assert.strictEqual(segment.unixOnSegment(Second.fromMillis(0n)),
         true)
-      assert.deepStrictEqual(segment.unixToAtomicRange(Second.fromMillis(0)),
-        new Range(Second.fromMillis(0)))
-      assert.strictEqual(segment.atomicOnSegment(Second.fromMillis(0)),
+      assert.deepStrictEqual(segment.unixToAtomicRange(Second.fromMillis(0n)),
+        new Range(Second.fromMillis(0n)))
+      assert.strictEqual(segment.atomicOnSegment(Second.fromMillis(0n)),
         true)
-      assert.deepStrictEqual(segment.atomicToUnix(Second.fromMillis(0)),
-        Second.fromMillis(0))
+      assert.deepStrictEqual(segment.atomicToUnix(Second.fromMillis(0n)),
+        Second.fromMillis(0n))
     })
 
     it('modern day', () => {
-      assert.strictEqual(segment.unixOnSegment(Second.fromMillis(Date.UTC(2021, MAY, 16, 12, 11, 10, 9))),
+      assert.strictEqual(segment.unixOnSegment(Second.fromMillis(BigInt(Date.UTC(2021, MAY, 16, 12, 11, 10, 9)))),
         true)
-      assert.deepStrictEqual(segment.unixToAtomicRange(Second.fromMillis(Date.UTC(2021, MAY, 16, 12, 11, 10, 9))),
-        new Range(Second.fromMillis(Date.UTC(2021, MAY, 16, 12, 11, 10, 9))))
-      assert.strictEqual(segment.atomicOnSegment(Second.fromMillis(Date.UTC(2021, MAY, 16, 12, 11, 10, 9))),
+      assert.deepStrictEqual(segment.unixToAtomicRange(Second.fromMillis(BigInt(Date.UTC(2021, MAY, 16, 12, 11, 10, 9)))),
+        new Range(Second.fromMillis(BigInt(Date.UTC(2021, MAY, 16, 12, 11, 10, 9)))))
+      assert.strictEqual(segment.atomicOnSegment(Second.fromMillis(BigInt(Date.UTC(2021, MAY, 16, 12, 11, 10, 9)))),
         true)
-      assert.deepStrictEqual(segment.atomicToUnix(Second.fromMillis(Date.UTC(2021, MAY, 16, 12, 11, 10, 9))),
-        Second.fromMillis(Date.UTC(2021, MAY, 16, 12, 11, 10, 9)))
+      assert.deepStrictEqual(segment.atomicToUnix(Second.fromMillis(BigInt(Date.UTC(2021, MAY, 16, 12, 11, 10, 9)))),
+        Second.fromMillis(BigInt(Date.UTC(2021, MAY, 16, 12, 11, 10, 9))))
     })
 
     it('before start point', () => {
-      assert.strictEqual(segment.unixOnSegment(Second.fromMillis(-1)),
+      assert.strictEqual(segment.unixOnSegment(Second.fromMillis(-1n)),
         false)
-      assert.deepStrictEqual(segment.unixToAtomicRange(Second.fromMillis(-1)),
-        new Range(Second.fromMillis(-1)))
-      assert.strictEqual(segment.atomicOnSegment(Second.fromMillis(-1)),
+      assert.deepStrictEqual(segment.unixToAtomicRange(Second.fromMillis(-1n)),
+        new Range(Second.fromMillis(-1n)))
+      assert.strictEqual(segment.atomicOnSegment(Second.fromMillis(-1n)),
         false)
-      assert.deepStrictEqual(segment.atomicToUnix(Second.fromMillis(-1)),
-        Second.fromMillis(-1))
+      assert.deepStrictEqual(segment.atomicToUnix(Second.fromMillis(-1n)),
+        Second.fromMillis(-1n))
     })
   })
 
   describe('sloped, finite ray', () => {
     const segment = new Segment(
-      { atomic: Second.fromMillis(0), unix: Second.fromMillis(0) },
-      { atomic: Second.fromMillis(2_000) }, // 2 TAI seconds
+      { atomic: Second.fromMillis(0n), unix: Second.fromMillis(0n) },
+      { atomic: Second.fromMillis(2_000n) }, // 2 TAI seconds
       { unixPerAtomic: new Rat(1n, 2n) } // TAI runs twice as fast as Unix time
     )
 
     it('zero point', () => {
-      assert.strictEqual(segment.unixOnSegment(Second.fromMillis(0)),
+      assert.strictEqual(segment.unixOnSegment(Second.fromMillis(0n)),
         true)
-      assert.deepStrictEqual(segment.unixToAtomicRange(Second.fromMillis(0)),
-        new Range(Second.fromMillis(0)))
-      assert.strictEqual(segment.atomicOnSegment(Second.fromMillis(0)),
+      assert.deepStrictEqual(segment.unixToAtomicRange(Second.fromMillis(0n)),
+        new Range(Second.fromMillis(0n)))
+      assert.strictEqual(segment.atomicOnSegment(Second.fromMillis(0n)),
         true)
-      assert.deepStrictEqual(segment.atomicToUnix(Second.fromMillis(0)),
-        Second.fromMillis(0))
+      assert.deepStrictEqual(segment.atomicToUnix(Second.fromMillis(0n)),
+        Second.fromMillis(0n))
     })
 
     it('a little later', () => {
-      assert.strictEqual(segment.unixOnSegment(Second.fromMillis(501)),
+      assert.strictEqual(segment.unixOnSegment(Second.fromMillis(501n)),
         true)
-      assert.deepStrictEqual(segment.unixToAtomicRange(Second.fromMillis(501)),
-        new Range(Second.fromMillis(1_002)))
-      assert.strictEqual(segment.atomicOnSegment(Second.fromMillis(1_002)),
+      assert.deepStrictEqual(segment.unixToAtomicRange(Second.fromMillis(501n)),
+        new Range(Second.fromMillis(1_002n)))
+      assert.strictEqual(segment.atomicOnSegment(Second.fromMillis(1_002n)),
         true)
-      assert.deepStrictEqual(segment.atomicToUnix(Second.fromMillis(1_002)),
-        Second.fromMillis(501))
+      assert.deepStrictEqual(segment.atomicToUnix(Second.fromMillis(1_002n)),
+        Second.fromMillis(501n))
     })
 
     it('right before end point', () => {
-      assert.strictEqual(segment.unixOnSegment(Second.fromMillis(999)),
+      assert.strictEqual(segment.unixOnSegment(Second.fromMillis(999n)),
         true)
-      assert.deepStrictEqual(segment.unixToAtomicRange(Second.fromMillis(999)),
-        new Range(Second.fromMillis(1_998)))
+      assert.deepStrictEqual(segment.unixToAtomicRange(Second.fromMillis(999n)),
+        new Range(Second.fromMillis(1_998n)))
 
-      assert.strictEqual(segment.atomicOnSegment(Second.fromMillis(1_998)),
+      assert.strictEqual(segment.atomicOnSegment(Second.fromMillis(1_998n)),
         true)
-      assert.deepStrictEqual(segment.atomicToUnix(Second.fromMillis(1_998)),
-        Second.fromMillis(999))
-      assert.strictEqual(segment.atomicOnSegment(Second.fromMillis(1_999)),
+      assert.deepStrictEqual(segment.atomicToUnix(Second.fromMillis(1_998n)),
+        Second.fromMillis(999n))
+      assert.strictEqual(segment.atomicOnSegment(Second.fromMillis(1_999n)),
         true)
-      assert.deepStrictEqual(segment.atomicToUnix(Second.fromMillis(1_999)),
+      assert.deepStrictEqual(segment.atomicToUnix(Second.fromMillis(1_999n)),
         new Second(new Rat(1_999n, 2_000n))) // truncates to 999ms
     })
 
     it('end point', () => {
-      assert.strictEqual(segment.unixOnSegment(Second.fromMillis(1_000)),
+      assert.strictEqual(segment.unixOnSegment(Second.fromMillis(1_000n)),
         false)
-      assert.deepStrictEqual(segment.unixToAtomicRange(Second.fromMillis(1_000)),
-        new Range(Second.fromMillis(2_000)))
-      assert.strictEqual(segment.atomicOnSegment(Second.fromMillis(2_000)),
+      assert.deepStrictEqual(segment.unixToAtomicRange(Second.fromMillis(1_000n)),
+        new Range(Second.fromMillis(2_000n)))
+      assert.strictEqual(segment.atomicOnSegment(Second.fromMillis(2_000n)),
         false)
-      assert.deepStrictEqual(segment.atomicToUnix(Second.fromMillis(2_000)),
-        Second.fromMillis(1_000))
+      assert.deepStrictEqual(segment.atomicToUnix(Second.fromMillis(2_000n)),
+        Second.fromMillis(1_000n))
     })
   })
 
   describe('horizontal ray', () => {
     const segment = new Segment(
-      { atomic: Second.fromMillis(0), unix: Second.fromMillis(0) },
-      { atomic: Second.fromMillis(2_000) }, // 2 TAI seconds
+      { atomic: Second.fromMillis(0n), unix: Second.fromMillis(0n) },
+      { atomic: Second.fromMillis(2_000n) }, // 2 TAI seconds
       { unixPerAtomic: new Rat(0n) }
     )
 
     it('zero point', () => {
-      assert.strictEqual(segment.unixOnSegment(Second.fromMillis(0)),
+      assert.strictEqual(segment.unixOnSegment(Second.fromMillis(0n)),
         true)
-      assert.deepStrictEqual(segment.unixToAtomicRange(Second.fromMillis(0)),
-        new Range(Second.fromMillis(0), Second.fromMillis(2_000), true))
-      assert.strictEqual(segment.atomicOnSegment(Second.fromMillis(0)),
+      assert.deepStrictEqual(segment.unixToAtomicRange(Second.fromMillis(0n)),
+        new Range(Second.fromMillis(0n), Second.fromMillis(2_000n), true))
+      assert.strictEqual(segment.atomicOnSegment(Second.fromMillis(0n)),
         true)
-      assert.deepStrictEqual(segment.atomicToUnix(Second.fromMillis(0)),
-        Second.fromMillis(0))
+      assert.deepStrictEqual(segment.atomicToUnix(Second.fromMillis(0n)),
+        Second.fromMillis(0n))
     })
 
     it('later in TAI', () => {
-      assert.strictEqual(segment.atomicOnSegment(Second.fromMillis(1_999)),
+      assert.strictEqual(segment.atomicOnSegment(Second.fromMillis(1_999n)),
         true)
-      assert.deepStrictEqual(segment.atomicToUnix(Second.fromMillis(1_999)),
-        Second.fromMillis(0))
-      assert.strictEqual(segment.atomicOnSegment(Second.fromMillis(2_000)),
+      assert.deepStrictEqual(segment.atomicToUnix(Second.fromMillis(1_999n)),
+        Second.fromMillis(0n))
+      assert.strictEqual(segment.atomicOnSegment(Second.fromMillis(2_000n)),
         false)
-      assert.deepStrictEqual(segment.atomicToUnix(Second.fromMillis(2_000)),
-        Second.fromMillis(0))
+      assert.deepStrictEqual(segment.atomicToUnix(Second.fromMillis(2_000n)),
+        Second.fromMillis(0n))
     })
 
     it('later in Unix time', () => {
-      assert.strictEqual(segment.unixOnSegment(Second.fromMillis(1_000)),
+      assert.strictEqual(segment.unixOnSegment(Second.fromMillis(1_000n)),
         false)
-      assert.throws(() => segment.unixToAtomicRange(Second.fromMillis(-1)),
+      assert.throws(() => segment.unixToAtomicRange(Second.fromMillis(-1n)),
         /This Unix time never happened/)
     })
   })


### PR DESCRIPTION
I discovered that `Number.MAX_SAFE_INTEGER` nanoseconds is only about 104 days, which means that the new nanoseconds API isn't entirely precise prior when interacting with dates prior to 19 September 1969 or after 14 April 1970.

To assist with this, `unixToAtomic` and `atomicToUnix` now also accept BigInts. If a BigInt is provided, a BigInt is returned. Some internals have been juggled around to support this - `Second.fromMillis` and `Second.fromNanos` now demand a BigInt, and `Second.prototype.toMillis` and `Second.prototype.toNanos` now return BigInts, with the `MillisConverter` and `NanosConverter` classes now being responsible for actually converting the values to/from floats if need be.