### PR TITLE
Introducing `atomicToDriftRate()`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,8 @@
 
 ## 5.1.0
 
-Added `atomicToOffset()`.
+* Added `atomicToOffset()`.
+* Added `atomicToDriftRate()`.
 
 ## 5.0.0
 

--- a/README.md
+++ b/README.md
@@ -181,7 +181,7 @@ Converts the input TAI millisecond count to a Unix millisecond count. Throws if 
 When Unix time is inserted,
 
 * with the `OVERRUN` model, Unix time overruns and then backtracks. This means that sometimes two TAI millisecond counts convert to the same Unix millisecond count.
-* with the `BREAK` model,  Unix time is indeterminate; `NaN` is returned.
+* with the `BREAK` model,  Unix time is indeterminate; `NaN` is returned (even if `atomic` is a BigInt).
 * with the `STALL` model, Unix time stalls. This means that a whole range of TAI millisecond counts all convert to the same Unix millisecond count.
 * with the `SMEAR` model, the discontinuity is smeared out from midday to midday across the discontinuity.
 
@@ -199,7 +199,7 @@ The returned value is always positive, as TAI has been ahead of Unix time for as
 When Unix time is inserted,
 
 * with the `OVERRUN` model, the offset jumps up discontinuously between one input TAI millisecond count and the next.
-* with the `BREAK` model,  Unix time is indeterminate; `NaN` is returned.
+* with the `BREAK` model,  Unix time is indeterminate; `NaN` is returned (even if `atomic` is a BigInt).
 * with the `STALL` model, the offset increases smoothly over the course of the inserted time.
 * with the `SMEAR` model, the offset increases smoothly from midday to midday across the discontinuity.
 
@@ -207,6 +207,26 @@ When Unix time is removed,
 
 * with the `OVERRUN`, `BREAK` and `STALL` models, the offset jumps down discontinuously between input one TAI millisecond count and the next.
 * with the `SMEAR` model, the offset decreases smoothly from midday to midday across the discontinuity.
+
+### taiConverter.atomicToDriftRate(atomic)
+
+Converts the input TAI millisecond count to the current drift rate between TAI and Unix time in TAI milliseconds per Unix day. Throws if `atomic` is not an integer. Returns an integer. If the precise value to be returned is fractional, it is rounded towards negative infinity. If `atomic` is a BigInt, returns a BigInt. If `atomic` is prior to the beginning of TAI, `NaN` is returned (even if `atomic` is a BigInt).
+
+This is the rate at which `atomicToOffset(atomic)` is changing (see above). Prior to 1 January 1972, Unix seconds were slightly shorter than TAI seconds (the precise ratio varied), so this value was a small positive number. After 1 January 1972, Unix seconds and TAI seconds are precisely the same length, so the drift rate is zero.
+
+When Unix time is inserted,
+
+* with the `OVERRUN` model, the drift rate is unchanged over the course of the discontinuity.
+* with the `BREAK` model, the drift rate is indeterminate; `NaN` is returned (even if `atomic` is a BigInt).
+* with the `STALL` model, the drift rate is infinite; `Infinity` is returned (even if `atomic` is a BigInt).
+* with the `SMEAR` model, the drift rate increases by 1000ms (or whatever amount of time is inserted) at midday prior to the discontinuity and returns to normal at midday after it.
+
+When Unix time is removed,
+
+* with the `OVERRUN`, `BREAK` and `STALL` models, the drift rate is unchanged over the course of the discontinuity.
+* with the `SMEAR` model, the drift rate decreases by 1000ms (or whatever amount of time is removed) at midday prior to the discontinuity and returns to normal at midday after it.
+
+Drift rates have historically been very small, which means the truncated millisecond results are inaccurate. It is recommended to use the nanoseconds API (see below), which returns precise results.
 
 ### taiConverter.unixToAtomic(unix[, options])
 
@@ -276,8 +296,15 @@ const taiConverter = TaiConverter(MODELS.STALL)
 console.log(UNIX_START)
 // -283_996_800_000_000_000 Unix nanoseconds
 
-console.log(taiConverter.unixToAtomic(UNIX_START))
+const taiStart = taiConverter.unixToAtomic(UNIX_START)
+console.log(taiStart)
 // -283_996_798_577_182_000 TAI nanoseconds
