### PR TITLE
No leap second, December 2026

### DIFF
--- a/README.md
+++ b/README.md
@@ -115,7 +115,7 @@ For your reference, at the time of writing:
 
 ### Validity for the future
 
-Leap seconds (or the lack thereof) are announced in the International Earth Rotation and Reference Systems Service (IERS)'s six-monthly Bulletin C. For example, at the time of writing, [the latest such bulletin](https://hpiers.obspm.fr/iers/bul/bulc/bulletinc.71) was published on 6 January 2026 and announced that there will be no leap second at the end of June 2026. This means that `t-a-i`'s calculations are guaranteed to be correct up to, but not including, the *next* potential leap second, which in this case is at the end of December 2026. At or beyond this point, the introduction of leap seconds cannot be predicted in advance, and the correctness of `t-a-i`'s behaviour cannot be guaranteed.
+Leap seconds (or the lack thereof) are announced in the International Earth Rotation and Reference Systems Service (IERS)'s six-monthly Bulletin C. For example, at the time of writing, [the latest such bulletin](https://hpiers.obspm.fr/iers/bul/bulc/bulletinc.72) was published on 6 July 2026 and announced that there will be no leap second at the end of December 2026. This means that `t-a-i`'s calculations are guaranteed to be correct up to, but not including, the *next* potential leap second, which in this case is at the end of June 2027. At or beyond this point, the introduction of leap seconds cannot be predicted in advance, and the correctness of `t-a-i`'s behaviour cannot be guaranteed.
 
 As a result, `t-a-i`'s behaviour beyond the next-but-one (possible) leap second is considered to be undefined. Updates to the source data when new leap seconds are announced will not be considered breaking changes, and will not incur a major version bump.
 

--- a/src/div.js
+++ b/src/div.js
@@ -1,7 +1,8 @@
 // Divide two BigInts and round the result towards negative infinity
 
-// Why doesn't JavaScript have this?
+// Why doesn't JavaScript have these?
 export const sign = a => a > 0n ? 1n : a === 0n ? 0n : -1n