+
+console.log(taiConverter.atomicToOffset(taiStart))
+// 1_422_818_000n TAI nanoseconds
+
+console.log(taiConverter.atomicToOffset(taiStart))
+// 1_422_818_000n TAI nanoseconds
 ```
 
 #### A note on precision when using the nanoseconds API

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "t-a-i",
-  "version": "5.1.0",
+  "version": "5.2.0",
   "description": "Converts Unix milliseconds to and from International Atomic Time (TAI) milliseconds",
   "homepage": "https://github.com/qntm/t-a-i",
   "repository": {

--- a/src/converter.js
+++ b/src/converter.js
@@ -35,11 +35,19 @@ export class Converter {
   atomicToOffset (atomic) {
     const segment = this.atomicToSegment(atomic)
     if (segment === undefined) {
-      // Pre-1961, or BREAK model and we hit a break
       return NaN
     }
 
     return segment.atomicToOffset(atomic)
+  }
+
+  atomicToDriftRate (atomic) {
+    const segment = this.atomicToSegment(atomic)
+    if (segment === undefined) {
+      return NaN
+    }
+
+    return segment.driftRate()
   }
 
   unixToAtomic (unix) {

--- a/src/millis-converter.js
+++ b/src/millis-converter.js
@@ -1,4 +1,5 @@
 import { Second } from './second.js'
+import { Rat } from './rat.js'
 import { Converter } from './converter.js'
 
 const unwrap = millis => {
@@ -47,6 +48,23 @@ export class MillisConverter {
     const { isInteger, second: atomic } = unwrap(atomicMillis)
     const unix = this.converter.atomicToOffset(atomic)
     return wrap({ isInteger, second: unix })
+  }
+
+  atomicToDriftRate (atomicMillis) {
+    const { isInteger, second: atomic } = unwrap(atomicMillis)
+    let atomicPerUnix = this.converter.atomicToDriftRate(atomic)
+
+    if (Number.isNaN(atomicPerUnix) || atomicPerUnix === Infinity) {
+      return atomicPerUnix
+    }
+
+    let atomicMillisPerUnixDay = atomicPerUnix.times(new Rat(86_400_000n)).trunc()
+
+    if (isInteger) {
+      atomicMillisPerUnixDay = Number(atomicMillisPerUnixDay)
+    }
+
+    return atomicMillisPerUnixDay
   }
 
   unixToAtomic (unixMillis, options = {}) {

--- a/src/millis-converter.js
+++ b/src/millis-converter.js
@@ -52,7 +52,7 @@ export class MillisConverter {
 
   atomicToDriftRate (atomicMillis) {
     const { isInteger, second: atomic } = unwrap(atomicMillis)
-    let atomicPerUnix = this.converter.atomicToDriftRate(atomic)
+    const atomicPerUnix = this.converter.atomicToDriftRate(atomic)
 
     if (Number.isNaN(atomicPerUnix) || atomicPerUnix === Infinity) {
       return atomicPerUnix

--- a/src/nanos-converter.js
+++ b/src/nanos-converter.js
@@ -52,7 +52,7 @@ export class NanosConverter {
 
   atomicToDriftRate (atomicNanos) {
     const { isInteger, second: atomic } = unwrap(atomicNanos)
-    let atomicPerUnix = this.converter.atomicToDriftRate(atomic)
+    const atomicPerUnix = this.converter.atomicToDriftRate(atomic)
 
     if (Number.isNaN(atomicPerUnix) || atomicPerUnix === Infinity) {
       return atomicPerUnix

--- a/src/nanos-converter.js
+++ b/src/nanos-converter.js
@@ -1,3 +1,4 @@
+import { Rat } from './rat.js'
 import { Second } from './second.js'
 import { Converter } from './converter.js'
 
@@ -47,6 +48,23 @@ export class NanosConverter {
     const { isInteger, second: atomic } = unwrap(atomicNanos)
     const unix = this.converter.atomicToOffset(atomic)
     return wrap({ isInteger, second: unix })
+  }
+
+  atomicToDriftRate (atomicNanos) {
+    const { isInteger, second: atomic } = unwrap(atomicNanos)
+    let atomicPerUnix = this.converter.atomicToDriftRate(atomic)
+
+    if (Number.isNaN(atomicPerUnix) || atomicPerUnix === Infinity) {
+      return atomicPerUnix
+    }
+
+    let atomicNanosPerUnixDay = atomicPerUnix.times(new Rat(86_400_000_000_000n)).trunc()
+
+    if (isInteger) {
+      atomicNanosPerUnixDay = Number(atomicNanosPerUnixDay)
+    }
+
+    return atomicNanosPerUnixDay
   }
 
   unixToAtomic (unixNanos, options = {}) {

--- a/src/segment.js
+++ b/src/segment.js
@@ -74,6 +74,8 @@ export class Segment {
     return atomic.minusS(unix)
   }
 
+  // Drift rate is measured in TAI seconds per Unix second
+  // Usually this is 0 or in the billionths (up to 30 nanoseconds per second)
   driftRate () {
     if (this.slope.unixPerAtomic.eq(new Rat(0n))) {
       return Infinity

--- a/test/converter.test.js
+++ b/test/converter.test.js
@@ -24,6 +24,7 @@ describe('Converter', () => {
         assert.deepEqual(converter.unixToAtomic(Second.fromMillis(0n)), [new Range(Second.fromMillis(0n))])
         assert.deepEqual(converter.atomicToUnix(Second.fromMillis(0n)), Second.fromMillis(0n))
         assert.deepEqual(converter.atomicToOffset(Second.fromMillis(0n)), Second.fromMillis(0n))
+        assert.deepEqual(converter.atomicToDriftRate(Second.fromMillis(0n)), new Rat(0n))
       })
     })
 
@@ -34,6 +35,7 @@ describe('Converter', () => {
         assert.deepEqual(converter.unixToAtomic(Second.fromMillis(0n)), [new Range(Second.fromMillis(0n))])
         assert.deepEqual(converter.atomicToUnix(Second.fromMillis(0n)), Second.fromMillis(0n))
         assert.deepEqual(converter.atomicToOffset(Second.fromMillis(0n)), Second.fromMillis(0n))
+        assert.deepEqual(converter.atomicToDriftRate(Second.fromMillis(0n)), new Rat(0n))
       })
     })
 
@@ -44,6 +46,7 @@ describe('Converter', () => {
         assert.deepEqual(converter.atomicToUnix(Second.fromMillis(0n)), Second.fromMillis(0n))
         assert.equal(converter.atomicToUnix(Second.fromMillis(-1n)), NaN)
         assert.equal(converter.atomicToOffset(Second.fromMillis(-1n)), NaN)
+        assert.deepEqual(converter.atomicToDriftRate(Second.fromMillis(-1n)), NaN)
       })
 
       it('fails when the Unix count is out of bounds', () => {
@@ -55,6 +58,7 @@ describe('Converter', () => {
         assert.deepEqual(converter.unixToAtomic(Second.fromMillis(0n)), [new Range(Second.fromMillis(0n))])
         assert.deepEqual(converter.atomicToUnix(Second.fromMillis(0n)), Second.fromMillis(0n))
         assert.deepEqual(converter.atomicToOffset(Second.fromMillis(0n)), Second.fromMillis(0n))
+        assert.deepEqual(converter.atomicToDriftRate(Second.fromMillis(0n)), new Rat(0n))
       })
     })
 
@@ -65,6 +69,7 @@ describe('Converter', () => {
         assert.deepEqual(converter.unixToAtomic(Second.fromMillis(0n)), [new Range(Second.fromMillis(0n))])
         assert.deepEqual(converter.atomicToUnix(Second.fromMillis(0n)), Second.fromMillis(0n))
         assert.deepEqual(converter.atomicToOffset(Second.fromMillis(0n)), Second.fromMillis(0n))
+        assert.deepEqual(converter.atomicToDriftRate(Second.fromMillis(0n)), new Rat(0n))
       })
     })
   })
@@ -186,6 +191,37 @@ describe('Converter', () => {
           Second.fromMillis(1_000n)
         )
       })
+
+      it('atomicToDriftRate', () => {
+        assert.deepEqual(converter.atomicToDriftRate(Second.fromMillis(0n)), new Rat(0n))
+
+        assert.deepEqual(
+          converter.atomicToDriftRate(Second.fromMillis(BigInt(Date.UTC(1979, DEC, 31, 23, 59, 59, 999)))),
+          new Rat(0n)
+        )
+        assert.deepEqual(
+          converter.atomicToDriftRate(Second.fromMillis(BigInt(Date.UTC(1980, JAN, 1, 0, 0, 0, 0)))),
+          new Rat(0n)
+        )
+        assert.deepEqual(
+          converter.atomicToDriftRate(Second.fromMillis(BigInt(Date.UTC(1980, JAN, 1, 0, 0, 0, 1)))),
+          new Rat(0n)
+        )
+
+        // BACKTRACK
+        assert.deepEqual(
+          converter.atomicToDriftRate(Second.fromMillis(BigInt(Date.UTC(1980, JAN, 1, 0, 0, 0, 999)))),
+          new Rat(0n)
+        )
+        assert.deepEqual(
+          converter.atomicToDriftRate(Second.fromMillis(BigInt(Date.UTC(1980, JAN, 1, 0, 0, 1, 0)))),
+          new Rat(0n)
+        )
+        assert.deepEqual(
+          converter.atomicToDriftRate(Second.fromMillis(BigInt(Date.UTC(1980, JAN, 1, 0, 0, 1, 1)))),
+          new Rat(0n)
+        )
+      })
     })
 
     describe('BREAK', () => {
@@ -302,6 +338,38 @@ describe('Converter', () => {
           Second.fromMillis(1_000n)
         )
       })
+
+      it('atomicToDriftRate', () => {
+        assert.deepEqual(converter.atomicToDriftRate(Second.fromMillis(0n)), new Rat(0n))
+
+        // UNDEFINED UNIX TIME STARTS
+        assert.deepEqual(
+          converter.atomicToDriftRate(Second.fromMillis(BigInt(Date.UTC(1979, DEC, 31, 23, 59, 59, 999)))),
+          new Rat(0n)
+        )
+        assert.equal(
+          converter.atomicToDriftRate(Second.fromMillis(BigInt(Date.UTC(1980, JAN, 1, 0, 0, 0, 0)))),
+          NaN
+        )
+        assert.equal(
+          converter.atomicToDriftRate(Second.fromMillis(BigInt(Date.UTC(1980, JAN, 1, 0, 0, 0, 1)))),
+          NaN
+        )
+
+        // UNDEFINED UNIX TIME ENDS
+        assert.equal(
+          converter.atomicToDriftRate(Second.fromMillis(BigInt(Date.UTC(1980, JAN, 1, 0, 0, 0, 999)))),
+          NaN
+        )
+        assert.deepEqual(
+          converter.atomicToDriftRate(Second.fromMillis(BigInt(Date.UTC(1980, JAN, 1, 0, 0, 1, 0)))),
+          new Rat(0n)
+        )
+        assert.deepEqual(
+          converter.atomicToDriftRate(Second.fromMillis(BigInt(Date.UTC(1980, JAN, 1, 0, 0, 1, 1)))),
+          new Rat(0n)
+        )
+      })
     })
 
     describe('STALL', () => {
@@ -400,6 +468,38 @@ describe('Converter', () => {
         assert.deepEqual(
           converter.atomicToOffset(Second.fromMillis(BigInt(Date.UTC(1980, JAN, 1, 0, 0, 1, 1)))),
           Second.fromMillis(1_000n)
+        )
+      })
+
+      it('atomicToDriftRate', () => {
+        assert.deepEqual(converter.atomicToDriftRate(Second.fromMillis(0n)), new Rat(0n))
+
+        // STALL STARTS
+        assert.deepEqual(
+          converter.atomicToDriftRate(Second.fromMillis(BigInt(Date.UTC(1979, DEC, 31, 23, 59, 59, 999)))),
+          new Rat(0n)
+        )
+        assert.equal(
+          converter.atomicToDriftRate(Second.fromMillis(BigInt(Date.UTC(1980, JAN, 1, 0, 0, 0, 0)))),
+          Infinity
+        )
+        assert.equal(
+          converter.atomicToDriftRate(Second.fromMillis(BigInt(Date.UTC(1980, JAN, 1, 0, 0, 0, 1)))),
+          Infinity
+        )
+
+        // STALL ENDS
+        assert.equal(
+          converter.atomicToDriftRate(Second.fromMillis(BigInt(Date.UTC(1980, JAN, 1, 0, 0, 0, 999)))),
+          Infinity
+        )
+        assert.deepEqual(
+          converter.atomicToDriftRate(Second.fromMillis(BigInt(Date.UTC(1980, JAN, 1, 0, 0, 1, 0)))),
+          new Rat(0n)
+        )
+        assert.deepEqual(
+          converter.atomicToDriftRate(Second.fromMillis(BigInt(Date.UTC(1980, JAN, 1, 0, 0, 1, 1)))),
+          new Rat(0n)
         )
       })
     })
@@ -539,6 +639,44 @@ describe('Converter', () => {
           Second.fromMillis(1000n)
         )
       })
+
+      it('atomicToDriftRate', () => {
+        assert.deepEqual(converter.atomicToDriftRate(Second.fromMillis(0n)), new Rat(0n))
+
+        // SMEAR STARTS, UNIX TIME RUNS A LITTLE SLOWER THAN ATOMIC
+        assert.deepEqual(
+          converter.atomicToDriftRate(Second.fromMillis(BigInt(Date.UTC(1979, DEC, 31, 11, 59, 59, 999)))),
+          new Rat(0n)
+        )
+        assert.deepEqual(
+          converter.atomicToDriftRate(Second.fromMillis(BigInt(Date.UTC(1979, DEC, 31, 12, 0, 0, 0)))),
+          new Rat(1_000n, 86_400_000n) // TAI will gain 1 second over the course of the next 24 Unix hours
+        )
+        assert.deepEqual(
+          converter.atomicToDriftRate(Second.fromMillis(BigInt(Date.UTC(1979, DEC, 31, 12, 0, 0, 1)))),
+          new Rat(1_000n, 86_400_000n)
+        )
+
+        // SMEAR MIDPOINT
+        assert.deepEqual(
+          converter.atomicToDriftRate(Second.fromMillis(BigInt(Date.UTC(1980, JAN, 1, 0, 0, 0, 500)))),
+          new Rat(1_000n, 86_400_000n)
+        )
+
+        // SMEAR ENDS, UNIX HAS DROPPED A FULL SECOND BEHIND
+        assert.deepEqual(
+          converter.atomicToDriftRate(Second.fromMillis(BigInt(Date.UTC(1980, JAN, 1, 12, 0, 0, 999)))),
+          new Rat(1_000n, 86_400_000n)
+        )
+        assert.deepEqual(
+          converter.atomicToDriftRate(Second.fromMillis(BigInt(Date.UTC(1980, JAN, 1, 12, 0, 1, 0)))),
+          new Rat(0n)
+        )
+        assert.deepEqual(
+          converter.atomicToDriftRate(Second.fromMillis(BigInt(Date.UTC(1980, JAN, 1, 12, 0, 1, 1)))),
+          new Rat(0n)
+        )
+      })
     })
   })
 
@@ -629,6 +767,24 @@ describe('Converter', () => {
           Second.fromMillis(-1_000n)
         )
       })
+
+      it('atomicToDriftRate', () => {
+        assert.deepEqual(converter.atomicToDriftRate(Second.fromMillis(0n)), new Rat(0n))
+
+        // JUMP AHEAD
+        assert.deepEqual(
+          converter.atomicToDriftRate(Second.fromMillis(BigInt(Date.UTC(1979, DEC, 31, 23, 59, 58, 999)))),
+          new Rat(0n)
+        )
+        assert.deepEqual(
+          converter.atomicToDriftRate(Second.fromMillis(BigInt(Date.UTC(1979, DEC, 31, 23, 59, 59, 0)))),
+          new Rat(0n)
+        )
+        assert.deepEqual(
+          converter.atomicToDriftRate(Second.fromMillis(BigInt(Date.UTC(1979, DEC, 31, 23, 59, 59, 1)))),
+          new Rat(0n)
+        )
+      })
     })
 
     describe('BREAK', () => {
@@ -712,6 +868,24 @@ describe('Converter', () => {
           Second.fromMillis(-1_000n)
         )
       })
+
+      it('atomicToDriftRate', () => {
+        assert.deepEqual(converter.atomicToDriftRate(Second.fromMillis(0n)), new Rat(0n))
+
+        // JUMP AHEAD
+        assert.deepEqual(
+          converter.atomicToDriftRate(Second.fromMillis(BigInt(Date.UTC(1979, DEC, 31, 23, 59, 58, 999)))),
+          new Rat(0n)
+        )
+        assert.deepEqual(
+          converter.atomicToDriftRate(Second.fromMillis(BigInt(Date.UTC(1979, DEC, 31, 23, 59, 59, 0)))),
+          new Rat(0n)
+        )
+        assert.deepEqual(
+          converter.atomicToDriftRate(Second.fromMillis(BigInt(Date.UTC(1979, DEC, 31, 23, 59, 59, 1)))),
+          new Rat(0n)
+        )
+      })
     })
 
     describe('STALL', () => {
@@ -793,6 +967,24 @@ describe('Converter', () => {
         assert.deepEqual(
           converter.atomicToOffset(Second.fromMillis(BigInt(Date.UTC(1979, DEC, 31, 23, 59, 59, 1)))),
           Second.fromMillis(-1_000n)
+        )
+      })
+
+      it('atomicToDriftRate', () => {
+        assert.deepEqual(converter.atomicToDriftRate(Second.fromMillis(0n)), new Rat(0n))
+
+        // JUMP AHEAD
+        assert.deepEqual(
+          converter.atomicToDriftRate(Second.fromMillis(BigInt(Date.UTC(1979, DEC, 31, 23, 59, 58, 999)))),
+          new Rat(0n)
+        )
+        assert.deepEqual(
+          converter.atomicToDriftRate(Second.fromMillis(BigInt(Date.UTC(1979, DEC, 31, 23, 59, 59, 0)))),
+          new Rat(0n)
+        )
+        assert.deepEqual(
+          converter.atomicToDriftRate(Second.fromMillis(BigInt(Date.UTC(1979, DEC, 31, 23, 59, 59, 1)))),
+          new Rat(0n)
         )
       })
     })
@@ -932,6 +1124,44 @@ describe('Converter', () => {
           Second.fromMillis(-1_000n)
         )
       })
+
+      it('atomicToDriftRate', () => {
+        assert.deepEqual(converter.atomicToDriftRate(Second.fromMillis(0n)), new Rat(0n))
+
+        // SMEAR STARTS, UNIX TIME RUNS A LITTLE FASTER THAN ATOMIC
+        assert.deepEqual(
+          converter.atomicToDriftRate(Second.fromMillis(BigInt(Date.UTC(1979, DEC, 31, 11, 59, 59, 999)))),
+          new Rat(0n)
+        )
+        assert.deepEqual(
+          converter.atomicToDriftRate(Second.fromMillis(BigInt(Date.UTC(1979, DEC, 31, 12, 0, 0, 0)))),
+          new Rat(-1_000n, 86_400_000n) // TAI will lose 1s over the next 24 Unix hours
+        )
+        assert.deepEqual(
+          converter.atomicToDriftRate(Second.fromMillis(BigInt(Date.UTC(1979, DEC, 31, 12, 0, 0, 1)))),
+          new Rat(-1_000n, 86_400_000n)
+        )
+
+        // SMEAR MIDPOINT
+        assert.deepEqual(
+          converter.atomicToDriftRate(Second.fromMillis(BigInt(Date.UTC(1979, DEC, 31, 23, 59, 59, 500)))),
+          new Rat(-1_000n, 86_400_000n)
+        )
+
+        // SMEAR ENDS, UNIX HAS RUN A FULL SECOND FASTER THAN ATOMIC
+        assert.deepEqual(
+          converter.atomicToDriftRate(Second.fromMillis(BigInt(Date.UTC(1980, JAN, 1, 11, 59, 58, 999)))),
+          new Rat(-1_000n, 86_400_000n)
+        )
+        assert.deepEqual(
+          converter.atomicToDriftRate(Second.fromMillis(BigInt(Date.UTC(1980, JAN, 1, 11, 59, 59, 0)))),
+          new Rat(0n)
+        )
+        assert.deepEqual(
+          converter.atomicToDriftRate(Second.fromMillis(BigInt(Date.UTC(1980, JAN, 1, 11, 59, 59, 1)))),
+          new Rat(0n)
+        )
+      })
     })
   })
 
@@ -957,6 +1187,10 @@ describe('Converter', () => {
           converter.atomicToOffset(new Second(new Rat(900n, 1_000_000n))),
           new Second(new Rat(-1n, 10_000n))
         )
+        assert.deepEqual(
+          converter.atomicToDriftRate(new Second(new Rat(900n, 1_000_000n))),
+          new Rat(0n)
+        )
       })
 
       it('at the end of the ray', () => {
@@ -979,6 +1213,10 @@ describe('Converter', () => {
         assert.deepEqual(
           converter.atomicToOffset(new Second(new Rat(-900n, 1_000_000n))),
           new Second(new Rat(1n, 10_000n))
+        )
+        assert.deepEqual(
+          converter.atomicToDriftRate(new Second(new Rat(900n, 1_000_000n))),
+          new Rat(0n)
         )
       })
     })
@@ -1090,6 +1328,41 @@ describe('Converter', () => {
             Second.fromMillis(2000n)
           )
         })
+
+        it('atomicToDriftRate', () => {
+          assert.deepEqual(
+            converter.atomicToDriftRate(Second.fromMillis(0n)),
+            new Rat(0n)
+          )
+
+          // STALL STARTS
+          assert.deepEqual(
+            converter.atomicToDriftRate(Second.fromMillis(999n)),
+            new Rat(0n)
+          )
+          assert.equal(
+            converter.atomicToDriftRate(Second.fromMillis(1000n)),
+            NaN
+          )
+          assert.equal(
+            converter.atomicToDriftRate(Second.fromMillis(1001n)),
+            NaN
+          )
+
+          // STALL ENDS
+          assert.equal(
+            converter.atomicToDriftRate(Second.fromMillis(2999n)),
+            NaN
+          )
+          assert.deepEqual(
+            converter.atomicToDriftRate(Second.fromMillis(3000n)),
+            new Rat(0n)
+          )
+          assert.deepEqual(
+            converter.atomicToDriftRate(Second.fromMillis(3001n)),
+            new Rat(0n)
+          )
+        })
       })
 
       describe('STALL', () => {
@@ -1193,6 +1466,41 @@ describe('Converter', () => {
             Second.fromMillis(2000n)
           )
         })
+
+        it('atomicToDriftRate', () => {
+          assert.deepEqual(
+            converter.atomicToDriftRate(Second.fromMillis(0n)),
+            new Rat(0n)
+          )
+
+          // STALL STARTS
+          assert.deepEqual(
+            converter.atomicToDriftRate(Second.fromMillis(999n)),
+            new Rat(0n)
+          )
+          assert.equal(
+            converter.atomicToDriftRate(Second.fromMillis(1000n)),
+            Infinity
+          )
+          assert.equal(
+            converter.atomicToDriftRate(Second.fromMillis(1001n)),
+            Infinity
+          )
+
+          // STALL ENDS
+          assert.equal(
+            converter.atomicToDriftRate(Second.fromMillis(2999n)),
+            Infinity
+          )
+          assert.deepEqual(
+            converter.atomicToDriftRate(Second.fromMillis(3000n)),
+            new Rat(0n)
+          )
+          assert.deepEqual(
+            converter.atomicToDriftRate(Second.fromMillis(3001n)),
+            new Rat(0n)
+          )
+        })
       })
     })
 
@@ -1231,20 +1539,24 @@ describe('Converter', () => {
       const atomic = new Second(new Rat(8_000_082_000n, 1_000_000_000n))
       const unix = converter.atomicToUnix(atomic)
       const offset = converter.atomicToOffset(atomic)
+      const driftRate = converter.atomicToDriftRate(atomic)
 
       assert.deepEqual(unix, new Second(new Rat(0n)))
       assert.deepEqual(offset, new Second(new Rat(8_000_082_000n, 1_000_000_000n)))
       assert.deepEqual(atomic.minusS(unix), offset)
+      assert.deepEqual(driftRate, new Rat(30n, 1_000_000_000n)) // TAI gaining 30ns per Unix second
     })
 
     it('one nanosecond after the Unix epoch', () => {
       const atomic = new Second(new Rat(8_000_082_001n, 1_000_000_000n))
       const unix = converter.atomicToUnix(atomic)
       const offset = converter.atomicToOffset(atomic)
+      const driftRate = converter.atomicToDriftRate(atomic)
 
       assert.deepEqual(unix, new Second(new Rat(1n, 1_000_000_030n))) // 0.99999997000000089999997300000081ns
       assert.deepEqual(offset, new Second(new Rat(8_000_082_240_002_460_030n, 1_000_000_030_000_000_000n))) // 8000082000.0000000299999991ns
       assert.deepEqual(atomic.minusS(unix), offset)
+      assert.deepEqual(driftRate, new Rat(30n, 1_000_000_000n)) // TAI gaining 30ns per Unix second
 
       // However, truncations to nanoseconds lose precision
       assert.equal(atomic.toNanos(), 8_000_082_001n) // exact

--- a/test/index.test.js
+++ b/test/index.test.js
@@ -763,4 +763,15 @@ describe('TaiConverter', () => {
       assert.equal(taiConverter.unixToAtomic(Date.UTC(2017, JAN, 1, 12, 0, 0, 0)), Date.UTC(2017, JAN, 1, 12, 0, 37))
     })
   })
+
+  describe('historic data', () => {
+    it('atomicToDriftRate (is not very useful)', () => {
+      const taiConverter = TaiConverter(MODELS.STALL)
+      assert.equal(taiConverter.atomicToDriftRate(BigInt(Date.UTC(1961, JAN, 2))), 1n) // 15 TAI ns / Unix day, TRUNCATED
+      assert.equal(taiConverter.atomicToDriftRate(BigInt(Date.UTC(1962, JAN, 2))), 1n) // 13 TAI ns / Unix day, TRUNCATED
+      assert.equal(taiConverter.atomicToDriftRate(BigInt(Date.UTC(1964, JAN, 2))), 1n) // 15 TAI ns / Unix day, TRUNCATED
+      assert.equal(taiConverter.atomicToDriftRate(BigInt(Date.UTC(1966, JAN, 2))), 2n) // 30 TAI ns / Unix day, TRUNCATED
+      assert.equal(taiConverter.atomicToDriftRate(BigInt(Date.UTC(1972, JAN, 2))), 0n) // 0 TAI ns / Unix day, EXACT
+    })
+  })
 })

--- a/test/millis-converter.test.js
+++ b/test/millis-converter.test.js
@@ -3,7 +3,6 @@ import { describe, it } from 'node:test'
 
 import { MODELS } from '../src/munge.js'
 import { MillisConverter } from '../src/millis-converter.js'
-import { taiData } from '../src/tai-data.js'
 
 const JAN = 0
 const OCT = 9

--- a/test/millis-converter.test.js
+++ b/test/millis-converter.test.js
@@ -3,6 +3,7 @@ import { describe, it } from 'node:test'
 
 import { MODELS } from '../src/munge.js'
 import { MillisConverter } from '../src/millis-converter.js'
+import { taiData } from '../src/tai-data.js'
 
 const JAN = 0
 const OCT = 9
@@ -27,6 +28,7 @@ describe('MillisConverter', () => {
         assert.equal(millisConverter.atomicToUnix(0), 0)
         assert.equal(millisConverter.atomicToUnix(0n), 0n)
         assert.equal(millisConverter.atomicToOffset(0n), 0n)
+        assert.equal(millisConverter.atomicToDriftRate(0n), 0n)
       })
     })
 
@@ -37,6 +39,7 @@ describe('MillisConverter', () => {
         assert.equal(millisConverter.unixToAtomic(0), 0)
         assert.equal(millisConverter.atomicToUnix(0), 0)
         assert.equal(millisConverter.atomicToOffset(0), 0)
+        assert.equal(millisConverter.atomicToDriftRate(0n), 0n)
       })
     })
 
@@ -50,6 +53,8 @@ describe('MillisConverter', () => {
         assert.throws(() => millisConverter.atomicToUnix('boops'), /Not an integer: boops/)
         assert.throws(() => millisConverter.atomicToOffset(NaN), /Not an integer: NaN/)
         assert.throws(() => millisConverter.atomicToOffset('booops'), /Not an integer: booops/)
+        assert.throws(() => millisConverter.atomicToDriftRate(NaN), /Not an integer: NaN/)
+        assert.throws(() => millisConverter.atomicToDriftRate('boooops'), /Not an integer: boooops/)
       })
 
       it('fails when the atomic count is out of bounds', () => {
@@ -57,6 +62,8 @@ describe('MillisConverter', () => {
         assert.equal(millisConverter.atomicToUnix(-1), NaN)
         assert.equal(millisConverter.atomicToOffset(0), 0)
         assert.equal(millisConverter.atomicToOffset(-1), NaN)
+        assert.equal(millisConverter.atomicToDriftRate(0), 0)
+        assert.equal(millisConverter.atomicToDriftRate(-1), NaN)
       })
 
       it('fails when the Unix count is out of bounds', () => {
@@ -71,6 +78,7 @@ describe('MillisConverter', () => {
         assert.equal(millisConverter.unixToAtomic(0), 0)
         assert.equal(millisConverter.atomicToUnix(0), 0)
         assert.equal(millisConverter.atomicToOffset(0), 0)
+        assert.equal(millisConverter.atomicToDriftRate(0), 0)
       })
     })
 
@@ -81,6 +89,7 @@ describe('MillisConverter', () => {
         assert.equal(millisConverter.unixToAtomic(0), 0)
         assert.equal(millisConverter.atomicToUnix(0), 0)
         assert.equal(millisConverter.atomicToOffset(0), 0)
+        assert.equal(millisConverter.atomicToDriftRate(0), 0)
       })
     })
   })
@@ -184,6 +193,19 @@ describe('MillisConverter', () => {
         assert.equal(millisConverter.atomicToOffset(Date.UTC(1980, JAN, 1, 0, 0, 1, 0)), 1000)
         assert.equal(millisConverter.atomicToOffset(Date.UTC(1980, JAN, 1, 0, 0, 1, 1)), 1000)
       })
+
+      it('atomicToDriftRate', () => {
+        assert.equal(millisConverter.atomicToDriftRate(0), 0)
+
+        assert.equal(millisConverter.atomicToDriftRate(Date.UTC(1979, DEC, 31, 23, 59, 59, 999)), 0)
+        assert.equal(millisConverter.atomicToDriftRate(Date.UTC(1980, JAN, 1, 0, 0, 0, 0)), 0)
+        assert.equal(millisConverter.atomicToDriftRate(Date.UTC(1980, JAN, 1, 0, 0, 0, 1)), 0)
+
+        // BACKTRACK
+        assert.equal(millisConverter.atomicToDriftRate(Date.UTC(1980, JAN, 1, 0, 0, 0, 999)), 0)
+        assert.equal(millisConverter.atomicToDriftRate(Date.UTC(1980, JAN, 1, 0, 0, 1, 0)), 0)
+        assert.equal(millisConverter.atomicToDriftRate(Date.UTC(1980, JAN, 1, 0, 0, 1, 1)), 0)
+      })
     })
 
     describe('BREAK', () => {
@@ -228,6 +250,19 @@ describe('MillisConverter', () => {
         assert.equal(millisConverter.atomicToOffset(Date.UTC(1980, JAN, 1, 0, 0, 0, 999)), NaN)
         assert.equal(millisConverter.atomicToOffset(Date.UTC(1980, JAN, 1, 0, 0, 1, 0)), 1000)
         assert.equal(millisConverter.atomicToOffset(Date.UTC(1980, JAN, 1, 0, 0, 1, 1)), 1000)
+      })
+
+      it('atomicToDriftRate', () => {
+        assert.equal(millisConverter.atomicToDriftRate(0), 0)
+
+        assert.equal(millisConverter.atomicToDriftRate(Date.UTC(1979, DEC, 31, 23, 59, 59, 999)), 0)
+        assert.equal(millisConverter.atomicToDriftRate(Date.UTC(1980, JAN, 1, 0, 0, 0, 0)), NaN)
+        assert.equal(millisConverter.atomicToDriftRate(Date.UTC(1980, JAN, 1, 0, 0, 0, 1)), NaN)
+
+        // BACKTRACK
+        assert.equal(millisConverter.atomicToDriftRate(Date.UTC(1980, JAN, 1, 0, 0, 0, 999)), NaN)
+        assert.equal(millisConverter.atomicToDriftRate(Date.UTC(1980, JAN, 1, 0, 0, 1, 0)), 0)
+        assert.equal(millisConverter.atomicToDriftRate(Date.UTC(1980, JAN, 1, 0, 0, 1, 1)), 0)
       })
     })
 
@@ -297,6 +332,19 @@ describe('MillisConverter', () => {
         assert.equal(millisConverter.atomicToOffset(Date.UTC(1980, JAN, 1, 0, 0, 1, 0)), 1000)
         assert.equal(millisConverter.atomicToOffset(Date.UTC(1980, JAN, 1, 0, 0, 1, 1)), 1000)
       })
+
+      it('atomicToDriftRate', () => {
+        assert.equal(millisConverter.atomicToDriftRate(0), 0)
+
+        assert.equal(millisConverter.atomicToDriftRate(Date.UTC(1979, DEC, 31, 23, 59, 59, 999)), 0)
+        assert.equal(millisConverter.atomicToDriftRate(Date.UTC(1980, JAN, 1, 0, 0, 0, 0)), Infinity)
+        assert.equal(millisConverter.atomicToDriftRate(Date.UTC(1980, JAN, 1, 0, 0, 0, 1)), Infinity)
+
+        // BACKTRACK
+        assert.equal(millisConverter.atomicToDriftRate(Date.UTC(1980, JAN, 1, 0, 0, 0, 999)), Infinity)
+        assert.equal(millisConverter.atomicToDriftRate(Date.UTC(1980, JAN, 1, 0, 0, 1, 0)), 0)
+        assert.equal(millisConverter.atomicToDriftRate(Date.UTC(1980, JAN, 1, 0, 0, 1, 1)), 0)
+      })
     })
 
     describe('SMEAR', () => {
@@ -351,6 +399,23 @@ describe('MillisConverter', () => {
         assert.equal(millisConverter.atomicToOffset(Date.UTC(1980, JAN, 1, 12, 0, 0, 999)), 999) // truncated down
         assert.equal(millisConverter.atomicToOffset(Date.UTC(1980, JAN, 1, 12, 0, 1, 0)), 1000)
         assert.equal(millisConverter.atomicToOffset(Date.UTC(1980, JAN, 1, 12, 0, 1, 1)), 1000)
+      })
+
+      it('atomicToDriftRate', () => {
+        assert.equal(millisConverter.atomicToDriftRate(0), 0)
+
+        // SMEAR STARTS
+        assert.equal(millisConverter.atomicToDriftRate(Date.UTC(1979, DEC, 31, 11, 59, 59, 999)), 0)
+        assert.equal(millisConverter.atomicToDriftRate(Date.UTC(1979, DEC, 31, 12, 0, 0, 0)), 1000)
+        assert.equal(millisConverter.atomicToDriftRate(Date.UTC(1979, DEC, 31, 12, 0, 0, 1)), 1000)
+
+        // SMEAR MIDPOINT
+        assert.equal(millisConverter.atomicToDriftRate(Date.UTC(1980, JAN, 1, 0, 0, 0, 500)), 1000)
+
+        // SMEAR ENDS
+        assert.equal(millisConverter.atomicToDriftRate(Date.UTC(1980, JAN, 1, 12, 0, 0, 999)), 1000)
+        assert.equal(millisConverter.atomicToDriftRate(Date.UTC(1980, JAN, 1, 12, 0, 1, 0)), 0)
+        assert.equal(millisConverter.atomicToDriftRate(Date.UTC(1980, JAN, 1, 12, 0, 1, 1)), 0)
       })
     })
   })
@@ -595,7 +660,7 @@ describe('MillisConverter', () => {
         assert.equal(millisConverter.atomicToUnix(Date.UTC(1979, DEC, 31, 23, 59, 59, 500)), Date.UTC(1980, JAN, 1, 0, 0, 0, 0))
 
         // END OF SMEAR
-        assert.equal(millisConverter.atomicToUnix(Date.UTC(1980, JAN, 1, 11, 59, 59, 999)), Date.UTC(1980, JAN, 1, 12, 0, 0, 999))
+        assert.equal(millisConverter.atomicToUnix(Date.UTC(1980, JAN, 1, 11, 59, 58, 999)), Date.UTC(1980, JAN, 1, 11, 59, 59, 998))
         assert.equal(millisConverter.atomicToUnix(Date.UTC(1980, JAN, 1, 11, 59, 59, 0)), Date.UTC(1980, JAN, 1, 12, 0, 0, 0))
         assert.equal(millisConverter.atomicToUnix(Date.UTC(1980, JAN, 1, 11, 59, 59, 1)), Date.UTC(1980, JAN, 1, 12, 0, 0, 1))
       })
@@ -612,9 +677,26 @@ describe('MillisConverter', () => {
         assert.equal(millisConverter.atomicToOffset(Date.UTC(1979, DEC, 31, 23, 59, 59, 500)), -500)
 
         // END OF SMEAR
-        assert.equal(millisConverter.atomicToOffset(Date.UTC(1980, JAN, 1, 11, 59, 59, 999)), -1000) // truncated down from -999.999...9
+        assert.equal(millisConverter.atomicToOffset(Date.UTC(1980, JAN, 1, 11, 59, 58, 999)), -1000) // truncated down from -999.999...9
         assert.equal(millisConverter.atomicToOffset(Date.UTC(1980, JAN, 1, 11, 59, 59, 0)), -1000)
         assert.equal(millisConverter.atomicToOffset(Date.UTC(1980, JAN, 1, 11, 59, 59, 1)), -1000)
+      })
+
+      it('atomicToDriftRate', () => {
+        assert.equal(millisConverter.atomicToDriftRate(0), 0)
+
+        // START OF SMEAR
+        assert.equal(millisConverter.atomicToDriftRate(Date.UTC(1979, DEC, 31, 11, 59, 59, 999)), 0)
+        assert.equal(millisConverter.atomicToDriftRate(Date.UTC(1979, DEC, 31, 12, 0, 0, 0)), -1000)
+        assert.equal(millisConverter.atomicToDriftRate(Date.UTC(1979, DEC, 31, 12, 0, 0, 1)), -1000)
+
+        // MIDPOINT OF SMEAR
+        assert.equal(millisConverter.atomicToDriftRate(Date.UTC(1979, DEC, 31, 23, 59, 59, 500)), -1000)
+
+        // END OF SMEAR
+        assert.equal(millisConverter.atomicToDriftRate(Date.UTC(1980, JAN, 1, 11, 59, 58, 999)), -1000)
+        assert.equal(millisConverter.atomicToDriftRate(Date.UTC(1980, JAN, 1, 11, 59, 59, 0)), 0)
+        assert.equal(millisConverter.atomicToDriftRate(Date.UTC(1980, JAN, 1, 11, 59, 59, 1)), 0)
       })
     })
   })
@@ -1122,6 +1204,23 @@ describe('MillisConverter', () => {
           assert.equal(millisConverter.atomicToOffset(3_001n), 2_500n)
           assert.equal(millisConverter.atomicToOffset(4_499n), 2_500n)
           assert.equal(millisConverter.atomicToOffset(4_500n), 2_500n)
+        })
+
+        it('atomicToDriftRate (BigInts)', () => {
+          assert.equal(millisConverter.atomicToDriftRate(0n), 0n)
+          assert.equal(millisConverter.atomicToDriftRate(499n), 0n)
+          assert.equal(millisConverter.atomicToDriftRate(500n), 0n)
+          assert.equal(millisConverter.atomicToDriftRate(999n), 0n)
+          assert.equal(millisConverter.atomicToDriftRate(1_000n), 0n)
+          assert.equal(millisConverter.atomicToDriftRate(1_001n), 0n)
+          assert.equal(millisConverter.atomicToDriftRate(1_999n), 0n)
+          assert.equal(millisConverter.atomicToDriftRate(2_000n), 0n)
+          assert.equal(millisConverter.atomicToDriftRate(2_001n), 0n)
+          assert.equal(millisConverter.atomicToDriftRate(2_999n), 0n)
+          assert.equal(millisConverter.atomicToDriftRate(3_000n), 0n)
+          assert.equal(millisConverter.atomicToDriftRate(3_001n), 0n)
+          assert.equal(millisConverter.atomicToDriftRate(4_499n), 0n)
+          assert.equal(millisConverter.atomicToDriftRate(4_500n), 0n)
         })
       })
 

--- a/test/nanos-converter.test.js
+++ b/test/nanos-converter.test.js
@@ -34,6 +34,7 @@ describe('NanosConverter', () => {
         assert.equal(nanosConverter.unixToAtomic(0), 0)
         assert.equal(nanosConverter.atomicToUnix(0), 0)
         assert.equal(nanosConverter.atomicToOffset(0), 0)
+        assert.equal(nanosConverter.atomicToDriftRate(0n), 0n)
       })
     })
 
@@ -44,6 +45,7 @@ describe('NanosConverter', () => {
         assert.equal(nanosConverter.unixToAtomic(0), 0)
         assert.equal(nanosConverter.atomicToUnix(0), 0)
         assert.equal(nanosConverter.atomicToOffset(0), 0)
+        assert.equal(nanosConverter.atomicToDriftRate(0n), 0n)
       })
     })
 
@@ -55,8 +57,10 @@ describe('NanosConverter', () => {
         assert.throws(() => nanosConverter.unixToAtomic('boop'), /Not an integer: boop/)
         assert.throws(() => nanosConverter.atomicToUnix(Infinity), /Not an integer: Infinity/)
         assert.throws(() => nanosConverter.atomicToUnix('boops'), /Not an integer: boops/)
-        assert.throws(() => nanosConverter.atomicToUnix(NaN), /Not an integer: NaN/)
-        assert.throws(() => nanosConverter.atomicToUnix('booops'), /Not an integer: booops/)
+        assert.throws(() => nanosConverter.atomicToOffset(NaN), /Not an integer: NaN/)
+        assert.throws(() => nanosConverter.atomicToOffset('booops'), /Not an integer: booops/)
+        assert.throws(() => nanosConverter.atomicToDriftRate(-Infinity), /Not an integer: -Infinity/)
+        assert.throws(() => nanosConverter.atomicToDriftRate('boooops'), /Not an integer: boooops/)
       })
 
       it('fails when the atomic count is out of bounds', () => {
@@ -64,6 +68,8 @@ describe('NanosConverter', () => {
         assert.equal(nanosConverter.atomicToUnix(-1), NaN)
         assert.equal(nanosConverter.atomicToOffset(0), 0)
         assert.equal(nanosConverter.atomicToOffset(-1), NaN)
+        assert.equal(nanosConverter.atomicToDriftRate(0), 0)
+        assert.equal(nanosConverter.atomicToDriftRate(-1), NaN)
       })
 
       it('fails when the Unix count is out of bounds', () => {
@@ -78,6 +84,7 @@ describe('NanosConverter', () => {
         assert.equal(nanosConverter.unixToAtomic(0), 0)
         assert.equal(nanosConverter.atomicToUnix(0), 0)
         assert.equal(nanosConverter.atomicToOffset(0), 0)
+        assert.equal(nanosConverter.atomicToDriftRate(0n), 0n)
       })
     })
 
@@ -88,6 +95,7 @@ describe('NanosConverter', () => {
         assert.equal(nanosConverter.unixToAtomic(0), 0)
         assert.equal(nanosConverter.atomicToUnix(0), 0)
         assert.equal(nanosConverter.atomicToOffset(0), 0)
+        assert.equal(nanosConverter.atomicToDriftRate(0n), 0n)
       })
     })
   })
@@ -163,6 +171,20 @@ describe('NanosConverter', () => {
         assert.equal(nanosConverter.atomicToOffset(BigInt(Date.UTC(1980, JAN, 1, 0, 0, 0, 999)) * 1_000_000n), 999_000_000n)
         assert.equal(nanosConverter.atomicToOffset(BigInt(Date.UTC(1980, JAN, 1, 0, 0, 1, 0)) * 1_000_000n), 1_000_000_000n)
         assert.equal(nanosConverter.atomicToOffset(BigInt(Date.UTC(1980, JAN, 1, 0, 0, 1, 1)) * 1_000_000n), 1_000_000_000n)
+      })
+
+      it('atomicToDriftRate', () => {
+        assert.equal(nanosConverter.atomicToDriftRate(0n), 0n)
+
+        // STALL STARTS
+        assert.equal(nanosConverter.atomicToDriftRate(BigInt(Date.UTC(1979, DEC, 31, 23, 59, 59, 999)) * 1_000_000n), 0n)
+        assert.equal(nanosConverter.atomicToDriftRate(BigInt(Date.UTC(1980, JAN, 1, 0, 0, 0, 0)) * 1_000_000n), Infinity)
+        assert.equal(nanosConverter.atomicToDriftRate(BigInt(Date.UTC(1980, JAN, 1, 0, 0, 0, 1)) * 1_000_000n), Infinity)
+
+        // STALL ENDS
+        assert.equal(nanosConverter.atomicToDriftRate(BigInt(Date.UTC(1980, JAN, 1, 0, 0, 0, 999)) * 1_000_000n), Infinity)
+        assert.equal(nanosConverter.atomicToDriftRate(BigInt(Date.UTC(1980, JAN, 1, 0, 0, 1, 0)) * 1_000_000n), 0n)
+        assert.equal(nanosConverter.atomicToDriftRate(BigInt(Date.UTC(1980, JAN, 1, 0, 0, 1, 1)) * 1_000_000n), 0n)
       })
     })
 
@@ -246,7 +268,7 @@ describe('NanosConverter', () => {
       })
 
       it('atomicToOffset', () => {
-        assert.equal(nanosConverter.atomicToUnix(0n), 0n)
+        assert.equal(nanosConverter.atomicToOffset(0n), 0n)
 
         // SMEAR STARTS
         assert.equal(nanosConverter.atomicToOffset(BigInt(Date.UTC(1979, DEC, 31, 11, 59, 59, 999)) * 1_000_000n), 0n)
@@ -260,6 +282,23 @@ describe('NanosConverter', () => {
         assert.equal(nanosConverter.atomicToOffset(BigInt(Date.UTC(1980, JAN, 1, 12, 0, 0, 999)) * 1_000_000n), 999_999_988n)
         assert.equal(nanosConverter.atomicToOffset(BigInt(Date.UTC(1980, JAN, 1, 12, 0, 1, 0)) * 1_000_000n), 1_000_000_000n)
         assert.equal(nanosConverter.atomicToOffset(BigInt(Date.UTC(1980, JAN, 1, 12, 0, 1, 1)) * 1_000_000n), 1_000_000_000n)
+      })
+
+      it('atomicToDriftRate', () => {
+        assert.equal(nanosConverter.atomicToDriftRate(0n), 0n)
+
+        // SMEAR STARTS
+        assert.equal(nanosConverter.atomicToDriftRate(BigInt(Date.UTC(1979, DEC, 31, 11, 59, 59, 999)) * 1_000_000n), 0n)
+        assert.equal(nanosConverter.atomicToDriftRate(BigInt(Date.UTC(1979, DEC, 31, 12, 0, 0, 0)) * 1_000_000n), 1_000_000_000n)
+        assert.equal(nanosConverter.atomicToDriftRate(BigInt(Date.UTC(1979, DEC, 31, 12, 0, 0, 1)) * 1_000_000n), 1_000_000_000n)
+
+        // SMEAR MIDPOINT
+        assert.equal(nanosConverter.atomicToDriftRate(BigInt(Date.UTC(1980, JAN, 1, 0, 0, 0, 500)) * 1_000_000n), 1_000_000_000n)
+
+        // SMEAR ENDS
+        assert.equal(nanosConverter.atomicToDriftRate(BigInt(Date.UTC(1980, JAN, 1, 12, 0, 0, 999)) * 1_000_000n), 1_000_000_000n)
+        assert.equal(nanosConverter.atomicToDriftRate(BigInt(Date.UTC(1980, JAN, 1, 12, 0, 1, 0)) * 1_000_000n), 0n)
+        assert.equal(nanosConverter.atomicToDriftRate(BigInt(Date.UTC(1980, JAN, 1, 12, 0, 1, 1)) * 1_000_000n), 0n)
       })
     })
   })

--- a/test/nanos.test.js
+++ b/test/nanos.test.js
@@ -5,8 +5,12 @@ import { TaiConverter, MODELS, UNIX_START, UNIX_END } from '../src/nanos.js'
 
 const JAN = 0
 const JUN = 5
+const JUL = 6
+const AUG = 7
 const OCT = 9
 const DEC = 11
+
+const TAI_START = -283_996_798_577_182_000n
 
 describe('UNIX_START', () => {
   it('is correct', () => {
@@ -42,7 +46,7 @@ describe('TaiConverter', () => {
         )
         assert.deepEqual(
           unixToAtomic(BigInt(Date.UTC(1961, JAN, 1, 0, 0, 0, 0)) * 1_000_000n),
-          [-283_996_798_577_182_000n]
+          [TAI_START]
         )
         assert.deepEqual(
           unixToAtomic(BigInt(Date.UTC(1961, JAN, 1, 0, 0, 0, 0)) * 1_000_000n),
@@ -81,6 +85,10 @@ describe('TaiConverter', () => {
     })
 
     describe('atomicToUnix', () => {
+      it('start of history', () => {
+        assert.equal(taiConverter.atomicToUnix(TAI_START), -283_996_800_000_000_000n)
+      })
+
       it('typical', () => {
         // A typical leap second from the past, note repetition
         assert.equal(taiConverter.atomicToUnix(Date.UTC(1999, JAN, 1, 0, 0, 29, 750) * 1_000_000), Date.UTC(1998, DEC, 31, 23, 59, 58, 750) * 1_000_000)
@@ -212,6 +220,11 @@ describe('TaiConverter', () => {
   })
 
   describe('atomicToOffset', () => {
+    it('start of history', () => {
+      const taiConverter = TaiConverter(MODELS.STALL)
+      assert.equal(taiConverter.atomicToOffset(TAI_START), 1_422_818_000n)
+    })
+
     it('may or may not reflect a simple subtraction', () => {
       const taiConverter = TaiConverter(MODELS.STALL)
 
@@ -269,6 +282,100 @@ describe('TaiConverter', () => {
       const atomic = 8_000_082_001n
       assert.equal(atomic - taiConverter.atomicToUnix(atomic), 8_000_082_001n) // wrong
       assert.equal(taiConverter.atomicToOffset(atomic), 8_000_082_000n) // right
+    })
+  })
+
+  describe('atomicToDriftRate', () => {
+    it('start of history', () => {
+      const taiConverter = TaiConverter(MODELS.STALL)
+      assert.equal(taiConverter.atomicToDriftRate(TAI_START), 1_296_000n) // 1.296 TAI ms / Unix day = 15 TAI ns / Unix second
+    })
+
+    it('historic conversions', () => {
+      const taiConverter = TaiConverter(MODELS.STALL)
+
+      // Normal drift
+      assert.equal(taiConverter.atomicToDriftRate(BigInt(Date.UTC(1961, JAN, 2)) * 1_000_000n), 1_296_000n) // 15 TAI ns / Unix day
+      assert.equal(taiConverter.atomicToDriftRate(BigInt(Date.UTC(1962, JAN, 2)) * 1_000_000n), 1_123_200n) // 13 TAI ns / Unix day
+      assert.equal(taiConverter.atomicToDriftRate(BigInt(Date.UTC(1964, JAN, 2)) * 1_000_000n), 1_296_000n) // 15 TAI ns / Unix day
+      assert.equal(taiConverter.atomicToDriftRate(BigInt(Date.UTC(1966, JAN, 2)) * 1_000_000n), 2_592_000n) // 30 TAI ns / Unix day
+      assert.equal(taiConverter.atomicToDriftRate(BigInt(Date.UTC(1972, JAN, 2)) * 1_000_000n), 0n) // 0 TAI ns / Unix day
+    })
+
+    it('during smear of 1 Aug 1961: 0.05 seconds removed', () => {
+      const taiConverter = TaiConverter(MODELS.SMEAR)
+
+      // Start of smear
+      assert.equal(
+        taiConverter.atomicToDriftRate(taiConverter.unixToAtomic(BigInt(Date.UTC(1961, JUL, 31, 11, 59, 59, 59)) * 1_000_000n)),
+        1_296_000n
+      )
+      assert.equal(
+        taiConverter.atomicToDriftRate(taiConverter.unixToAtomic(BigInt(Date.UTC(1961, JUL, 31, 12, 0, 0, 0)) * 1_000_000n)),
+        1_296_000n - 50_000_000n
+      )
+      assert.equal(
+        taiConverter.atomicToDriftRate(taiConverter.unixToAtomic(BigInt(Date.UTC(1961, JUL, 31, 12, 0, 0, 1)) * 1_000_000n)),
+        1_296_000n - 50_000_000n
+      )
+
+      // Midpoint of smear
+      assert.equal(
+        taiConverter.atomicToDriftRate(taiConverter.unixToAtomic(BigInt(Date.UTC(1961, AUG, 1, 0, 0, 0, 0)) * 1_000_000n)),
+        1_296_000n - 50_000_000n
+      )
+
+      // End of smear
+      assert.equal(
+        taiConverter.atomicToDriftRate(taiConverter.unixToAtomic(BigInt(Date.UTC(1961, AUG, 1, 11, 59, 59, 59)) * 1_000_000n)),
+        1_296_000n - 50_000_000n
+      )
+      assert.equal(
+        taiConverter.atomicToDriftRate(taiConverter.unixToAtomic(BigInt(Date.UTC(1961, AUG, 1, 12, 0, 0, 0)) * 1_000_000n)),
+        1_296_000n
+      )
+      assert.equal(
+        taiConverter.atomicToDriftRate(taiConverter.unixToAtomic(BigInt(Date.UTC(1961, AUG, 1, 12, 0, 0, 1)) * 1_000_000n)),
+        1_296_000n
+      )
+    })
+
+    it('during smear of 1 Jan 2017: 1 seconds inserted', () => {
+      const taiConverter = TaiConverter(MODELS.SMEAR)
+
+      // Start of smear
+      assert.equal(
+        taiConverter.atomicToDriftRate(taiConverter.unixToAtomic(BigInt(Date.UTC(2016, DEC, 31, 11, 59, 59, 59)) * 1_000_000n)),
+        0n
+      )
+      assert.equal(
+        taiConverter.atomicToDriftRate(taiConverter.unixToAtomic(BigInt(Date.UTC(2016, DEC, 31, 12, 0, 0, 0)) * 1_000_000n)),
+        1_000_000_000n
+      )
+      assert.equal(
+        taiConverter.atomicToDriftRate(taiConverter.unixToAtomic(BigInt(Date.UTC(2016, DEC, 31, 12, 0, 0, 1)) * 1_000_000n)),
+        1_000_000_000n
+      )
+
+      // Midpoint of smear
+      assert.equal(
+        taiConverter.atomicToDriftRate(taiConverter.unixToAtomic(BigInt(Date.UTC(2017, JAN, 1, 0, 0, 0, 0)) * 1_000_000n)),
+        1_000_000_000n
+      )
+
+      // End of smear
+      assert.equal(
+        taiConverter.atomicToDriftRate(taiConverter.unixToAtomic(BigInt(Date.UTC(2017, JAN, 1, 11, 59, 59, 59)) * 1_000_000n)),
+        1_000_000_000n
+      )
+      assert.equal(
+        taiConverter.atomicToDriftRate(taiConverter.unixToAtomic(BigInt(Date.UTC(2017, JAN, 1, 12, 0, 0, 0)) * 1_000_000n)),
+        0n
+      )
+      assert.equal(
+        taiConverter.atomicToDriftRate(taiConverter.unixToAtomic(BigInt(Date.UTC(2017, JAN, 1, 12, 0, 0, 1)) * 1_000_000n)),
+        0n
+      )
     })
   })
 })

--- a/test/nanos.test.js
+++ b/test/nanos.test.js
@@ -340,7 +340,7 @@ describe('TaiConverter', () => {
       )
     })
 
-    it('during smear of 1 Jan 2017: 1 seconds inserted', () => {
+    it('during smear of 1 Jan 2017: 1 second inserted', () => {
       const taiConverter = TaiConverter(MODELS.SMEAR)
 
       // Start of smear


### PR DESCRIPTION
Follows #91. I discovered that this would be a really desirable feature to have for the purposes of my leap second simulator so here it is. With docs!