+export const abs = a => a > 0n ? a : -a
 
 export const div = (a, b) => {
   const q = a / b

--- a/src/rat.js
+++ b/src/rat.js
@@ -1,4 +1,4 @@
-import { div, gcd } from './div.js'
+import { div, gcd, sign, abs } from './div.js'
 
 export class Rat {
   constructor (nu, de = 1n) {
@@ -8,16 +8,14 @@ export class Rat {
     if (typeof de !== 'bigint') {
       throw Error('denominator must be a BigInt')
     }
-    if (de === 0n) {
-      throw Error('denominator cannot be zero')
+    if (de <= 0n) {
+      throw Error('denominator must be positive')
     }
 
-    const g = gcd(nu, de) // non-zero
+    const g = gcd(abs(nu), de) // positive
 
-    const g2 = (de < 0) === (g < 0) ? g : -g
-
-    this.nu = nu / g2 // sign of `this.nu` is the sign of the represented rational
-    this.de = de / g2 // positive
+    this.nu = nu / g // sign of `this.nu` is the sign of the represented rational
+    this.de = de / g // positive
   }
 
   plus (other) {
@@ -25,7 +23,7 @@ export class Rat {
   }
 
   minus (other) {
-    return this.plus(new Rat(-other.nu, other.de))
+    return new Rat(this.nu * other.de - this.de * other.nu, this.de * other.de)
   }
 
   times (other) {
@@ -33,19 +31,19 @@ export class Rat {
   }
 
   divide (other) {
-    return this.times(new Rat(other.de, other.nu))
+    return new Rat(sign(other.nu) * this.nu * other.de, this.de * abs(other.nu))
   }
 
   eq (other) {
-    return this.minus(other).nu === 0n
+    return this.nu * other.de === other.nu * this.de
   }
 
   le (other) {
-    return this.minus(other).nu <= 0n
+    return this.nu * other.de <= other.nu * this.de
   }
 
   gt (other) {
-    return this.minus(other).nu > 0n
+    return this.nu * other.de > other.nu * this.de
   }
 
   // Truncate the fraction towards negative infinity

--- a/src/tai-data.js
+++ b/src/tai-data.js
@@ -6,12 +6,12 @@ const JAN = 0
 const FEB = 1
 const MAR = 2
 const APR = 3
-// const JUN = 5
+const JUN = 5
 const JUL = 6
 const AUG = 7
 const SEP = 8
 const NOV = 10
-const DEC = 11
+// const DEC = 11
 
 // First column: Unix millisecond count when this relationship became effective
 // Second column: TAI minus UTC in TAI seconds as of the root point
@@ -67,4 +67,4 @@ export const UNIX_START_MILLIS = taiData[0][0]
 // Our limit of validity is determined by IERS Bulletin C's limit of validity.
 // https://hpiers.obspm.fr/iers/bul/bulc/BULLETINC.GUIDE.html
 // Updating this value? Don't forget to update the README too!
-export const UNIX_END_MILLIS = Date.UTC(2026, DEC, 28)
+export const UNIX_END_MILLIS = Date.UTC(2027, JUN, 28)

--- a/test/rat.test.js
+++ b/test/rat.test.js
@@ -8,7 +8,8 @@ describe('Rat', () => {
     assert.throws(() => new Rat(1, 2n), /numerator must be a BigInt/)
     assert.throws(() => new Rat(1n, 2), /denominator must be a BigInt/)
     assert.throws(() => new Rat(1n, 0), /denominator must be a BigInt/)
-    assert.throws(() => new Rat(-1n, 0n), /denominator cannot be zero/)
+    assert.throws(() => new Rat(-1n, 0n), /denominator must be positive/)
+    assert.throws(() => new Rat(-1n, -1n), /denominator must be positive/)
   })
 
   it('defaults to an integer', () => {
@@ -35,23 +36,25 @@ describe('Rat', () => {
 
   it('divides', () => {
     assert.deepEqual(new Rat(6n, 5n).divide(new Rat(4n, 5n)), new Rat(30n, 20n))
+    assert.deepEqual(new Rat(-6n, 5n).divide(new Rat(4n, 5n)), new Rat(-30n, 20n))
+    assert.deepEqual(new Rat(6n, 5n).divide(new Rat(-4n, 5n)), new Rat(-30n, 20n))
+    assert.deepEqual(new Rat(-6n, 5n).divide(new Rat(-4n, 5n)), new Rat(30n, 20n))
     assert.deepEqual(new Rat(0n, 5n).divide(new Rat(4n, 5n)), new Rat(0n, 20n))
   })
 
   it('greater than', () => {
-    assert.equal(new Rat(-1n, 3n).gt(new Rat(1n, -2n)), true)
+    assert.equal(new Rat(-1n, 3n).gt(new Rat(-1n, 2n)), true)
     assert.equal(new Rat(0n).gt(new Rat(1n)), false)
   })
 
   it('equal', () => {
-    assert.equal(new Rat(-1n, 3n).eq(new Rat(4n, -12n)), true)
+    assert.equal(new Rat(-1n, 3n).eq(new Rat(-4n, 12n)), true)
     assert.equal(new Rat(0n).eq(new Rat(-1n)), false)
     assert.equal(new Rat(0n).eq(new Rat(-0n)), true)
   })
 
   it('less than or equal', () => {
-    assert.equal(new Rat(-2n, -3n).le(new Rat(-2n, -3n)), true)
-    assert.equal(new Rat(-2n, -3n).le(new Rat(2n, 3n)), true)
+    assert.equal(new Rat(2n, 3n).le(new Rat(2n, 3n)), true)
     assert.equal(new Rat(9n, 12n).le(new Rat(6n, 8n)), true)
     assert.equal(new Rat(9n, 13n).le(new Rat(6n, 8n)), true)
   })
@@ -73,24 +76,6 @@ describe('Rat', () => {
       assert.equal(new Rat(-12n, 10n).trunc(), -2n)
       assert.equal(new Rat(-15n, 10n).trunc(), -2n)
       assert.equal(new Rat(-18n, 10n).trunc(), -2n)
-    })
-
-    it('negatives', () => {
-      assert.equal(new Rat(-18n, -10n).trunc(), 1n)
-      assert.equal(new Rat(-15n, -10n).trunc(), 1n)
-      assert.equal(new Rat(-12n, -10n).trunc(), 1n)
-      assert.equal(new Rat(-10n, -10n).trunc(), 1n)
-      assert.equal(new Rat(-8n, -10n).trunc(), 0n)
-      assert.equal(new Rat(-5n, -10n).trunc(), 0n)
-      assert.equal(new Rat(-2n, -10n).trunc(), 0n)
-      assert.equal(new Rat(0n, -10n).trunc(), 0n)
-      assert.equal(new Rat(2n, -10n).trunc(), -1n)
-      assert.equal(new Rat(5n, -10n).trunc(), -1n)
-      assert.equal(new Rat(8n, -10n).trunc(), -1n)
-      assert.equal(new Rat(10n, -10n).trunc(), -1n)
-      assert.equal(new Rat(12n, -10n).trunc(), -2n)
-      assert.equal(new Rat(15n, -10n).trunc(), -2n)
-      assert.equal(new Rat(18n, -10n).trunc(), -2n)
     })
   })
 })

--- a/test/second.test.js
+++ b/test/second.test.js
@@ -29,19 +29,18 @@ describe('Second', () => {
   })
 
   it('greater than', () => {
-    assert.equal(new Second(new Rat(-1n, 3n)).gtS(new Second(new Rat(1n, -2n))), true)
+    assert.equal(new Second(new Rat(-1n, 3n)).gtS(new Second(new Rat(-1n, 2n))), true)
     assert.equal(new Second(new Rat(0n)).gtS(new Second(new Rat(1n))), false)
   })
 
   it('equal', () => {
-    assert.equal(new Second(new Rat(-1n, 3n)).eqS(new Second(new Rat(4n, -12n))), true)
+    assert.equal(new Second(new Rat(-1n, 3n)).eqS(new Second(new Rat(-4n, 12n))), true)
     assert.equal(new Second(new Rat(0n)).eqS(new Second(new Rat(-1n))), false)
     assert.equal(new Second(new Rat(0n)).eqS(new Second(new Rat(-0n))), true)
   })
 
   it('less than or equal', () => {
-    assert.equal(new Second(new Rat(-2n, -3n)).leS(new Second(new Rat(-2n, -3n))), true)
-    assert.equal(new Second(new Rat(-2n, -3n)).leS(new Second(new Rat(2n, 3n))), true)
+    assert.equal(new Second(new Rat(2n, 3n)).leS(new Second(new Rat(2n, 3n))), true)
     assert.equal(new Second(new Rat(9n, 12n)).leS(new Second(new Rat(6n, 8n))), true)
     assert.equal(new Second(new Rat(9n, 13n)).leS(new Second(new Rat(6n, 8n))), true)
   })


### PR DESCRIPTION
In addition to the updated limit of validity, I'm also modifying the internal `Rat` class to:

1. Build fewer temporary `Rat` objects during normal operation, for performance reasons
2. Disallow negative denominators